### PR TITLE
Remove leftover from bug 148006 fix #2

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceConsole.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceConsole.java
@@ -26,10 +26,7 @@ import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.IJobManager;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jdt.internal.debug.ui.IJavaDebugHelpContextIds;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
@@ -207,19 +204,11 @@ public class JavaStackTraceConsole extends TextConsole {
     	WorkbenchJob job = new WorkbenchJob(ConsoleMessages.JavaStackTraceConsole_1) {
 			@Override
 			public IStatus runInUIThread(IProgressMonitor monitor) {
-	            IJobManager jobManager = Job.getJobManager();
-	            try {
-	                jobManager.join(this, monitor);
-	            } catch (OperationCanceledException e1) {
-	                return Status.CANCEL_STATUS;
-	            } catch (InterruptedException e1) {
-	                return Status.CANCEL_STATUS;
-	            }
 	            IDocument document = getDocument();
 	            String orig = document.get();
 	            if (orig != null && orig.length() > 0) {
 	                document.set(format(orig));
-	            }
+				}
 
 				return Status.OK_STATUS;
 			}


### PR DESCRIPTION
Bug 148006 introduced a coding mistake.

It makes no sense to join on the job instance. What was meant, was the
outer JavaStackTraceConsole instance. So we still see errors if console
changes the document on which the MatchJob is working.

But fixing that would introduce deadlocks like in bug 451797

So simply delete this no-op line that was there since ever.

Note: the bug that was meant to be fixed: when the console format runs
in parallel to the MatchJob running, it should wait.

But waiting in UI thread mean *freeze*.