### PR TITLE
Bug 547041 - Add hyperlinks for stack traces copied from Debug view

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/AbstractJavaStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/AbstractJavaStackTraceConsoleTest.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2022 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial API and implementation
+ *     Simeon Andreev - Bug 547041: Pulled as base class from {@link JavaStackTraceConsoleTest}
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.console;
+
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.debug.tests.TestUtil;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
+import org.eclipse.jdt.debug.ui.console.JavaStackTraceConsoleFactory;
+import org.eclipse.jdt.internal.debug.ui.console.ConsoleMessages;
+import org.eclipse.jdt.internal.debug.ui.console.JavaStackTraceConsole;
+import org.eclipse.jdt.internal.debug.ui.console.JavaStackTraceConsolePage;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPositionCategoryException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Position;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleManager;
+import org.eclipse.ui.console.TextConsoleViewer;
+import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
+import org.eclipse.ui.internal.console.ConsoleView;
+
+/**
+ * Base for {@link JavaStackTraceConsole} tests.
+ */
+public class AbstractJavaStackTraceConsoleTest extends AbstractDebugUiTests {
+
+	private final static Pattern LEFT_INDENT = Pattern.compile("^[ \\t]*");
+	private final static Pattern RIGHT_INDENT = Pattern.compile("\\s+$");
+
+	protected final JavaStackTraceConsoleFactory fConsoleFactory = new JavaStackTraceConsoleFactory();
+	protected JavaStackTraceConsole fConsole;
+
+	public AbstractJavaStackTraceConsoleTest(String name) {
+		super(name);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		initConsole(true);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		removeConsole(false);
+		super.tearDown();
+	}
+
+	/**
+	 * Create and register a {@link JavaStackTraceConsole}.
+	 *
+	 * @param assertDefaultContent
+	 *            If <code>true</code> assert console is initialized with its default content.
+	 * @see #removeConsole(boolean)
+	 */
+	protected void initConsole(boolean assertDefaultContent) {
+		fConsoleFactory.openConsole();
+		IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+		IConsole[] consoles = consoleManager.getConsoles();
+		fConsole = null;
+		for (IConsole console : consoles) {
+			if (console instanceof JavaStackTraceConsole) {
+				fConsole = (JavaStackTraceConsole) console;
+				// do not end loop. There should be only one JavaStackTraceConsole but if there are more
+				// the last one is most likely the one we opened
+			}
+		}
+		assertNotNull("Failed to open a JavaStackTraceConsole", fConsole);
+		if (assertDefaultContent) {
+			assertInitialContent();
+		}
+	}
+
+	/**
+	 * Remove the previous created console.
+	 *
+	 * @param preserveContent
+	 *            If <code>true</code> the remove does not prevent the current console content from being loaded by next
+	 *            {@link JavaStackTraceConsole}.
+	 * @see #initConsole(boolean)
+	 */
+	protected void removeConsole(boolean preserveContent) {
+		if (!preserveContent) {
+			fConsole.clearConsole();
+		}
+		final int contentLength = fConsole.getDocument().getLength();
+
+		IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+		consoleManager.removeConsoles(new IConsole[] { fConsole });
+
+		final Path stackTraceFile = Paths.get(JavaStackTraceConsole.FILE_NAME);
+		if (!preserveContent) {
+			assertTrue("Leaked content of JavaStackTraceConsole", Files.notExists(stackTraceFile));
+		} else {
+			assertTrue("JavaStackTraceConsole content was not persisted", Files.exists(stackTraceFile));
+			try {
+				assertTrue("Persisted content seems incomplete", Files.size(stackTraceFile) >= contentLength);
+			} catch (IOException e) {
+				fail("Persisted content seems incomplete");
+			}
+		}
+	}
+
+	protected IDocument consoleDocumentWithText(String text) throws InterruptedException {
+		IDocument document = fConsole.getDocument();
+		document.set(text);
+		// wait for document being parsed and hyperlinks created
+		Job.getJobManager().join(fConsole, null);
+		TestUtil.runEventLoop();
+		return document;
+	}
+
+	protected String getLine(IDocument doc, int line) {
+		IRegion lineInfo;
+		try {
+			lineInfo = doc.getLineInformation(line);
+			return doc.get(lineInfo.getOffset(), lineInfo.getLength());
+		} catch (BadLocationException ex) {
+			return null;
+		}
+	}
+
+	/**
+	 * Do some tests on the stack trace indentation. No hardcoded valued just some general assumptions.
+	 *
+	 * @param doc
+	 *            document to test
+	 * @param startLine
+	 *            first line to check
+	 */
+	protected void checkIndentationConsistency(IDocument doc, int startLine) {
+		boolean firstSuppress = true;
+		int lastIndent = -1;
+		// Remember how the next line's indentation can differ from the previous.
+		// -1 -> less indented
+		// 0 -> equal
+		// 1 -> more indented
+		int allowedIndentChange = 1;
+		for (int i = startLine, lineCount = doc.getNumberOfLines(); i < lineCount; i++) {
+			String line = getLine(doc, i);
+			line = line.replaceFirst("^\\[[^\\s\\]]+\\] ", ""); // remove and prefix if any
+			if (i != 0) { // first line can be empty
+				assertNotEquals("Empty line " + i, "", line);
+			}
+			assertFalse("Trailing whitespace in line " + i, RIGHT_INDENT.matcher(line).find());
+
+			boolean causedBy = line.trim().startsWith("Caused by: ");
+			boolean suppressed = line.trim().startsWith("Suppressed: ");
+			if (causedBy || (suppressed && !firstSuppress)) {
+				allowedIndentChange = -1;
+			}
+
+			int lineIndent = getLineIndentation(line);
+			if (allowedIndentChange < 0) {
+				assertTrue("Wrong indented line " + i + ": " + lastIndent + " > " + lineIndent, lastIndent > lineIndent);
+			} else if (allowedIndentChange == 0) {
+				assertEquals("Mixed indentation in line " + i, lastIndent, lineIndent);
+			} else if (allowedIndentChange > 0) {
+				assertTrue("Wrong indented line " + i + ": " + lastIndent + " < " + lineIndent, lastIndent < lineIndent);
+			}
+			lastIndent = lineIndent;
+			allowedIndentChange = 0;
+			if (causedBy || suppressed || i == startLine) {
+				allowedIndentChange = 1;
+			}
+			firstSuppress &= !suppressed;
+		}
+	}
+
+	protected int getLineIndentation(String line) {
+		int tabSize = 4;
+		String indent = "";
+		Matcher m = LEFT_INDENT.matcher(line);
+		if (m.find()) {
+			indent = m.group();
+		}
+		int tabCount = indent.length() - indent.replace("\t", "").length();
+		return indent.length() + (tabSize - 1) * tabCount;
+	}
+
+	/**
+	 * Set given text, invoke formatting and wait until finished.
+	 *
+	 * @param text
+	 *            new console text
+	 * @return the consoles document
+	 */
+	protected IDocument consoleDocumentFormatted(String text) {
+		IDocument document = fConsole.getDocument();
+		document.set(text);
+		fConsole.format();
+		// wait for document being formatted
+		TestUtil.waitForJobs(getName(), 30, 1000);
+		return document;
+	}
+
+	protected String[] linkTextsAtPositions(int... offsets) throws BadLocationException {
+		IDocument document = fConsole.getDocument();
+
+		List<String> texts = new ArrayList<>(offsets.length);
+		List<Position> positions = linkPositions(offsets);
+		for (Position pos : positions) {
+			String matchText = document.get(pos.getOffset(), pos.getLength());
+			texts.add(matchText);
+		}
+		return texts.toArray(new String[texts.size()]);
+	}
+
+	protected List<Position> linkPositions(int... offsets) {
+		List<Position> filteredPositions = new ArrayList<>(offsets.length);
+		for (Position position : allLinkPositions()) {
+			for (int offset : offsets) {
+				if (offset >= position.getOffset() && offset <= (position.getOffset() + position.getLength())) {
+					filteredPositions.add(position);
+					break;
+				}
+			}
+		}
+		return filteredPositions;
+	}
+
+	protected Position[] allLinkPositions() {
+		try {
+			return fConsole.getDocument().getPositions(ConsoleHyperlinkPosition.HYPER_LINK_CATEGORY);
+		} catch (BadPositionCategoryException ex) {
+			// no hyperlinks
+		}
+		return new Position[0];
+	}
+
+	protected String allLinks() {
+		return Arrays.toString(allLinkPositions());
+	}
+
+	/**
+	 * Check if initial content is shown.
+	 */
+	public void assertInitialContent() {
+		assertEquals("Console not loaded with initial content.", ConsoleMessages.JavaStackTraceConsole_0, fConsole.getDocument().get());
+	}
+
+	/**
+	 * Tries to get the viewer of the currently tested console.
+	 *
+	 * @return the consoles viewer
+	 */
+	protected TextConsoleViewer getConsolesViewer() {
+		TestUtil.waitForJobs(getName(), 100, DEFAULT_TIMEOUT);
+		IWorkbenchWindow workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		assertNotNull(workbenchWindow);
+		IWorkbenchPage activePage = workbenchWindow.getActivePage();
+		assertNotNull(activePage);
+		JavaStackTraceConsolePage page = null;
+		for (IViewReference vref : activePage.getViewReferences()) {
+			IViewPart view = vref.getView(false);
+			if (view instanceof ConsoleView) {
+				ConsoleView consoleView = (ConsoleView) view;
+				if (consoleView.getConsole() == fConsole && consoleView.getCurrentPage() instanceof JavaStackTraceConsolePage) {
+					page = (JavaStackTraceConsolePage) consoleView.getCurrentPage();
+					break;
+				}
+			}
+		}
+		assertNotNull(page);
+		return page.getViewer();
+	}
+
+	/**
+	 * Simulate user pressing a key.
+	 *
+	 * @param widget
+	 *            widget to type in
+	 * @param c
+	 *            character to type
+	 */
+	protected void doKeyStroke(StyledText widget, char c) {
+		final Event e = new Event();
+		e.character = c;
+		widget.notifyListeners(SWT.KeyDown, e);
+		widget.notifyListeners(SWT.KeyUp, e);
+	}
+}

--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2020 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial API and implementation
+ *     Paul Pazderski - Bug 546900: Tests to check initial console content and content persistence
+ *     Paul Pazderski - Bug 343023: Tests for 'clear initial content on first edit'
+ *     Paul Pazderski - Bug 304219: Tests for formatting
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.console;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.debug.tests.TestUtil;
+import org.eclipse.jdt.internal.debug.ui.console.JavaDebugStackTraceConsoleTracker;
+import org.eclipse.jdt.internal.debug.ui.console.JavaDebugStackTraceHyperlink;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+/**
+ * Tests for hyper-links added for stack traces copied from the {@code Debug} view. See {@link JavaDebugStackTraceHyperlink} and
+ * {@link JavaDebugStackTraceConsoleTracker}.
+ */
+public class JavaDebugStackTraceConsoleTest extends AbstractJavaStackTraceConsoleTest {
+
+	public JavaDebugStackTraceConsoleTest(String name) {
+		super(name);
+	}
+
+	public void testLinkNavigation() throws Exception {
+		String projectName = JavaDebugStackTraceConsoleTest.class.getSimpleName();
+		IJavaProject project = createProject(projectName, "testfiles/source/", JavaProjectHelper.JAVA_SE_1_8_EE_NAME, true);
+		waitForBuild();
+		waitForJobs();
+
+		consoleDocumentWithText("SomeClass.someMethod() line: 26");
+
+		IHyperlink[] hyperlinks = fConsole.getHyperlinks();
+		assertEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				2, hyperlinks.length);
+
+		String expectedText = "\t\tsomeField = new Vector();";
+		try {
+			for (IHyperlink hyperlink : hyperlinks) {
+				closeAllEditors();
+				hyperlink.linkActivated();
+				IEditorPart editor = waitForEditorOpen();
+				String[] selectedText = new String[1];
+				sync(() -> selectedText[0] = getSelectedText(editor));
+				assertEquals("Wrong text selected after hyperlink navigation", expectedText, selectedText[0]);
+			}
+		} finally {
+			closeAllEditors();
+			boolean force = true;
+			project.getProject().delete(force, new NullProgressMonitor());
+		}
+	}
+
+	public void testNotAvailableLineLocation() throws Exception {
+		consoleDocumentWithText("SomeClass.someMethod() line: not available [native method]");
+
+		assertArrayEquals("Wrong hyperlinks", new Position[0], allLinkPositions());
+	}
+
+	public void testInvalidLineLocation() throws Exception {
+		consoleDocumentWithText("SomeClass.someMethod() line: a1");
+
+		assertArrayEquals("Wrong hyperlinks", new Position[0], allLinkPositions());
+	}
+
+	public void testHyperlink() throws Exception {
+		consoleDocumentWithText("SomeClass.someMethod() line: 11");
+
+		String[] matchTexts = linkTextsAtPositions(0, 24);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass", "line: 11" }, matchTexts);
+	}
+
+	public void testEmptySpaces() throws Exception {
+		consoleDocumentWithText("\t \t SomeClass.someMethod() line: 11  \t\t ");
+
+		String[] matchTexts = linkTextsAtPositions(4, 28);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass", "line: 11" }, matchTexts);
+	}
+
+	public void testInnerClass() throws Exception {
+		consoleDocumentWithText("SomeClass$5.someMethod() line: 1155");
+
+		String[] matchTexts = linkTextsAtPositions(0, 26);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass", "line: 1155" }, matchTexts);
+
+
+		consoleDocumentWithText("SomeClass2$Inner1$Inner2.someMethod() line: 1256");
+
+		matchTexts = linkTextsAtPositions(0, 39);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass2", "line: 1256" }, matchTexts);
+	}
+
+	public void testSubtype() throws Exception {
+		consoleDocumentWithText("Subtype(Type).someMethod() line: 999");
+
+		String[] matchTexts = linkTextsAtPositions(9, 28);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "Type", "line: 999" }, matchTexts);
+	}
+
+	public void testQualifiedClass() throws Exception {
+		consoleDocumentWithText("somewhere1.somewhere2.SomeClass.someMethod() line: 123");
+
+		String[] matchTexts = linkTextsAtPositions(0, 46);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "somewhere1.somewhere2.SomeClass", "line: 123" }, matchTexts);
+	}
+
+	public void testParameterizedClass() throws Exception {
+		consoleDocumentWithText("SomeClass<SomeType>.someMethod() line: 504");
+
+		String[] matchTexts = linkTextsAtPositions(0, 34);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass", "line: 504" }, matchTexts);
+	}
+
+	public void testParameterizedSuperType() throws Exception {
+		consoleDocumentWithText("Subtype<T>(Type<K>).someMethod() line: 704");
+
+		String[] matchTexts = linkTextsAtPositions(12, 34);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "Type", "line: 704" }, matchTexts);
+	}
+
+	public void testMethodParameters() throws Exception {
+		consoleDocumentWithText("Some3Class.someMethod(SomeType[]) line: 301");
+
+		String[] matchTexts = linkTextsAtPositions(0, 36);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "Some3Class", "line: 301" }, matchTexts);
+
+
+		consoleDocumentWithText("SomeClass55.someMethod(Type1, SomeType2...) line: 111");
+
+		matchTexts = linkTextsAtPositions(0, 45);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "SomeClass55", "line: 111" }, matchTexts);
+
+
+		consoleDocumentWithText("Some1Class101.someMethod(Type1<Type10>, SomeType2) line: 1");
+
+		matchTexts = linkTextsAtPositions(0, 52);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "Some1Class101", "line: 1" }, matchTexts);
+
+
+		consoleDocumentWithText("Some1101Class101.someMethod(Type1<?>, SomeType2<?>) line: 12");
+
+		matchTexts = linkTextsAtPositions(0, 53);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "Some1101Class101", "line: 12" }, matchTexts);
+	}
+
+	public void testMixedCases() throws Exception {
+		consoleDocumentWithText("org.somewhere.Some3Class.someMethod(org.eclipse.SomeType<?>) line: 3011\t");
+
+		String[] matchTexts = linkTextsAtPositions(0, 62);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "org.somewhere.Some3Class", "line: 3011" }, matchTexts);
+
+
+		consoleDocumentWithText("  org.SomeClass55(org.eclipse.SuperClass).myMethod(org.Type1<com.SomeType3>, com.SomeType2...) line: 10 ");
+
+		matchTexts = linkTextsAtPositions(19, 96);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "org.eclipse.SuperClass", "line: 10" }, matchTexts);
+
+
+		consoleDocumentWithText("\torg.MyType(somewhere1.somewhere2.Some1Class101$org.Type<com.AnotherType>).toString(java.lang.String[], int) line: 2 ");
+
+		matchTexts = linkTextsAtPositions(13, 110);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "somewhere1.somewhere2.Some1Class101", "line: 2" }, matchTexts);
+
+
+		consoleDocumentWithText(" org.MyType2(somewhere1.somewhere2.Some1Class105<my.Type>$org.Type<com.AnotherType>$com.InnerType).toString(java.lang.List<org.SomeClass>, byte, long,double) line: 5   ");
+
+		matchTexts = linkTextsAtPositions(14, 159);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(),
+				new String[] { "somewhere1.somewhere2.Some1Class105", "line: 5" }, matchTexts);
+	}
+
+	private static String getSelectedText(IEditorPart editor) {
+		ITextEditor textEditor = (ITextEditor) editor;
+		ISelectionProvider selectionProvider = textEditor.getSelectionProvider();
+		ISelection selection = selectionProvider.getSelection();
+		ITextSelection textSelection = (ITextSelection) selection;
+		String selectedText = textSelection.getText();
+		return selectedText;
+	}
+
+	private IEditorPart waitForEditorOpen() throws Exception {
+		waitForJobs();
+		IEditorPart[] editor = new IEditorPart[1];
+		sync(() -> editor[0] = getActivePage().getActiveEditor());
+		long timeout = 30_000;
+		long start = System.currentTimeMillis();
+		while (editor[0] == null && System.currentTimeMillis() - start < timeout) {
+			waitForJobs();
+			sync(() -> editor[0] = getActivePage().getActiveEditor());
+		}
+		if (editor[0] == null) {
+			throw new AssertionError("Timeout occurred while waiting for editor to open");
+		}
+		return editor[0];
+	}
+
+	private void waitForJobs() throws Exception {
+		TestUtil.waitForJobs(getName(), 250, 1_000);
+	}
+}

--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceConsoleTest.java
@@ -19,124 +19,24 @@ package org.eclipse.jdt.debug.tests.console;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jdt.debug.tests.AbstractDebugTest;
-import org.eclipse.jdt.debug.tests.TestUtil;
-import org.eclipse.jdt.debug.ui.console.JavaStackTraceConsoleFactory;
-import org.eclipse.jdt.internal.debug.ui.console.ConsoleMessages;
 import org.eclipse.jdt.internal.debug.ui.console.JavaStackTraceConsole;
-import org.eclipse.jdt.internal.debug.ui.console.JavaStackTraceConsolePage;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ST;
-import org.eclipse.swt.custom.StyledText;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.ui.IViewPart;
-import org.eclipse.ui.IViewReference;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.console.ConsolePlugin;
-import org.eclipse.ui.console.IConsole;
-import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.TextConsoleViewer;
-import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
-import org.eclipse.ui.internal.console.ConsoleView;
 
 /**
  * Tests {@link JavaStackTraceConsole}
  */
-public class JavaStackTraceConsoleTest extends AbstractDebugTest {
-
-	private final static Pattern LEFT_INDENT = Pattern.compile("^[ \\t]*");
-	private final static Pattern RIGHT_INDENT = Pattern.compile("\\s+$");
-
-	private final JavaStackTraceConsoleFactory fConsoleFactory = new JavaStackTraceConsoleFactory();
-	private JavaStackTraceConsole fConsole;
+public class JavaStackTraceConsoleTest extends AbstractJavaStackTraceConsoleTest {
 
 	public JavaStackTraceConsoleTest(String name) {
 		super(name);
-	}
-
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-		initConsole(true);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		removeConsole(false);
-		super.tearDown();
-	}
-
-	/**
-	 * Create and register a {@link JavaStackTraceConsole}.
-	 *
-	 * @param assertDefaultContent
-	 *            If <code>true</code> assert console is initialized with its default content.
-	 * @see #removeConsole(boolean)
-	 */
-	private void initConsole(boolean assertDefaultContent) {
-		fConsoleFactory.openConsole();
-		IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-		IConsole[] consoles = consoleManager.getConsoles();
-		fConsole = null;
-		for (IConsole console : consoles) {
-			if (console instanceof JavaStackTraceConsole) {
-				fConsole = (JavaStackTraceConsole) console;
-				// do not end loop. There should be only one JavaStackTraceConsole but if there are more
-				// the last one is most likely the one we opened
-			}
-		}
-		assertNotNull("Failed to open a JavaStackTraceConsole", fConsole);
-		if (assertDefaultContent) {
-			assertInitialContent();
-		}
-	}
-
-	/**
-	 * Remove the previous created console.
-	 *
-	 * @param preserveContent
-	 *            If <code>true</code> the remove does not prevent the current console content from being loaded by next
-	 *            {@link JavaStackTraceConsole}.
-	 * @see #initConsole(boolean)
-	 */
-	private void removeConsole(boolean preserveContent) {
-		if (!preserveContent) {
-			fConsole.clearConsole();
-		}
-		final int contentLength = fConsole.getDocument().getLength();
-
-		IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-		consoleManager.removeConsoles(new IConsole[] { fConsole });
-
-		final Path stackTraceFile = Paths.get(JavaStackTraceConsole.FILE_NAME);
-		if (!preserveContent) {
-			assertTrue("Leaked content of JavaStackTraceConsole", Files.notExists(stackTraceFile));
-		} else {
-			assertTrue("JavaStackTraceConsole content was not persisted", Files.exists(stackTraceFile));
-			try {
-				assertTrue("Persisted content seems incomplete", Files.size(stackTraceFile) >= contentLength);
-			} catch (IOException e) {
-				fail("Persisted content seems incomplete");
-			}
-		}
 	}
 
 	public void testHyperlinkMatchSignatureSimple() throws Exception {
@@ -503,183 +403,5 @@ public class JavaStackTraceConsoleTest extends AbstractDebugTest {
 		assertEquals("at org.eclipse.debug.internal.ui.views.console.ProcessConsole.handleDebugEvents(ProcessConsole.java:438)", getLine(doc, 5).replace("[java]", "").trim());
 		assertEquals("at org.eclipse.debug.core.DebugPlugin$EventNotifier.run(DebugPlugin.java:1043)", getLine(doc, 6).replace("[java]", "").trim());
 		checkIndentationConsistency(doc, 3);
-	}
-
-	private IDocument consoleDocumentWithText(String text) throws InterruptedException {
-		IDocument document = fConsole.getDocument();
-		document.set(text);
-		// wait for document being parsed and hyperlinks created
-		Job.getJobManager().join(fConsole, null);
-		return document;
-	}
-
-	private String getLine(IDocument doc, int line) {
-		IRegion lineInfo;
-		try {
-			lineInfo = doc.getLineInformation(line);
-			return doc.get(lineInfo.getOffset(), lineInfo.getLength());
-		} catch (BadLocationException ex) {
-			return null;
-		}
-	}
-
-	/**
-	 * Do some tests on the stack trace indentation. No hardcoded valued just some general assumptions.
-	 *
-	 * @param doc
-	 *            document to test
-	 * @param startLine
-	 *            first line to check
-	 */
-	private void checkIndentationConsistency(IDocument doc, int startLine) {
-		boolean firstSuppress = true;
-		int lastIndent = -1;
-		// Remember how the next line's indentation can differ from the previous.
-		// -1 -> less indented
-		// 0 -> equal
-		// 1 -> more indented
-		int allowedIndentChange = 1;
-		for (int i = startLine, lineCount = doc.getNumberOfLines(); i < lineCount; i++) {
-			String line = getLine(doc, i);
-			line = line.replaceFirst("^\\[[^\\s\\]]+\\] ", ""); // remove and prefix if any
-			if (i != 0) { // first line can be empty
-				assertNotEquals("Empty line " + i, "", line);
-			}
-			assertFalse("Trailing whitespace in line " + i, RIGHT_INDENT.matcher(line).find());
-
-			boolean causedBy = line.trim().startsWith("Caused by: ");
-			boolean suppressed = line.trim().startsWith("Suppressed: ");
-			if (causedBy || (suppressed && !firstSuppress)) {
-				allowedIndentChange = -1;
-			}
-
-			int lineIndent = getLineIndentation(line);
-			if (allowedIndentChange < 0) {
-				assertTrue("Wrong indented line " + i + ": " + lastIndent + " > " + lineIndent, lastIndent > lineIndent);
-			} else if (allowedIndentChange == 0) {
-				assertEquals("Mixed indentation in line " + i, lastIndent, lineIndent);
-			} else if (allowedIndentChange > 0) {
-				assertTrue("Wrong indented line " + i + ": " + lastIndent + " < " + lineIndent, lastIndent < lineIndent);
-			}
-			lastIndent = lineIndent;
-			allowedIndentChange = 0;
-			if (causedBy || suppressed || i == startLine) {
-				allowedIndentChange = 1;
-			}
-			firstSuppress &= !suppressed;
-		}
-	}
-
-	private int getLineIndentation(String line) {
-		int tabSize = 4;
-		String indent = "";
-		Matcher m = LEFT_INDENT.matcher(line);
-		if (m.find()) {
-			indent = m.group();
-		}
-		int tabCount = indent.length() - indent.replace("\t", "").length();
-		return indent.length() + (tabSize - 1) * tabCount;
-	}
-
-	/**
-	 * Set given text, invoke formatting and wait until finished.
-	 *
-	 * @param text
-	 *            new console text
-	 * @return the consoles document
-	 */
-	private IDocument consoleDocumentFormatted(String text) {
-		IDocument document = fConsole.getDocument();
-		document.set(text);
-		fConsole.format();
-		// wait for document being formatted
-		TestUtil.waitForJobs(getName(), 30, 1000);
-		return document;
-	}
-
-	private String[] linkTextsAtPositions(int... offsets) throws BadLocationException {
-		IDocument document = fConsole.getDocument();
-
-		List<String> texts = new ArrayList<>(offsets.length);
-		List<Position> positions = linkPositions(offsets);
-		for (Position pos : positions) {
-			String matchText = document.get(pos.getOffset(), pos.getLength());
-			texts.add(matchText);
-		}
-		return texts.toArray(new String[texts.size()]);
-	}
-
-	private List<Position> linkPositions(int... offsets) {
-		List<Position> filteredPositions = new ArrayList<>(offsets.length);
-		for (Position position : allLinkPositions()) {
-			for (int offset : offsets) {
-				if (offset >= position.getOffset() && offset <= (position.getOffset() + position.getLength())) {
-					filteredPositions.add(position);
-					break;
-				}
-			}
-		}
-		return filteredPositions;
-	}
-
-	private Position[] allLinkPositions() {
-		try {
-			return fConsole.getDocument().getPositions(ConsoleHyperlinkPosition.HYPER_LINK_CATEGORY);
-		} catch (BadPositionCategoryException ex) {
-			// no hyperlinks
-		}
-		return new Position[0];
-	}
-
-	private String allLinks() {
-		return Arrays.toString(allLinkPositions());
-	}
-
-	/**
-	 * Check if initial content is shown.
-	 */
-	public void assertInitialContent() {
-		assertEquals("Console not loaded with initial content.", ConsoleMessages.JavaStackTraceConsole_0, fConsole.getDocument().get());
-	}
-
-	/**
-	 * Tries to get the viewer of the currently tested console.
-	 *
-	 * @return the consoles viewer
-	 */
-	private TextConsoleViewer getConsolesViewer() {
-		TestUtil.waitForJobs(getName(), 100, DEFAULT_TIMEOUT);
-		IWorkbenchWindow workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		assertNotNull(workbenchWindow);
-		IWorkbenchPage activePage = workbenchWindow.getActivePage();
-		assertNotNull(activePage);
-		JavaStackTraceConsolePage page = null;
-		for (IViewReference vref : activePage.getViewReferences()) {
-			IViewPart view = vref.getView(false);
-			if (view instanceof ConsoleView) {
-				ConsoleView consoleView = (ConsoleView) view;
-				if (consoleView.getConsole() == fConsole && consoleView.getCurrentPage() instanceof JavaStackTraceConsolePage) {
-					page = (JavaStackTraceConsolePage) consoleView.getCurrentPage();
-					break;
-				}
-			}
-		}
-		assertNotNull(page);
-		return page.getViewer();
-	}
-
-	/**
-	 * Simulate user pressing a key.
-	 *
-	 * @param widget
-	 *            widget to type in
-	 * @param c
-	 *            character to type
-	 */
-	private void doKeyStroke(StyledText widget, char c) {
-		final Event e = new Event();
-		e.character = c;
-		widget.notifyListeners(SWT.KeyDown, e);
-		widget.notifyListeners(SWT.KeyUp, e);
 	}
 }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.debug.tests.breakpoints.WatchpointTests;
 import org.eclipse.jdt.debug.tests.connectors.MultipleConnectionsTest;
 import org.eclipse.jdt.debug.tests.console.ConsoleTerminateAllActionTests;
 import org.eclipse.jdt.debug.tests.console.IOConsoleTests;
+import org.eclipse.jdt.debug.tests.console.JavaDebugStackTraceConsoleTest;
 import org.eclipse.jdt.debug.tests.console.JavaStackTraceConsoleTest;
 import org.eclipse.jdt.debug.tests.core.AlternateStratumTests;
 import org.eclipse.jdt.debug.tests.core.ArgumentTests;
@@ -259,6 +260,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(ConsoleInputTests.class));
 		addTest(new TestSuite(LineTrackerTests.class));
 		addTest(new TestSuite(JavaStackTraceConsoleTest.class));
+		addTest(new TestSuite(JavaDebugStackTraceConsoleTest.class));
 		addTest(new TestSuite(IOConsoleTests.class));
 		addTest(new TestSuite(ConsoleTerminateAllActionTests.class));
 

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3542,6 +3542,26 @@ M4 = Platform-specific fourth key
             </or>
          </enablement>
       </consolePatternMatchListener>
+      <!-- Add hyperlinks to stack traces copied from the Debug view, e.g.:
+
+              SomeClass.someMethod(String[]) line: 6
+              SomeClass.someMethod(SomeType1<?>, SomeType2<?>) line: 12
+              SomeClass<SomeType>.someMethod() line: 504
+
+           Triangle brackets for generics are specified as "&lt;" and "&gt;",
+           as characters "<" and ">" are not allowed within the pattern definition (due to xml).
+      -->
+      <consolePatternMatchListener
+            class="org.eclipse.jdt.internal.debug.ui.console.JavaDebugStackTraceConsoleTracker"
+            regex="[$\w\(\)\.&lt;&gt;]+\.[$\w]+\([$\s\w\[\]\.,?&lt;&gt;]*\) line: [\d]+"
+            qualifier="line: [\d]+"
+            id="org.eclipse.jdt.debug.ui.JavaDebugStackTraceConsoleTracker">
+         <enablement>
+            <or>
+               <test property="org.eclipse.ui.console.consoleTypeTest" value="javaStackTraceConsole"/>
+            </or>
+         </enablement>
+      </consolePatternMatchListener>
    </extension>
    <extension
          point="org.eclipse.ui.console.consolePageParticipants">

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenFromClipboardAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenFromClipboardAction.java
@@ -466,6 +466,11 @@ public class OpenFromClipboardAction implements IWorkbenchWindowActionDelegate {
 	 * @throws InterruptedException if canceled by the user
 	 */
 	private static void handleMatches(List<Object> matches, int line, String inputText) {
+		handleMatches(matches, line, inputText, ActionMessages.OpenFromClipboardAction_OpenFromClipboard);
+	}
+
+	public static void handleMatches(List<Object> matches, int line, String inputText, String title) {
+
 		if (matches.size() > 1) {
 			int flags = JavaElementLabelProvider.SHOW_DEFAULT | JavaElementLabelProvider.SHOW_QUALIFIED | JavaElementLabelProvider.SHOW_ROOT;
 			IWorkbenchWindow window = JDIDebugUIPlugin.getActiveWorkbenchWindow();
@@ -480,7 +485,7 @@ public class OpenFromClipboardAction implements IWorkbenchWindowActionDelegate {
 					return DialogSettings.getOrCreateSection(settings, "OpenFromClipboardAction_dialogBounds"); //$NON-NLS-1$
 				}
 			};
-			dialog.setTitle(ActionMessages.OpenFromClipboardAction_OpenFromClipboard);
+			dialog.setTitle(title);
 			dialog.setMessage(ActionMessages.OpenFromClipboardAction_SelectOrEnterTheElementToOpen);
 			dialog.setElements(matches.toArray());
 			dialog.setMultipleSelection(true);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/ConsoleMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/ConsoleMessages.java
@@ -38,6 +38,9 @@ public class ConsoleMessages extends NLS {
 	public static String JavaStackTraceHyperlink_Unable_to_parse_line_number_from_hyperlink__6;
 	public static String JavaStackTraceHyperlink_Unable_to_retrieve_hyperlink_text__8;
 
+	public static String JavaDebugStackTraceHyperlink_dialog_title;
+	public static String JavaDebugStackTraceHyperlink_dialog_message;
+
 	static {
 		// load message values from bundle file
 		NLS.initializeMessages(BUNDLE_NAME, ConsoleMessages.class);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/ConsoleMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/ConsoleMessages.properties
@@ -26,5 +26,7 @@ JavaStackTraceHyperlink_Source_not_found_for__0__2=Source not found for {0}
 JavaStackTraceHyperlink_Unable_to_parse_type_name_from_hyperlink__5=Unable to parse type name from hyperlink.
 JavaStackTraceHyperlink_Unable_to_parse_line_number_from_hyperlink__6=Unable to parse line number from hyperlink.
 JavaStackTraceHyperlink_Unable_to_retrieve_hyperlink_text__8=Unable to retrieve hyperlink text.
+JavaDebugStackTraceHyperlink_dialog_title=Select type
+JavaDebugStackTraceHyperlink_dialog_message=Multiple matches found for ''{0}''.\nSelect type to navigate to:
 AutoFormatSettingAction_0=Auto Format
 AutoFormatSettingAction_1=Auto Format

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaDebugStackTraceConsoleTracker.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaDebugStackTraceConsoleTracker.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.debug.ui.console;
+
+import java.util.function.Function;
+
+import org.eclipse.jdt.internal.debug.ui.console.JavaDebugStackTraceHyperlink.LinkSubstring;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.ui.console.PatternMatchEvent;
+import org.eclipse.ui.console.TextConsole;
+
+/**
+ * Creates hyper-links of type {@link JavaDebugStackTraceHyperLink}.
+ */
+public class JavaDebugStackTraceConsoleTracker extends JavaConsoleTracker {
+	@Override
+	public void matchFound(PatternMatchEvent event) {
+		try {
+			// add a hyperlink at "line: 123"
+			addHyperlinkAtContent(event, line -> JavaDebugStackTraceHyperlink.extractLineText(line));
+			// add a hyperlink at the type
+			addHyperlinkAtContent(event, line -> JavaDebugStackTraceHyperlink.extractTypeName(line));
+		} catch (BadLocationException e) {
+		}
+	}
+
+	private void addHyperlinkAtContent(PatternMatchEvent event, Function<String, LinkSubstring> contentSupplier) throws BadLocationException {
+		int offset = event.getOffset();
+		int length = event.getLength();
+
+		TextConsole console = getConsole();
+		IDocument document = console.getDocument();
+		String line = document.get(offset, length);
+		LinkSubstring linkSubstring = contentSupplier.apply(line);
+
+		if (linkSubstring != null) {
+			int hyperlinkStartIndex = offset + linkSubstring.startIndex;
+			int hyperlinkLength = linkSubstring.substring.length();
+			IHyperlink link = new JavaDebugStackTraceHyperlink(console);
+			console.addHyperlink(link, hyperlinkStartIndex, hyperlinkLength);
+		}
+	}
+
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaDebugStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaDebugStackTraceHyperlink.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.debug.ui.console;
+
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.ui.console.TextConsole;
+
+/**
+ * A hyperlink from a stack trace line of the form:
+ *
+ * <pre>
+ *     Test.main(String[]) line: 6
+ * </pre>
+ */
+public class JavaDebugStackTraceHyperlink extends JavaStackTraceHyperlink {
+
+	static final String LINE_PREFIX = "line: "; //$NON-NLS-1$
+
+	private static final Pattern LINE_PATTERN = Pattern.compile(".*(" + LINE_PREFIX + "\\d+)"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	public JavaDebugStackTraceHyperlink(TextConsole console) {
+		super(console);
+	}
+
+	@Override
+	protected String getLinkText() throws CoreException {
+		try {
+			TextConsole console = getConsole();
+			IDocument document = console.getDocument();
+			IRegion region = console.getRegion(this);
+			int regionOffset = region.getOffset();
+
+			int lineNumber = document.getLineOfOffset(regionOffset);
+			IRegion lineInformation = document.getLineInformation(lineNumber);
+			int lineOffset = lineInformation.getOffset();
+			String line = document.get(lineOffset, lineInformation.getLength());
+			line = line.trim();
+			return line;
+		} catch (BadLocationException e) {
+			IStatus status = new Status(IStatus.ERROR, JDIDebugUIPlugin.getUniqueIdentifier(), 0, ConsoleMessages.JavaStackTraceHyperlink_Unable_to_retrieve_hyperlink_text__8, e);
+			throw new CoreException(status);
+		}
+	}
+
+	@Override
+	protected int getLineNumber(String linkText) {
+		LinkSubstring lineText = extractLineText(linkText);
+		if (lineText != null) {
+			try {
+				String lineNumberText = lineText.substring.substring(LINE_PREFIX.length());
+				return Integer.parseInt(lineNumberText);
+			} catch (NumberFormatException e) {
+				// ignore, we couldn't parse the line number
+			}
+		}
+		return -1;
+	}
+
+	@Override
+	protected String getTypeName(String linkText) throws CoreException {
+		LinkSubstring linkSubstring = extractTypeName(linkText);
+		if (linkSubstring != null) {
+			return linkSubstring.substring;
+		}
+		IStatus status = new Status(IStatus.ERROR, JDIDebugUIPlugin.getUniqueIdentifier(), 0, ConsoleMessages.JavaStackTraceHyperlink_Unable_to_parse_type_name_from_hyperlink__5, null);
+		throw new CoreException(status);
+	}
+
+	public static LinkSubstring extractLineText(String linkText) {
+		LinkSubstring lineText = null;
+		Matcher matcher = LINE_PATTERN.matcher(linkText);
+		if (matcher.matches()) {
+			int groupCount = matcher.groupCount();
+			int groupIndex = 1;
+			if (groupIndex <= groupCount) {
+				String lineNumberText = matcher.group(groupIndex);
+				int startIndex = matcher.start(groupIndex);
+				lineText = new LinkSubstring(lineNumberText, startIndex);
+			}
+		}
+		return lineText;
+	}
+
+	public static LinkSubstring extractTypeName(String linkText) {
+		boolean hasLeadingSubtype = false;
+		int startIndex = 0;
+		int indexOfOpeningBracket = linkText.indexOf('(');
+		int endIndex = indexOfOpeningBracket;
+		// check if we have format "Subtype(Type).method()", if so we want "Type"
+		int indexOfSecondOpeningBracket = linkText.indexOf('(', endIndex + 1);
+		int indexOfClosingBracket = linkText.indexOf(')', endIndex);
+		if (indexOfSecondOpeningBracket != -1 && indexOfClosingBracket != -1 && indexOfClosingBracket < indexOfSecondOpeningBracket) {
+			startIndex = endIndex + 1;
+			endIndex = indexOfClosingBracket;
+			hasLeadingSubtype = true;
+		}
+		if (endIndex >= 0) {
+			String substring = linkText.substring(startIndex, endIndex);
+			if (!hasLeadingSubtype) {
+				// remove the method name
+				int dotIndex = substring.lastIndexOf('.');
+				if (dotIndex != -1) {
+					endIndex = startIndex + dotIndex;
+					substring = linkText.substring(startIndex, endIndex);
+				}
+			}
+			// check if we have format "Type<ParameterType>.method()", if so we want "Type"
+			int indexOfTriangleBracket = substring.indexOf('<');
+			if (indexOfTriangleBracket != -1) {
+				endIndex = startIndex + indexOfTriangleBracket;
+				substring = linkText.substring(startIndex, endIndex);
+			}
+			int innerClassIndex = substring.indexOf('$');
+			if (innerClassIndex != -1) {
+				endIndex = startIndex + innerClassIndex;
+			}
+		}
+		String typeName = linkText.substring(startIndex, endIndex);
+		return new LinkSubstring(typeName, startIndex);
+	}
+
+	static class LinkSubstring {
+
+		final String substring;
+		final int startIndex;
+
+		private LinkSubstring(String substring, int startIndex) {
+			this.substring = substring;
+			this.startIndex = startIndex;
+		}
+	}
+}


### PR DESCRIPTION
This change adds hyperlinks for stack traces copied from the Debug view.
Those hyperlinks are usable from different consoles, e.g. the Java Stack
Traces Console

In case of ambiguous Type open a search dialog to ask for the concrete
type (also for normal stack traces).

- Original PR: https://git.eclipse.org/r/c/jdt/eclipse.jdt.debug/+/191130
- PR with "Open Type" fix: https://git.eclipse.org/r/c/jdt/eclipse.jdt.debug/+/192117
- This is just slightly modified version from later one.