### PR TITLE
Can't set a breakpoint in lambda using expression #6

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
@@ -1067,6 +1067,8 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 					}
 				} else if (body instanceof LambdaExpression) {
 					body.accept(this);
+				} else if (body instanceof MethodInvocation) {
+					body.accept(this);
 				}
 			}
 			return false;


### PR DESCRIPTION
Check nested method invocations for nested lambda bodies.
Fixes issue #6.