### PR TITLE
Bug 547041 - Fixed parsing of Debug view stacks with multiple generics

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
@@ -146,6 +146,13 @@ public class JavaDebugStackTraceConsoleTest extends AbstractJavaStackTraceConsol
 				new String[] { "Type", "line: 704" }, matchTexts);
 	}
 
+	public void testMultipleTypeParameters() throws Exception {
+		consoleDocumentWithText("ReferencePipeline$Head<E_IN,E_OUT>.forEach(Consumer<? super E_OUT>) line: 658");
+
+		String[] matchTexts = linkTextsAtPositions(0, 69);
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(), new String[] { "ReferencePipeline", "line: 658" }, matchTexts);
+	}
+
 	public void testMethodParameters() throws Exception {
 		consoleDocumentWithText("Some3Class.someMethod(SomeType[]) line: 301");
 

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3553,7 +3553,7 @@ M4 = Platform-specific fourth key
       -->
       <consolePatternMatchListener
             class="org.eclipse.jdt.internal.debug.ui.console.JavaDebugStackTraceConsoleTracker"
-            regex="[$\w\(\)\.&lt;&gt;]+\.[$\w]+\([$\s\w\[\]\.,?&lt;&gt;]*\) line: [\d]+"
+            regex="[$\w\(\)\.&lt;&gt;,]+\.[$\w]+\([$\s\w\[\]\.,?&lt;&gt;]*\) line: [\d]+"
             qualifier="line: [\d]+"
             id="org.eclipse.jdt.debug.ui.JavaDebugStackTraceConsoleTracker">
          <enablement>


### PR DESCRIPTION
If the type in a Debug view stack trace line has multiple type
parameters, the regexp for hyperlinks does not correctly detect the
whole line.

This change adds also comma to the accepted symbols for the type name
part of stack trace lines.

Change-Id: I31d38f2679caafa63c765efeb39d80ea831624cb
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>