### PR TITLE
Bug 579635 - NPE in MatchLocator.findIndexMatches(MatchLocator.java:306)

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DetailFormatterDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DetailFormatterDialog.java
@@ -369,6 +369,9 @@ public class DetailFormatterDialog extends StatusDialog implements ITypeProvider
 
 		SearchEngine engine= new SearchEngine(JavaCore.getWorkingCopies(null));
 		SearchPattern searchPattern = SearchPattern.createPattern(pattern, IJavaSearchConstants.TYPE, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		if (searchPattern == null) {
+			return;
+		}
 		IJavaSearchScope scope= SearchEngine.createWorkspaceScope();
 		SearchParticipant[] participants = new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 		try {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/EditLogicalStructureDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/EditLogicalStructureDialog.java
@@ -740,6 +740,9 @@ public class EditLogicalStructureDialog extends StatusDialog implements Listener
 
 		SearchEngine engine= new SearchEngine(JavaCore.getWorkingCopies(null));
 		SearchPattern searchPattern = SearchPattern.createPattern(pattern, IJavaSearchConstants.TYPE, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		if (searchPattern == null) {
+			return;
+		}
 		IJavaSearchScope scope= SearchEngine.createWorkspaceScope();
 		SearchParticipant[] participants = new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 		try {


### PR DESCRIPTION
SearchPattern.createPattern() can return null pattern if the input is not valid. So don't pass null patterns down to the Search engine, it doesn't like that.