### PR TITLE
Test script tweaking (#30)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		buildDiscarder(logRotator(numToKeepStr:'15'))
+		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}
 	agent {

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -35,6 +35,7 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
+          <appArgLine>-consoleLog</appArgLine>
           <dependencies>
             <dependency>
               <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->


### PR DESCRIPTION
- Show test execution progress on console
- Abort previously started builds on new patch set
- Keep 15 test executions

Fixes issue https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/30