### PR TITLE
Can't set breakpoints in lambda blocks (Fixes #33)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ pipeline {
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbuild-individual-bundles -Pbree-libs -Papi-check \
 						-Dcompare-version-with-baselines.skip=false \
-						-Dproject.build.sourceEncoding=UTF-8 
+						-Dproject.build.sourceEncoding=UTF-8 \
+						-DtrimStackTrace=false
 					"""
 				}
 			}

--- a/org.eclipse.jdt.debug.tests/java8/LambdaBreakpoints1.java
+++ b/org.eclipse.jdt.debug.tests/java8/LambdaBreakpoints1.java
@@ -1,0 +1,36 @@
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class LambdaBreakpoints1 {
+	public static void main(String[] args) throws Exception {
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		StringBuilder s = new StringBuilder();
+		CompletableFuture<?> f = CompletableFuture.completedFuture("0");
+		f = f.thenApply((x) -> {
+			s.append(x).append("1");
+			return s.toString(); // breakpoint 1
+		})
+		.thenApply(x ->
+			s.append("2") // breakpoint 2
+		)
+		.thenRun(() -> lastCall(s))
+		.thenRunAsync(() -> {}, executor);
+		executor.shutdown();
+		f.get();
+		String result = s.toString();
+		System.out.println(result); // breakpoint 4
+	}
+
+	private static void lastCall(StringBuilder b) {
+		b.append(C.s());
+	}
+
+	static class C {
+		static String s() {
+			if (Boolean.valueOf("true")) // breakpoint 3
+				return "3"; // <--- breakpoint 3 should not be here
+			return "???";
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugPerformanceTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugPerformanceTest.java
@@ -13,14 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests;
 
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceMeter;
+import org.eclipse.test.performance.PerformanceTestCase;
 
 /**
  * An abstract implementation of a debug performance test
  */
-public class AbstractDebugPerformanceTest extends AbstractDebugTest {
+public class AbstractDebugPerformanceTest extends AbstractDebugUiTests {
 
 	protected PerformanceMeter fPerformanceMeter;
 

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -497,6 +497,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				cfgs.add(createLaunchConfiguration(jp, "Bug578145LambdaInStaticInitializer"));
 				cfgs.add(createLaunchConfiguration(jp, "Bug578145LambdaInAnonymous"));
 				cfgs.add(createLaunchConfiguration(jp, "Bug578145LambdaOnChainCalls"));
+				cfgs.add(createLaunchConfiguration(jp, "LambdaBreakpoints1"));
 	    		loaded18 = true;
 	    		waitForBuild();
 	        }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IMarkerDelta;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
@@ -52,7 +51,6 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
-import org.eclipse.debug.core.IBreakpointListener;
 import org.eclipse.debug.core.IBreakpointManager;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -82,10 +80,8 @@ import org.eclipse.debug.internal.ui.views.console.ProcessConsole;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.IDebugModelPresentation;
 import org.eclipse.debug.ui.IDebugUIConstants;
-import org.eclipse.debug.ui.IDebugView;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTabGroup;
-import org.eclipse.debug.ui.actions.ToggleBreakpointAction;
 import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IClassFile;
@@ -148,24 +144,18 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.source.IVerticalRulerInfo;
 import org.eclipse.jface.util.SafeRunnable;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IHyperlink;
 import org.eclipse.ui.console.TextConsole;
-import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.console.ConsoleHyperlinkPosition;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.progress.UIJob;
-import org.eclipse.ui.progress.WorkbenchJob;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.sun.jdi.InternalException;
@@ -2539,7 +2529,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
                 Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
                 Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
 				// Let also all other pending jobs proceed, ignore console jobs
-				TestUtil.waitForJobs("waitForBuild", 100, 1000, ProcessConsole.class);
+				TestUtil.waitForJobs("waitForBuild", 100, 5000, ProcessConsole.class);
                 wasInterrupted = false;
             } catch (OperationCanceledException e) {
                 e.printStackTrace();
@@ -2709,151 +2699,6 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				((JDIDebugTarget) target).shutdown();
 			}
 		}
-	}
-
-	/**
-	 * Opens and returns an editor on the given file or <code>null</code>
-	 * if none. The editor will be activated.
-	 *
-	 * @param file
-	 * @return editor or <code>null</code>
-	 */
-	protected IEditorPart openEditor(final IFile file) throws PartInitException, InterruptedException {
-		Display display = DebugUIPlugin.getStandardDisplay();
-		if (Thread.currentThread().equals(display.getThread())) {
-			IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-			return IDE.openEditor(page, file, true);
-		}
-		final IEditorPart[] parts = new IEditorPart[1];
-		WorkbenchJob job = new WorkbenchJob(display, "open editor") {
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-				IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-				try {
-					parts[0] = IDE.openEditor(page, file, true);
-				} catch (PartInitException e) {
-					return e.getStatus();
-				}
-				return Status.OK_STATUS;
-			}
-		};
-		job.schedule();
-		job.join();
-		return parts[0];
-	}
-
-	/**
-	 * Opens the {@link IDebugView} with the given id, does nothing if no such view exists.
-	 * This method can return <code>null</code>
-	 *
-	 * @param viewId
-	 * @return the handle to the {@link IDebugView} with the given id
-	 * @throws PartInitException
-	 * @throws InterruptedException
-	 * @since 3.8.100
-	 */
-	protected IDebugView openDebugView(final String viewId) throws PartInitException, InterruptedException {
-		if(viewId != null) {
-			Display display = DebugUIPlugin.getStandardDisplay();
-			if (Thread.currentThread().equals(display.getThread())) {
-				return doShowDebugView(viewId);
-			}
-			final IDebugView[] view = new IDebugView[1];
-			WorkbenchJob job = new WorkbenchJob("Showing the debug view: "+viewId) {
-				@Override
-				public IStatus runInUIThread(IProgressMonitor monitor) {
-					try {
-					view[0] = doShowDebugView(viewId);
-					}
-					catch(CoreException ce) {
-						return ce.getStatus();
-					}
-					return Status.OK_STATUS;
-				}
-			};
-			job.schedule();
-			job.join();
-			return view[0];
-		}
-		return null;
-	}
-
-	/**
-	 * Opens a debug view
-	 * @param viewId
-	 * @return return the debug view handle or <code>null</code>
-	 * @throws PartInitException
-	 * @since 3.8.100
-	 */
-	private IDebugView doShowDebugView(String viewId) throws PartInitException {
-		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if(window != null) {
-			IWorkbenchPage page = window.getActivePage();
-			assertNotNull("We shold have found the active page to open the debug view in", page);
-			return (IDebugView) page.showView(viewId);
-		}
-		return null;
-	}
-
-	/**
-	 * Toggles a breakpoint in the editor at the given line number returning the breakpoint
-	 * or <code>null</code> if none.
-	 *
-	 * @param editor
-	 * @param lineNumber
-	 * @return returns the created breakpoint or <code>null</code> if none.
-	 * @throws InterruptedException
-	 */
-	protected IBreakpoint toggleBreakpoint(final IEditorPart editor, int lineNumber) throws InterruptedException {
-		final IVerticalRulerInfo info = new VerticalRulerInfoStub(lineNumber-1); // sub 1, as the doc lines start at 0
-		WorkbenchJob job = new WorkbenchJob(DebugUIPlugin.getStandardDisplay(), "toggle breakpoint") {
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-				ToggleBreakpointAction action = new ToggleBreakpointAction(editor, null, info);
-				action.run();
-				return Status.OK_STATUS;
-			}
-		};
-		final Object lock = new Object();
-		final IBreakpoint[] breakpoints = new IBreakpoint[1];
-		IBreakpointListener listener = new IBreakpointListener() {
-			@Override
-			public void breakpointRemoved(IBreakpoint breakpoint, IMarkerDelta delta) {
-			}
-			@Override
-			public void breakpointChanged(IBreakpoint breakpoint, IMarkerDelta delta) {
-			}
-			@Override
-			public void breakpointAdded(IBreakpoint breakpoint) {
-				synchronized (lock) {
-					breakpoints[0] = breakpoint;
-					lock.notifyAll();
-				}
-			}
-		};
-		IBreakpointManager manager = DebugPlugin.getDefault().getBreakpointManager();
-		manager.addBreakpointListener(listener);
-		synchronized (lock) {
-			job.schedule();
-			lock.wait(DEFAULT_TIMEOUT);
-		}
-		manager.removeBreakpointListener(listener);
-		return breakpoints[0];
-	}
-
-	/**
-	 * Closes all editors in the active workbench page.
-	 */
-	protected void closeAllEditors() {
-	    Runnable closeAll = new Runnable() {
-            @Override
-			public void run() {
-                IWorkbenchWindow activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-                activeWorkbenchWindow.getActivePage().closeAllEditors(false);
-            }
-        };
-        Display display = DebugUIPlugin.getStandardDisplay();
-        display.syncExec(closeAll);
 	}
 
 	/**

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/AbstractBreakpointWorkingSetTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/AbstractBreakpointWorkingSetTest.java
@@ -15,7 +15,7 @@ package org.eclipse.jdt.debug.tests.breakpoints;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.ui.IDebugUIConstants;
-import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
@@ -25,7 +25,7 @@ import org.eclipse.ui.PlatformUI;
  *
  * @since 3.2
  */
-public abstract class AbstractBreakpointWorkingSetTest extends AbstractDebugTest {
+public abstract class AbstractBreakpointWorkingSetTest extends AbstractDebugUiTests {
 
 	/**
 	 * Constructor

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/BreakpointListenerTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/BreakpointListenerTests.java
@@ -195,9 +195,6 @@ public class BreakpointListenerTests extends AbstractDebugTest implements IBreak
 		List<IJavaLineBreakpoint> bps = createBreakpoints("Breakpoints");
 
 		try {
-			// close all editors before closing project: @see bug 204023
-			closeAllEditors();
-
 			getBreakpointManager().addBreakpointListener((IBreakpointsListener)this);
 
 			resetCallbacks();

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/DeferredBreakpointTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/DeferredBreakpointTests.java
@@ -24,13 +24,13 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
-import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
 import org.eclipse.ui.IEditorPart;
 
 /**
  * Tests deferred breakpoints.
  */
-public class DeferredBreakpointTests extends AbstractDebugTest {
+public class DeferredBreakpointTests extends AbstractDebugUiTests {
 
 	/**
 	 * Constructor

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/LambdaBreakpointsInJava8Tests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/LambdaBreakpointsInJava8Tests.java
@@ -13,25 +13,37 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.breakpoints;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IThread;
+import org.eclipse.debug.core.model.IValue;
 import org.eclipse.debug.internal.ui.views.console.ProcessConsole;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
-import org.eclipse.jdt.debug.tests.AbstractDebugTest;
 import org.eclipse.jdt.debug.tests.TestUtil;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 
 /**
  * Tests lambda breakpoints.
  */
-public class LambdaBreakpointsInJava8Tests extends AbstractDebugTest {
+public class LambdaBreakpointsInJava8Tests extends AbstractDebugUiTests {
 
 	public LambdaBreakpointsInJava8Tests(String name) {
 		super(name);
@@ -100,6 +112,92 @@ public class LambdaBreakpointsInJava8Tests extends AbstractDebugTest {
 			terminateAndRemove(thread);
 			removeAllBreakpoints();
 		}
+	}
+
+	public void testBreakpointsInLambdaBlocks() throws Exception {
+		final String testClass = "LambdaBreakpoints1";
+		IType type = get18Project().findType(testClass);
+		assertNotNull("Missing file", type);
+		IResource file = type.getResource();
+		assertTrue("Missing file", file instanceof IFile);
+		JavaEditor editor = (JavaEditor) openEditor((IFile) file);
+		processUiEvents();
+		IJavaThread javaThread = null;
+		IBreakpoint[] bps = getBreakpointManager().getBreakpoints();
+		assertArrayEquals(new IBreakpoint[0], bps);
+
+		try {
+			BreakpointsMap bpMap = new BreakpointsMap();
+			IJavaLineBreakpoint bp1 = createLineBreakpoint(12, editor, bpMap);
+			IJavaLineBreakpoint bp2 = createLineBreakpoint(15, editor, bpMap);
+			IJavaLineBreakpoint bp3 = createLineBreakpoint(31, editor, bpMap);
+			IJavaLineBreakpoint bp4 = createLineBreakpoint(22, editor, bpMap);
+
+			processUiEvents();
+			bpMap.assertBreakpointsConsistency();
+
+			// Check the breakpoints aren't moved or removed after saving editor
+			// (that will trigger ValidBreakpointLocationLocator)
+			sync(() -> editor.doSave(new NullProgressMonitor()));
+			TestUtil.waitForJobs(getName(), 100, DEFAULT_TIMEOUT, ProcessConsole.class);
+			processUiEvents();
+
+			bpMap.assertBreakpointsConsistency();
+
+			javaThread = launchToBreakpoint(testClass);
+			assertNotNull("The program did not suspend", javaThread);
+			processUiEvents();
+
+			IBreakpoint hit = getBreakpoint(javaThread);
+			assertEquals("should hit breakpoint", bp1, hit);
+
+			hit = resume1(javaThread);
+			assertEquals("should hit breakpoint", bp2, hit);
+
+			hit = resume1(javaThread);
+			assertEquals("should hit breakpoint", bp3, hit);
+
+			hit = resume1(javaThread);
+			assertEquals("should hit breakpoint", bp4, hit);
+
+			IValue value = doEval(javaThread, "result");
+			assertEquals("wrong result: ", "0123", value.getValueString());
+		} finally {
+			sync(() -> editor.getSite().getPage().closeEditor(editor, false));
+			terminateAndRemove(javaThread);
+			removeAllBreakpoints();
+		}
+	}
+
+	private IBreakpoint resume1(IJavaThread javaThread) throws Exception {
+		super.resume(javaThread);
+		TestUtil.waitForJobs(getName(), 50, DEFAULT_TIMEOUT, ProcessConsole.class);
+		processUiEvents();
+		IBreakpoint hit = getBreakpoint(javaThread);
+		return hit;
+	}
+
+	@Override
+	protected IBreakpoint getBreakpoint(IThread thread) {
+		IBreakpoint b = super.getBreakpoint(thread);
+		if (b == null) {
+			TestUtil.waitForJobs(getName(), 100, DEFAULT_TIMEOUT, ProcessConsole.class);
+			b = super.getBreakpoint(thread);
+			if (b == null) {
+				IJavaThread t = (IJavaThread) thread;
+				try {
+					IStackFrame[] stackFrames = t.getStackFrames();
+					StringBuilder stack = new StringBuilder("Stack for thread " + thread.getName() + "\n");
+					for (IStackFrame frame : stackFrames) {
+						stack.append(frame.getName()).append("():").append(frame.getLineNumber()).append("\n");
+					}
+					assertNotNull("suspended, but not by breakpoint! " + stack, b);
+				} catch (DebugException e) {
+					throwException(e);
+				}
+			}
+		}
+		return b;
 	}
 
 	private void terminateAndRemoveJavaLaunches() {

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/MethodBreakpointTests15.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/MethodBreakpointTests15.java
@@ -23,13 +23,13 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.debug.core.IJavaMethodBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
-import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
 import org.eclipse.ui.IEditorPart;
 
 /**
  * Tests method breakpoints for 1.5 source code.
  */
-public class MethodBreakpointTests15 extends AbstractDebugTest {
+public class MethodBreakpointTests15 extends AbstractDebugUiTests {
 
 	public MethodBreakpointTests15(String name) {
 		super(name);

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/AbstractDebugUiTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/AbstractDebugUiTests.java
@@ -238,7 +238,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 * This method is to allow to catch AssertionFailedError's and other non-Exceptions happened in the UI thread
 	 */
 	@SuppressWarnings("unchecked")
-	private static <T extends Throwable> void throwException(Throwable exception) throws T {
+	public static <T extends Throwable> void throwException(Throwable exception) throws T {
 		throw (T) exception;
 	}
 
@@ -292,6 +292,12 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 			return IDE.openEditor(page, file, true);
 		};
 		return callInUi(callable);
+	}
+
+	protected IJavaLineBreakpoint createLineBreakpoint(int lineNumber, IEditorPart editor, BreakpointsMap bpMap) throws Exception {
+		IJavaLineBreakpoint breakpoint = (IJavaLineBreakpoint) toggleBreakpoint(editor, lineNumber);
+		bpMap.put(breakpoint, lineNumber);
+		return breakpoint;
 	}
 
 	/**
@@ -396,7 +402,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 				IJavaLineBreakpoint bp = entry.getKey();
 				assertBreakpointExists(bp, bps);
 				Integer line = entry.getValue();
-				assertEquals(line.intValue(), bp.getLineNumber());
+				assertEquals("Breakpoint moved", line.intValue(), bp.getLineNumber());
 			}
 		}
 	}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/AbstractDebugUiTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/AbstractDebugUiTests.java
@@ -13,24 +13,42 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.ui;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarkerDelta;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.IBreakpointListener;
+import org.eclipse.debug.core.IBreakpointManager;
+import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.debug.ui.IDebugView;
+import org.eclipse.debug.ui.actions.ToggleBreakpointAction;
+import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaMethodBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaMethodEntryBreakpoint;
 import org.eclipse.jdt.debug.tests.AbstractDebugTest;
 import org.eclipse.jdt.debug.tests.TestUtil;
+import org.eclipse.jdt.debug.tests.VerticalRulerInfoStub;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.text.source.IVerticalRulerInfo;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPerspectiveDescriptor;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -69,7 +87,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 				JavaUI.ID_PERSPECTIVE + ",");
 		preferenceStore.setValue(IInternalDebugUIConstants.PREF_USER_VIEW_BINDINGS, IInternalDebugCoreConstants.EMPTY_STRING);
 		preferenceStore.setValue(IInternalDebugUIConstants.PREF_ACTIVATE_DEBUG_VIEW, true);
-		sync(() -> TestUtil.waitForJobs(getName(), 10, 1000));
+		sync(() -> TestUtil.waitForJobs(getName(), 10, 10000));
 	}
 
 	@Override
@@ -80,7 +98,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 		preferenceStore.setValue(IDebugUIConstants.PREF_MANAGE_VIEW_PERSPECTIVES, debug_perspectives);
 		preferenceStore.setValue(IInternalDebugUIConstants.PREF_USER_VIEW_BINDINGS, user_view_bindings);
 		preferenceStore.setValue(IInternalDebugUIConstants.PREF_ACTIVATE_DEBUG_VIEW, activate_debug_view);
-		sync(() -> TestUtil.waitForJobs(getName(), 10, 1000));
+		sync(() -> TestUtil.waitForJobs(getName(), 10, 10000));
 		super.tearDown();
 	}
 
@@ -90,7 +108,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 * @param window
 	 * @param perspectiveId
 	 */
-	protected void switchPerspective(IWorkbenchWindow window, String perspectiveId) {
+	protected static void switchPerspective(IWorkbenchWindow window, String perspectiveId) {
 		IPerspectiveDescriptor descriptor = PlatformUI.getWorkbench().getPerspectiveRegistry().findPerspectiveWithId(perspectiveId);
 		assertNotNull("missing perspective " + perspectiveId, descriptor);
 		IWorkbenchPage page = window.getActivePage();
@@ -104,7 +122,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 *
 	 * @return the window in which the perspective is ready
 	 */
-	protected IWorkbenchWindow resetPerspective(final String id) throws Exception {
+	protected static IWorkbenchWindow resetPerspective(final String id) throws RuntimeException {
 		final IWorkbenchWindow[] windows = new IWorkbenchWindow[1];
 		sync(() -> {
 			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
@@ -119,7 +137,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 *
 	 * @return the window in which the perspective is ready
 	 */
-	protected IWorkbenchWindow resetDebugPerspective() throws Exception {
+	protected static IWorkbenchWindow resetDebugPerspective() throws RuntimeException {
 		return resetPerspective(IDebugUIConstants.ID_DEBUG_PERSPECTIVE);
 	}
 
@@ -128,8 +146,48 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 *
 	 * @return the window in which the perspective is ready
 	 */
-	protected IWorkbenchWindow resetJavaPerspective() throws Exception {
+	protected static IWorkbenchWindow resetJavaPerspective() throws RuntimeException {
 		return resetPerspective(JavaUI.ID_PERSPECTIVE);
+	}
+
+	/**
+	 * Process all queued UI events.
+	 */
+	public static void processUiEvents() throws RuntimeException {
+		sync(() -> {
+			Display display = Display.getCurrent();
+			if (!display.isDisposed()) {
+				while (display.readAndDispatch()) {
+					// Keep pumping events until the queue is empty
+				}
+			}
+		});
+	}
+
+	/**
+	 * Process all queued UI events. If called from background thread, just waits
+	 *
+	 * @param millis
+	 *            max wait time to process events
+	 */
+	public static void processUiEvents(final long millis) throws RuntimeException {
+		sync(() -> {
+			long start = System.currentTimeMillis();
+			while (System.currentTimeMillis() - start < millis) {
+				Display display = Display.getCurrent();
+				if (display != null && !display.isDisposed()) {
+					while (display.readAndDispatch()) {
+						// loop until the queue is empty
+					}
+				} else {
+					try {
+						Thread.sleep(10);
+					} catch (InterruptedException e) {
+						break;
+					}
+				}
+			}
+		});
 	}
 
 	/**
@@ -138,7 +196,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 * @param r
 	 * @throws Exception
 	 */
-	protected void sync(Runnable r) throws Exception {
+	protected static void sync(Runnable r) throws RuntimeException {
 		AtomicReference<Exception> error = new AtomicReference<>();
 		DebugUIPlugin.getStandardDisplay().syncExec(() -> {
 			try {
@@ -149,7 +207,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 			}
 		});
 		if (error.get() != null) {
-			throw error.get();
+			throwException(error.get());
 		}
 	}
 
@@ -159,7 +217,7 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	 * @param c
 	 * @throws Exception
 	 */
-	protected <V> V sync(Callable<V> c) throws Exception {
+	protected static <V> V sync(Callable<V> c) throws RuntimeException {
 		AtomicReference<Throwable> error = new AtomicReference<>();
 		AtomicReference<V> result = new AtomicReference<>();
 		DebugUIPlugin.getStandardDisplay().syncExec(() -> {
@@ -177,50 +235,170 @@ public abstract class AbstractDebugUiTests extends AbstractDebugTest {
 	}
 
 	/**
-	 * This and the another {@link #throwException1(Throwable)} method below are here to allow to catch AssertionFailedError's and other
-	 * non-Exceptions happened in the UI thread
-	 *
-	 * @param exception
-	 */
-	private static void throwException(Throwable exception) {
-		AbstractDebugUiTests.<RuntimeException> throwException1(exception);
-	}
-
-	/**
-	 * @param dummy to make compiler happy
+	 * This method is to allow to catch AssertionFailedError's and other non-Exceptions happened in the UI thread
 	 */
 	@SuppressWarnings("unchecked")
-	private static <T extends Throwable> void throwException1(Throwable exception) throws T {
+	private static <T extends Throwable> void throwException(Throwable exception) throws T {
 		throw (T) exception;
 	}
 
-	protected void processUiEvents(long millis) throws Exception {
-		Thread.sleep(millis);
-		if (Display.getCurrent() == null) {
-			sync(() -> TestUtil.runEventLoop());
-		} else {
-			TestUtil.runEventLoop();
+	protected static IWorkbenchPage getActivePage() throws RuntimeException {
+		Callable<IWorkbenchPage> callable = () -> {
+			IWorkbench workbench = PlatformUI.getWorkbench();
+			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+			if (window == null) {
+				window = workbench.getWorkbenchWindows()[0];
+				Shell shell = window.getShell();
+				shell.moveAbove(null);
+				shell.setActive();
+				shell.forceActive();
+			}
+			return window.getActivePage();
+		};
+		return callInUi(callable);
+	}
+
+	protected IEditorPart openEditor(String type) throws RuntimeException {
+		Callable<IEditorPart> callable = () -> {
+			IFile resource = (IFile) getResource(type);
+			IEditorPart editor = IDE.openEditor(getActivePage(), resource);
+			assertNotNull(editor);
+			processUiEvents(100);
+			return editor;
+		};
+		return callInUi(callable);
+	}
+
+	private static <T> T callInUi(Callable<T> callable) throws RuntimeException {
+		if (Display.getCurrent() != null) {
+			try {
+				return callable.call();
+			} catch (Exception e) {
+				throwException(e);
+			}
+		}
+		return sync(callable);
+	}
+
+	/**
+	 * Opens and returns an editor on the given file or <code>null</code> if none. The editor will be activated.
+	 *
+	 * @param file
+	 * @return editor or <code>null</code>
+	 */
+	protected static IEditorPart openEditor(final IFile file) throws RuntimeException {
+		Callable<IEditorPart> callable = () -> {
+			IWorkbenchPage page = getActivePage();
+			return IDE.openEditor(page, file, true);
+		};
+		return callInUi(callable);
+	}
+
+	/**
+	 * Toggles a breakpoint in the editor at the given line number returning the breakpoint or <code>null</code> if none.
+	 *
+	 * @param editor
+	 * @param lineNumber
+	 * @return returns the created breakpoint or <code>null</code> if none.
+	 */
+	protected IBreakpoint toggleBreakpoint(final IEditorPart editor, int lineNumber) throws Exception {
+		final Object lock = new Object();
+		final AtomicReference<IBreakpoint> breakpoint = new AtomicReference<>();
+		IBreakpointListener listener = new IBreakpointListener() {
+			@Override
+			public void breakpointRemoved(IBreakpoint breakpoint, IMarkerDelta delta) {
+			}
+
+			@Override
+			public void breakpointChanged(IBreakpoint breakpoint, IMarkerDelta delta) {
+			}
+
+			@Override
+			public void breakpointAdded(IBreakpoint b) {
+				synchronized (lock) {
+					breakpoint.set(b);
+					lock.notifyAll();
+				}
+			}
+		};
+		IBreakpointManager manager = DebugPlugin.getDefault().getBreakpointManager();
+		manager.addBreakpointListener(listener);
+		sync(() -> {
+			final IVerticalRulerInfo info = new VerticalRulerInfoStub(lineNumber - 1); // sub 1, as the doc lines start at 0
+			new ToggleBreakpointAction(editor, null, info).run();
+		});
+		synchronized (lock) {
+			if (breakpoint.get() == null) {
+				lock.wait(DEFAULT_TIMEOUT);
+			}
+		}
+		manager.removeBreakpointListener(listener);
+		IBreakpoint bp = breakpoint.get();
+		assertNotNull("Breakpoint not created", bp);
+		if (isLineBreakpoint(bp)) {
+			int line = ((IJavaLineBreakpoint) bp).getLineNumber();
+			assertEquals("Breakpoint line differs from expected", lineNumber, line);
+		}
+		return bp;
+	}
+
+	private boolean isLineBreakpoint(IBreakpoint bp) {
+		return bp instanceof IJavaLineBreakpoint
+				&& !(bp instanceof IJavaMethodBreakpoint)
+				&& !(bp instanceof IJavaMethodEntryBreakpoint);
+	}
+
+	/**
+	 * Closes all editors in the active workbench page.
+	 */
+	protected static void closeAllEditors() throws RuntimeException {
+		sync(() -> {
+			for (IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
+				window.getActivePage().closeAllEditors(false);
+			}
+		});
+	}
+
+	/**
+	 * Opens the view with the given id, does nothing if no such view exists. This method can return <code>null</code>
+	 *
+	 * @param viewId
+	 * @return the handle to the {@link IDebugView} with the given id
+	 */
+	protected static IViewPart openView(final String viewId) throws RuntimeException {
+		return sync(() -> {
+			return getActivePage().showView(viewId);
+		});
+	}
+
+	private void assertBreakpointExists(IJavaLineBreakpoint bp, IBreakpoint[] bps) throws Exception {
+		boolean contains = Arrays.asList(bps).contains(bp);
+		assertTrue("Breakpoint not found: " + bp + ", all: " + Arrays.toString(bps), contains);
+	}
+
+	public class BreakpointsMap {
+		IdentityHashMap<IJavaLineBreakpoint, Integer> breakpoints = new IdentityHashMap<>();
+		HashMap<Integer, IJavaLineBreakpoint> lines = new HashMap<>();
+
+		public void put(IJavaLineBreakpoint breakpoint, int line) throws Exception {
+			int lineNumber = breakpoint.getLineNumber();
+			assertEquals("Breakpoint line differs from original", line, lineNumber);
+			Integer old = breakpoints.put(breakpoint, lineNumber);
+			assertNull("Breakpoint already exists for line: " + old, old);
+			IJavaLineBreakpoint oldB = lines.put(lineNumber, breakpoint);
+			assertNull("Breakpoint already exists for line: " + lineNumber, oldB);
+		}
+
+		public void assertBreakpointsConsistency() throws Exception {
+			IBreakpoint[] bps = getBreakpointManager().getBreakpoints();
+			Set<Entry<IJavaLineBreakpoint, Integer>> set = breakpoints.entrySet();
+			for (Entry<IJavaLineBreakpoint, Integer> entry : set) {
+				IJavaLineBreakpoint bp = entry.getKey();
+				assertBreakpointExists(bp, bps);
+				Integer line = entry.getValue();
+				assertEquals(line.intValue(), bp.getLineNumber());
+			}
 		}
 	}
 
-	protected IWorkbenchPage getActivePage() {
-		IWorkbench workbench = PlatformUI.getWorkbench();
-		IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-		if (window == null) {
-			window = workbench.getWorkbenchWindows()[0];
-			Shell shell = window.getShell();
-			shell.moveAbove(null);
-			shell.setActive();
-			shell.forceActive();
-		}
-		return window.getActivePage();
-	}
-
-	protected IEditorPart openEditor(String type) throws Exception {
-		IFile resource = (IFile) getResource(type);
-		IEditorPart editor = IDE.openEditor(getActivePage(), resource);
-		assertNotNull(editor);
-		processUiEvents(100);
-		return editor;
-	}
 }

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
@@ -1160,7 +1160,13 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 			return false;
 		}
 		if (visit(node, false)) {
-			// first run through arguments to avoid pre-mature line breakpoint identification
+			Expression expression = node.getExpression();
+			if (expression instanceof ClassInstanceCreation || expression instanceof MethodInvocation) {
+				expression.accept(this);
+			}
+			if (fLocationFound) {
+				return false;
+			}
 			List<? extends ASTNode> arguments = node.arguments();
 			for (ASTNode astNode : arguments) {
 				// arguments needs to be accepted to handle stream operation where the lambda debug point
@@ -1172,10 +1178,6 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 				}
 			}
 
-			Expression expression = node.getExpression();
-			if (expression instanceof ClassInstanceCreation || expression instanceof MethodInvocation) {
-				expression.accept(this);
-			}
 		}
 		return visit(node, true);
 	}


### PR DESCRIPTION
Revert visit order to visit lambda expression first.

ValidBreakpointLocationLocator.visit(ASTNode, boolean) has code that
pre-maturely marks "unrelated" line as matching via fLineNumber <=
startLine to fix bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=42931

So if the lambda contains method calls after expressions, they will
always "win".