### PR TITLE
Bug 575131 - Deadlock with conditional breakpoints that suspend VM

### DIFF
--- a/org.eclipse.jdt.debug.tests/testprograms/SuspendVMConditionalBreakpointsTestSnippet.java
+++ b/org.eclipse.jdt.debug.tests/testprograms/SuspendVMConditionalBreakpointsTestSnippet.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * Snippet for: Bug 575131 - Deadlock during "JDI Expression Evaluation Event Dispatch"
+ */
+public class SuspendVMConditionalBreakpointsTestSnippet {
+
+	public static final int i = 50;
+	public static final int j = 25;
+
+	public static void main(String[] args) throws InterruptedException {
+		Thread t1 = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				for (int k = 0; k < 5; ++k) {
+					System.out.println("thread i=" + i); // suspend VM breakpoint with condition "if (i == 50) { System.out.println(i); } return false;"
+				}
+			}
+		});
+		Thread t2 = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				for (int k = 0; k < 5; ++k) {
+					System.out.println("thread j=" + j); // suspend VM breakpoint with condition "if (j == 25) { System.out.println(j); } return false;"
+				}
+			}
+		});
+		t1.start();
+		t2.start();
+		t1.join();
+		t2.join();
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -41,6 +41,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
@@ -197,7 +198,8 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 			"org.eclipse.debug.tests.targets.HcrClass9", "TestContributedStepFilterClass", "TerminateAll_01", "TerminateAll_02", "StepResult1",
 			"StepResult2", "StepResult3", "StepUncaught", "TriggerPoint_01", "BulkThreadCreationTest", "MethodExitAndException",
 			"Bug534319earlyStart", "Bug534319lateStart", "Bug534319singleThread", "Bug534319startBetwen", "MethodCall", "Bug538303", "Bug540243",
-			"OutSync", "OutSync2", "ConsoleOutputUmlaut", "ErrorRecurrence", "ModelPresentationTests", "Bug565982" };
+			"OutSync", "OutSync2", "ConsoleOutputUmlaut", "ErrorRecurrence", "ModelPresentationTests", "Bug565982",
+			"SuspendVMConditionalBreakpointsTestSnippet" };
 
 	/**
 	 * the default timeout
@@ -1209,6 +1211,12 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		}
 		setEventSet(waiter.getEventSet());
 		assertNotNull("Program did not suspend, launch terminated.", suspendee); //$NON-NLS-1$
+		// Bug 575131: resuming and suspending threads on breakpoint hit is done in a job, wait for this job
+		try {
+			Job.getJobManager().join(JDIDebugTarget.class, new NullProgressMonitor());
+		} catch (OperationCanceledException | InterruptedException e) {
+			throw new AssertionError("Failed ot wait for JDIDebugTarget jobs", e);
+		}
 		return suspendee;
 	}
 

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.debug.tests.breakpoints.RecordBreakpointTests;
 import org.eclipse.jdt.debug.tests.breakpoints.RunToLineTests;
 import org.eclipse.jdt.debug.tests.breakpoints.SpecialExceptionBreakpointTests;
 import org.eclipse.jdt.debug.tests.breakpoints.SuspendVMBreakpointsTests;
+import org.eclipse.jdt.debug.tests.breakpoints.SuspendVMConditionalBreakpointsTests;
 import org.eclipse.jdt.debug.tests.breakpoints.TargetPatternBreakpointTests;
 import org.eclipse.jdt.debug.tests.breakpoints.TestToggleBreakpointsTarget;
 import org.eclipse.jdt.debug.tests.breakpoints.TestToggleBreakpointsTarget8;
@@ -360,6 +361,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(HitCountBreakpointsTests.class));
 		addTest(new TestSuite(ThreadFilterBreakpointsTests.class));
 		addTest(new TestSuite(SuspendVMBreakpointsTests.class));
+		addTest(new TestSuite(SuspendVMConditionalBreakpointsTests.class));
 		addTest(new TestSuite(PreLaunchBreakpointTest.class));
 		addTest(new TestSuite(ImportBreakpointsTest.class));
 		addTest(new TestSuite(BreakpointWorkingSetTests.class));

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/StressTestSuspendVMConditionalBreakpoints.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/StressTestSuspendVMConditionalBreakpoints.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *  Copyright (c) 2022 Simeon Andreev and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests;
+
+import org.eclipse.jdt.debug.tests.breakpoints.SuspendVMConditionalBreakpointsTests;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Stress test suite for bug 575131. Not executed in automated tests.
+ */
+public class StressTestSuspendVMConditionalBreakpoints extends DebugSuite {
+
+	private static final int STRESS_TEST_REPEAT_COUNT = 500;
+
+	public static Test suite() {
+		return new StressTestSuspendVMConditionalBreakpoints();
+	}
+
+	public StressTestSuspendVMConditionalBreakpoints() {
+		for (int i = 0; i < STRESS_TEST_REPEAT_COUNT; ++i) {
+			addTest(new TestSuite(SuspendVMConditionalBreakpointsTests.class));
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/SuspendVMConditionalBreakpointsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/SuspendVMConditionalBreakpointsTests.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *  Copyright (c) 2022 Simeon Andreev and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.breakpoints;
+
+import org.eclipse.debug.core.DebugEvent;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.core.IJavaBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaDebugTarget;
+import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.testplugin.DebugElementKindEventWaiter;
+import org.eclipse.jdt.debug.testplugin.DebugEventWaiter;
+import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.debug.tests.TestUtil;
+
+/**
+ * Test that a SUSPEND_VM conditional breakpoints function as expected. Also tests for bug 575131.
+ */
+public class SuspendVMConditionalBreakpointsTests extends AbstractDebugTest {
+
+	/**
+	 * Constructor
+	 *
+	 * @param name
+	 */
+	public SuspendVMConditionalBreakpointsTests(String name) {
+		super(name);
+	}
+
+	/**
+	 * Tests that the VM is suspended when a conditional line breakpoint is hit.
+	 */
+	public void testSuspendVmLineConditionalBreakpoint() throws Exception {
+		String typeName = "SuspendVMConditionalBreakpointsTestSnippet";
+
+		IJavaLineBreakpoint bp1 = createLineBreakpoint(28, typeName);
+		bp1.setCondition("if (i == 50) { System.out.println(i); } return false;");
+		bp1.setConditionEnabled(true);
+		bp1.setSuspendPolicy(IJavaBreakpoint.SUSPEND_VM);
+		IJavaLineBreakpoint bp2 = createLineBreakpoint(36, typeName);
+		bp2.setCondition("if (j == 25) { System.out.println(j); } return false;");
+		bp2.setConditionEnabled(true);
+		bp2.setSuspendPolicy(IJavaBreakpoint.SUSPEND_VM);
+
+		IJavaDebugTarget debugTarget = null;
+		try {
+			TestUtil.waitForJobs("testSuspendVmLineConditionalBreakpoint before launch", 250, 500);
+			IJavaProject project = getProjectContext();
+			ILaunchConfiguration config = getLaunchConfiguration(project, typeName);
+
+			DebugEventWaiter waiter = new DebugElementKindEventWaiter(DebugEvent.BREAKPOINT, IJavaThread.class);
+			waiter.setTimeout(DEFAULT_TIMEOUT);
+			waiter.setEnableUIEventLoopProcessing(enableUIEventLoopProcessingInWaiter());
+
+			boolean registerLaunch = true;
+			IJavaThread suspendedThread = (IJavaThread) launchAndWait(config, waiter, registerLaunch);
+
+			debugTarget = (IJavaDebugTarget) suspendedThread.getDebugTarget();
+			TestUtil.waitForJobs("testSuspendVmLineConditionalBreakpoint after suspend", 250, 500);
+
+			debugTarget.resume();
+			TestUtil.waitForJobs("testSuspendVmLineConditionalBreakpoint after resume", 250, 500);
+		} finally {
+			if (debugTarget != null) {
+				terminateAndRemove(debugTarget);
+			}
+			removeAllBreakpoints();
+		}
+	}
+}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
@@ -1733,7 +1733,10 @@ public class JDIDebugTarget extends JDIDebugElement implements
 	protected void suspendThreads() {
 		Iterator<JDIThread> threads = getThreadIterator();
 		while (threads.hasNext()) {
-			threads.next().suspendedByVM();
+			JDIThread thread = threads.next();
+			if (!thread.isBreakpointHandlingOngoing()) {
+				thread.suspendedByVM();
+			}
 		}
 	}
 
@@ -1743,7 +1746,10 @@ public class JDIDebugTarget extends JDIDebugElement implements
 	protected void resumeThreads() throws DebugException {
 		Iterator<JDIThread> threads = getThreadIterator();
 		while (threads.hasNext()) {
-			threads.next().resumedByVM();
+			JDIThread thread = threads.next();
+			if (!thread.isBreakpointHandlingOngoing()) {
+				thread.resumedByVM();
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -319,6 +319,9 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	 */
 	private volatile IJavaObject fPreviousException;
 
+	private final AtomicBoolean fCompletingBreakpointHandling;
+	private final AtomicBoolean fHandlingSuspendForBreakpoint;
+
 	/**
 	 * Creates a new thread on the underlying thread reference in the given
 	 * debug target.
@@ -337,6 +340,8 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 		setUnderlyingThread(thread);
 		fAsyncJob = new ThreadJob();
 		initialize();
+		fCompletingBreakpointHandling = new AtomicBoolean(false);
+		fHandlingSuspendForBreakpoint = new AtomicBoolean(false);
 	}
 
 	/**
@@ -1358,6 +1363,15 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	 */
 	public boolean handleSuspendForBreakpoint(JavaBreakpoint breakpoint,
 			boolean suspendVote) {
+		fHandlingSuspendForBreakpoint.set(true);
+		try {
+			return handleSuspendForBreakpointInternal(breakpoint);
+		} finally {
+			fHandlingSuspendForBreakpoint.set(true);
+		}
+	}
+
+	private boolean handleSuspendForBreakpointInternal(JavaBreakpoint breakpoint) {
 		int policy = IJavaBreakpoint.SUSPEND_THREAD;
 		synchronized (this) {
 			if (fClientSuspendRequest) {
@@ -1381,6 +1395,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 			if (policy == IJavaBreakpoint.SUSPEND_VM) {
 				((JDIDebugTarget) getDebugTarget())
 						.prepareToSuspendByBreakpoint(breakpoint);
+				suspendedByVM();
 			} else {
 				setRunning(false);
 			}
@@ -1495,6 +1510,15 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	 */
 	public void completeBreakpointHandling(JavaBreakpoint breakpoint,
 			boolean suspend, boolean queue, EventSet set) {
+		fCompletingBreakpointHandling.set(true);
+		try {
+			completeBreakpointHandlingInternal(breakpoint, suspend, queue, set);
+		} finally {
+			fCompletingBreakpointHandling.set(false);
+		}
+	}
+
+	private void completeBreakpointHandlingInternal(JavaBreakpoint breakpoint, boolean suspend, boolean queue, EventSet set) {
 		synchronized (this) {
 			try {
 				int policy = breakpoint.getSuspendPolicy();
@@ -1514,6 +1538,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 					if (policy == IJavaBreakpoint.SUSPEND_VM) {
 						((JDIDebugTarget) getDebugTarget())
 								.cancelSuspendByBreakpoint(breakpoint);
+						resumedByVM();
 					} else {
 						setRunning(true);
 						// dispose cached stack frames so we re-retrieve on the
@@ -1526,7 +1551,6 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 				setRunning(true);
 			}
 		}
-
 	}
 
 	@Override
@@ -3649,4 +3673,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 		this.fMethodResult = fMethodResult;
 	}
 
+	boolean isBreakpointHandlingOngoing() {
+		return fCompletingBreakpointHandling.get() || fHandlingSuspendForBreakpoint.get();
+	}
 }

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -1367,7 +1367,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 		try {
 			return handleSuspendForBreakpointInternal(breakpoint);
 		} finally {
-			fHandlingSuspendForBreakpoint.set(true);
+			fHandlingSuspendForBreakpoint.set(false);
 		}
 	}
 


### PR DESCRIPTION
Bug 575131 - Deadlock with conditional breakpoints that suspend VM

Adjusts JDIDebugTarget resumeThreads() and
suspendThreads() to not resume resp. suspend threads that are handling
breakpoints.

Also adds a test to reproduce the deadlock, as well as a stress test
suite that will repeat the new test (since the deadlock is sporadic).
The stress test suite is not executed during automated tests.

Change-Id: Icfcd5ebb04e77e437bc308d5cb6911a77eb3b673
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>