### PR TITLE
No links in Java stack trace console for types with module names

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceConsoleTest.java
@@ -69,7 +69,7 @@ public class JavaStackTraceConsoleTest extends AbstractJavaStackTraceConsoleTest
 	}
 
 	public void testHyperlinkNoMatch() throws Exception {
-		consoleDocumentWithText("at foo.bar.Type.method1(foo.bar.Type.java:42)");
+		consoleDocumentWithText("at foo.bar.Type.method1(foo.bar#.Type.java:42)");
 
 		Position[] positions = allLinkPositions();
 		assertArrayEquals("Expected no hyperlinks for invalid type name", new Position[0], positions);
@@ -403,5 +403,12 @@ public class JavaStackTraceConsoleTest extends AbstractJavaStackTraceConsoleTest
 		assertEquals("at org.eclipse.debug.internal.ui.views.console.ProcessConsole.handleDebugEvents(ProcessConsole.java:438)", getLine(doc, 5).replace("[java]", "").trim());
 		assertEquals("at org.eclipse.debug.core.DebugPlugin$EventNotifier.run(DebugPlugin.java:1043)", getLine(doc, 6).replace("[java]", "").trim());
 		checkIndentationConsistency(doc, 3);
+	}
+
+	public void testHyperlinkMatchWithModule() throws Exception {
+		consoleDocumentWithText("at java.nio.charset.Charset.checkName(java.base/Charset.java:296)");
+
+		String[] matchTexts = linkTextsAtPositions(38);
+		assertArrayEquals(allLinks(), new String[] { "java.base/Charset.java:296" }, matchTexts);
 	}
 }

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3503,7 +3503,7 @@ M4 = Platform-specific fourth key
          point="org.eclipse.ui.console.consolePatternMatchListeners">
       <consolePatternMatchListener
             class="org.eclipse.jdt.internal.debug.ui.console.JavaConsoleTracker"
-            regex="\(\w*${java_extensions_regex}\S*\)"
+            regex="\([\w\.\\/]*${java_extensions_regex}\S*\)"
             qualifier="${java_extensions_regex}"
             flags="UNICODE_CHARACTER_CLASS"
             id="org.eclipse.jdt.debug.ui.JavaConsoleTracker">


### PR DESCRIPTION
(Fixes #23)

If a type name has a module name prefix, the Java Stack Trace Console
and Process Console do not show a hyperlink for lines with that type.
E.g. no hyperlink is created for this line:

at java.nio.charset.Charset.checkName(java.base/Charset.java:296)

This change adjusts the regexp used for the hyperlink creation, to
ensure also such types are matched. Also a test case is added to
JavaStackTraceConsoleTest.

See: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/23

Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

