### PR TITLE
Fix path decoding of URL to File containing space (fixes #64)

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/JDIHelpers.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/JDIHelpers.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.internal.launching.sourcelookup.advanced;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -70,10 +71,10 @@ public final class JDIHelpers implements IJDIHelpers {
 			try {
 				URL url = new URL(locations[1]);
 				if ("file".equals(url.getProtocol())) { //$NON-NLS-1$
-					return new File(url.getPath()).toPath().normalize().toFile();
+					return new File(url.toURI()).toPath().normalize().toFile();
 				}
 			}
-			catch (MalformedURLException e) {
+			catch (URISyntaxException | MalformedURLException e) {
 				// fall through
 			}
 		}


### PR DESCRIPTION
A space in an URL is encoded as "%20" and has to be decoded to " ".

Otherwise a debugged JAR rooted in a path containing space is not
opening class file but java file editor.

see https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/64
