### PR TITLE
[19] Modules changed for Java 19

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ModuleOptionsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ModuleOptionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 GK Software SE and others.
+ * Copyright (c) 2019, 2022 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     Stephan Herrmann - initial API and implementation
@@ -105,6 +109,17 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 			+ "jdk.nio.mapmode," //
 			+ "jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,"
 			+ "jdk.unsupported.desktop," //
+			+ "jdk.xml.dom";
+	private static final String ASSUMED_DEFAULT_MODULES_19 = "java.se," //
+			+ "jdk.accessibility,jdk.attach,jdk.compiler,jdk.dynalink,jdk.httpserver," //
+			+ "jdk.incubator.vector," // jdk.incubator.foreign removed in 19
+			+ "jdk.jartool,jdk.javadoc,jdk.jconsole,jdk.jdi," //
+			+ "jdk.jfr," //
+			+ "jdk.jshell,jdk.jsobject,jdk.management," //
+			+ "jdk.management.jfr," //
+			+ "jdk.net," //
+			+ "jdk.nio.mapmode," //
+			+ "jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported," + "jdk.unsupported.desktop," //
 			+ "jdk.xml.dom";
 
 
@@ -252,7 +267,7 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 			case ASSUMED_DEFAULT_MODULES_16:
 				expectedModules = "java.se," //
 						+ "jdk.accessibility," //
-						+ "jdk.dynalink," 
+						+ "jdk.dynalink,"
 						+ "jdk.httpserver," //
 						+ "jdk.incubator.foreign,jdk.incubator.vector," // jdk.incubator.vector added in 16
 						+ "jdk.jartool,jdk.jconsole,jdk.jshell," //
@@ -262,6 +277,19 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 						+ "jdk.nio.mapmode," //
 						+ "jdk.sctp,"
 						+ "jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
+						+ "jdk.unsupported.desktop," //
+						+ "jdk.xml.dom";
+			case ASSUMED_DEFAULT_MODULES_19:
+				expectedModules = "java.se," //
+						+ "jdk.accessibility," //
+						+ "jdk.dynalink," + "jdk.httpserver," //
+						+ "jdk.incubator.vector," // jdk.incubator.foreign removed in 19
+						+ "jdk.jartool,jdk.jconsole,jdk.jshell," //
+						+ "jdk.jsobject," //
+						+ "jdk.management.jfr," //
+						+ "jdk.net," //
+						+ "jdk.nio.mapmode," //
+						+ "jdk.sctp," + "jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
 						+ "jdk.unsupported.desktop," //
 						+ "jdk.xml.dom";
 				break;

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
   <profiles>
     <profile>
       <id>build-individual-bundles</id>
+      <properties>
+      	<eclipse-p2-repo.url>http://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
+      	<skipAPIAnalysis>true</skipAPIAnalysis>
+ 	  </properties>
       <repositories>
         <repository>
           <releases>


### PR DESCRIPTION
fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/65

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
jdk.incubator.foreign removed in Java 19

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

