### PR TITLE
Improve slow launch on big workspace (closes #73)

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.19.700.qualifier
+Bundle-Version: 3.19.800.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
@@ -352,8 +352,9 @@ public class RuntimeClasspathEntry implements IRuntimeClasspathEntry {
 	protected IResource getResource(IPath path) {
 		if (path != null) {
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-			if (getType() == PROJECT) {
-				// project entry should always have a workspace relative path, try the fastest lookup first
+			if (getType() == PROJECT || path.getDevice() == null) {
+				// Project entry should always have a workspace relative path, try the fastest lookup first.
+				// Also entry without device has a great chance to find the answer quickly in the workspace.
 				IResource member = root.findMember(path);
 				if (member != null) {
 					return member;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
@@ -352,9 +352,8 @@ public class RuntimeClasspathEntry implements IRuntimeClasspathEntry {
 	protected IResource getResource(IPath path) {
 		if (path != null) {
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-			if (getType() == PROJECT || path.getDevice() == null) {
-				// Project entry should always have a workspace relative path, try the fastest lookup first.
-				// Also entry without device has a great chance to find the answer quickly in the workspace.
+			if (getType() == PROJECT || getType() == ARCHIVE) {
+				// try the fastest lookup first:
 				IResource member = root.findMember(path);
 				if (member != null) {
 					return member;

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.19.700-SNAPSHOT</version>
+  <version>3.19.800-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
getResource() for a workspace member no longer has to search for linked
resources in the whole workspace.

See issue #73 for explanation
