### PR TITLE
Support virtual threads (project loom) in JDI library

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/java19/TryVirtualThread.java
+++ b/org.eclipse.jdt.debug.jdi.tests/java19/TryVirtualThread.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+public class TryVirtualThread implements Runnable {
+	/**
+	 * A <code>Thread</code> object
+	 */
+	public static Thread fThread;
+
+	/**
+	 * A <code>Thread</code> object representing the main thread
+	 */
+	public static Thread fMainThread;
+	
+	public static Thread fVirtualThread;
+
+	
+	/**
+	 * The instance of the <code>MainClass</code>
+	 */
+	public static TryVirtualThread fObject = new TryVirtualThread();
+
+	/**
+	 * An integer value
+	 */
+	public static int fInt = 0;
+	
+	/**
+	 * A string initialized to 'hello world'
+	 */
+	public static String fString = "Hello World";
+	
+	/**
+	 * The name of an event type
+	 */
+	public static String fEventType = "";
+	
+	/**
+	 * Runs the test program
+	 * @param args
+	 */
+	public static void main(java.lang.String[] args) {
+		// Ensure at least one carrier thread is created.
+		fVirtualThread = Thread.startVirtualThread(() -> {
+			System.out.println("Start a test virtual thread.");
+		});
+
+		ThreadGroup group = new ThreadGroup("Test ThreadGroup");
+		fThread = new Thread(group, fObject, "Test Thread");
+		fThread.start();
+
+		fMainThread = Thread.currentThread();
+
+		// Prevent this thread from dying
+		while (true) {
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+	
+	@Override
+	public void run() {
+		try {
+			while (true) {
+				printAndSignal();
+				triggerEvent();
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+				}
+			}
+		} finally {
+			System.out.println("Running finally block in MainClass.run()");
+		}
+	}
+	
+	/**
+	 * Prints to System.out and throws an exception to indicate readiness
+	 */
+	synchronized public void printAndSignal() {
+		print(System.out);
+		// Signal readiness by throwing an exception
+		try {
+			throw new NegativeArraySizeException();
+		} catch (NegativeArraySizeException exc) {
+		}
+	}
+
+	public void print(OutputStream out) {
+		String string = fInt++ +". " + fString;
+		PrintWriter writer = new PrintWriter(out);
+		writer.println(string);
+		writer.flush();
+	}
+	
+	/**
+	 *	Trigger an event for the front-end.
+	 */
+	private void triggerEvent() {
+		/* Ensure we do it only once */
+		String eventType = fEventType;
+		fEventType = "";
+
+		/* Trigger event according to the field fEventType */
+		if (eventType.isEmpty()) {
+			return;
+		} else if (eventType.equals("ThreadStartEvent")) {
+			triggerThreadStartEvent();
+		} else if (eventType.equals("ThreadDeathEvent")) {
+			triggerThreadDeathEvent();
+		} else {
+			System.out.println("Unknown event type: " + eventType);
+		}
+	}
+	
+	/**
+	 *	Trigger a thread end event for the front-end.
+	 */
+	private void triggerThreadDeathEvent() {
+		Thread.startVirtualThread(() -> {
+			System.out.println("Test VirtualThread Death Event");
+		});
+	}
+
+	/**
+	 *	Trigger a thread start event for the front-end.
+	 */
+	private void triggerThreadStartEvent() {
+		Thread.startVirtualThread(() -> {
+			System.out.println("Test VirtualThread Start Event");
+		});
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -6,6 +6,10 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
  
+  This is an implementation of an early-draft specification developed under the Java
+  Community Process (JCP) and is made available for testing and evaluation purposes
+  only. The code is not compatible with any specification of the JCP.
+ 
   Contributors:
      IBM Corporation - initial implementation
 -->
@@ -58,4 +62,33 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+  	<profile>
+		<id>test-on-javase-19</id>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<version>1.1</version>
+					<executions>
+						<execution>
+							<phase>validate</phase>
+							<goals>
+								<goal>toolchain</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<toolchains>
+							<jdk>
+								<id>JavaSE-19</id>
+							</jdk>
+						</toolchains>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+  </profiles>
 </project>

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2012 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.debug.jdi.tests;
 
@@ -88,7 +93,7 @@ public class AutomatedSuite extends TestSuite {
 		addTest(new TestSuite(VMDisconnectEventTest.class));
 		addTest(new TestSuite(VMDisposeTest.class));
 
-	//Java 1.6 capability tests
+		// Java 1.6 capability tests
 		addTest(new TestSuite(HeapWalkingTests.class));
 		addTest(new TestSuite(ConstantPoolTests.class));
 		addTest(new TestSuite(SourceNameFilterTests.class));
@@ -97,6 +102,11 @@ public class AutomatedSuite extends TestSuite {
 		addTest(new TestSuite(MonitorFrameInfoTests.class));
 		addTest(new TestSuite(ProvideArgumentsTests.class));
 		addTest(new TestSuite(ContendedMonitorTests.class));
+
+		// Java 19 capability tests
+		if (Runtime.version().feature() >= 19) {
+			addTest(new TestSuite(VirtualThreadTest.class));
+		}
 	}
 
 }

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestAll.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestAll.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.debug.jdi.tests;
 
@@ -85,9 +90,13 @@ public class TestAll {
 			classes.addElement(WatchpointRequestTest.class);
 		}
 
+		if (Runtime.version().feature() >= 19) {
+			classes.addElement(VirtualThreadTest.class);
+		}
+
 		classes.addElement(VirtualMachineExitTest.class);
 		classes.addElement(VMDisconnectEventTest.class);
-		classes.addElement(VMDisposeTest.class);	// note that this test does not restore the state properly.
+		classes.addElement(VMDisposeTest.class); // note that this test does not restore the state properly.
 		return classes;
 	}
 	/**

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Locale;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import org.eclipse.jdi.internal.ThreadReferenceImpl;
+
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.event.ThreadDeathEvent;
+import com.sun.jdi.event.ThreadStartEvent;
+import com.sun.jdi.request.ThreadDeathRequest;
+import com.sun.jdi.request.ThreadStartRequest;
+
+public class VirtualThreadTest extends AbstractJDITest {
+	private static final String defaultJavaCompilerName = "com.sun.tools.javac.api.JavacTool";
+	private static JavaCompiler compiler;
+	static {
+		compiler = ToolProvider.getSystemJavaCompiler();
+		if (compiler == null) {
+			try {
+				compiler = (JavaCompiler) Class.forName(defaultJavaCompilerName).getDeclaredConstructor().newInstance();
+			} catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException | InstantiationException
+					| IllegalAccessException | ClassNotFoundException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private ThreadReference fVirtualThread;
+	private ThreadReference fThread;
+	private ThreadReference fMainThread;
+
+	public VirtualThreadTest() {
+		fVmArgs = "--enable-preview";
+	}
+
+	/**
+	 * Init the fields that are used by this test only.
+	 *
+	 * @throws SecurityException
+	 * @throws NoSuchFieldException
+	 */
+	@Override
+	public void localSetUp() {
+		// Get thread
+		fVirtualThread = getThread("fVirtualThread");
+		fThread = getThread();
+		fMainThread = getMainThread();
+	}
+
+	/**
+	 * Make sure the test leaves the VM in the same state it found it.
+	 */
+	@Override
+	public void localTearDown() {
+		// The test has resumed the test thread, so suspend it
+		waitUntilReady();
+	}
+
+	@Override
+	protected void setUp() {
+		compileTestProgram();
+		super.setUp();
+	}
+
+	@Override
+	public void setVMInfo(VMInformation info) {
+		// do nothing
+	}
+
+	public static void main(String[] args) {
+		compileTestProgram();
+		new VirtualThreadTest().runSuite(args);
+	}
+
+	protected static void compileTestProgram() {
+		if (Runtime.version().feature() < 19) {
+			return;
+		}
+
+		String sourceFilePath = new File("./java19/TryVirtualThread.java").getAbsolutePath();
+		String outputFilePath = new File("./bin").getAbsolutePath();
+		compileFiles(sourceFilePath, outputFilePath);
+	}
+
+	private static void compileFiles(String sourceFilePath, String outputPath) {
+		DiagnosticCollector<? super JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+		StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnosticCollector, Locale.ENGLISH, Charset.forName("utf-8"));
+		Iterable<? extends JavaFileObject> javaFileObjects = fileManager.getJavaFileObjects(new File(sourceFilePath));
+		File outputFolder = new File(outputPath);
+		if (!outputFolder.exists()) {
+			outputFolder.mkdir();
+		}
+		String[] options = new String[] { "--enable-preview", "--release", "19", "-d", outputFolder.getAbsolutePath(), "-g", "-proc:none" };
+		final StringWriter output = new StringWriter();
+		CompilationTask task = compiler.getTask(output, fileManager, diagnosticCollector, Arrays.asList(options), null, javaFileObjects);
+		boolean result = task.call();
+		if (!result) {
+			throw new IllegalArgumentException("Compilation failed:\n" + output);
+		}
+
+	}
+
+	@Override
+	protected String getMainClassName() {
+		return "TryVirtualThread";
+	}
+
+	/**
+	 * Test JDI isVirtual()
+	 */
+	public void testJDIVirtualThread() {
+		assertTrue("1", ((ThreadReferenceImpl) fVirtualThread).isVirtual());
+		assertFalse("2", ((ThreadReferenceImpl) fMainThread).isVirtual());
+	}
+
+	/**
+	 * Test JDI ThreadStartEvent/ThreadDeathEvent
+	 */
+	public void testJDIThreadEvents() {
+		// Make sure the entire VM is not suspended before we start a new thread
+		// (otherwise this new thread will start suspended and we will never get the
+		// ThreadStart event)
+		fVM.resume();
+
+		// Trigger a thread start event
+		ThreadStartEvent fThreadStartEvent = (ThreadStartEvent) triggerAndWait(fVM.eventRequestManager().createThreadStartRequest(), "ThreadStartEvent", true);
+		assertNotNull("1", fThreadStartEvent);
+		assertEquals("2", "java.lang.VirtualThread", fThreadStartEvent.thread().type().name());
+
+		// Trigger a thread death event
+		ThreadDeathEvent fThreadDeathEvent = (ThreadDeathEvent) triggerAndWait(fVM.eventRequestManager().createThreadDeathRequest(), "ThreadDeathEvent", true);
+		assertNotNull("3", fThreadDeathEvent);
+		assertEquals("4", "java.lang.VirtualThread", fThreadDeathEvent.thread().type().name());
+	}
+
+	/**
+	 * Test restricting JDI ThreadStartEvent/ThreadDeathEvent to platform threads only
+	 */
+	public void testJDIPlatformThreadsOnlyFilter() {
+		// Make sure the entire VM is not suspended before we start a new thread
+		// (otherwise this new thread will start suspended and we will never get the
+		// ThreadStart event)
+		fVM.resume();
+
+		// Trigger a thread start event
+		ThreadStartRequest vThreadStartRequest = fVM.eventRequestManager().createThreadStartRequest();
+		try {
+			Method method = vThreadStartRequest.getClass().getMethod("addPlatformThreadsOnlyFilter");
+			method.invoke(vThreadStartRequest);
+		} catch (NoSuchMethodException | SecurityException e) {
+			fail("1");
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			fail("2");
+		}
+		ThreadStartEvent startEvent = (ThreadStartEvent) triggerAndWait(vThreadStartRequest, "ThreadStartEvent", true, 3000);
+		assertNull("3", startEvent);
+
+		// Trigger a thread death event
+		ThreadDeathRequest vThreadDeathRequest = fVM.eventRequestManager().createThreadDeathRequest();
+		try {
+			Method method = vThreadDeathRequest.getClass().getMethod("addPlatformThreadsOnlyFilter");
+			method.invoke(vThreadDeathRequest);
+		} catch (NoSuchMethodException | SecurityException e) {
+			fail("4");
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			fail("5");
+		}
+		ThreadDeathEvent deathEvent = (ThreadDeathEvent) triggerAndWait(vThreadDeathRequest, "ThreadDeathEvent", true, 3000);
+		assertNull("6", deathEvent);
+	}
+}

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.19.300.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/OpaqueFrameException.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/OpaqueFrameException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdi;
+
+/**
+ * Thrown to indicate an operation could not be performed on a frame.
+ *
+ * @since 3.20
+ */
+public class OpaqueFrameException extends RuntimeException {
+
+	private static final long serialVersionUID = 3779456734107108574L;
+
+	public OpaqueFrameException() {
+		super();
+	}
+
+	public OpaqueFrameException(String message) {
+		super(message);
+	}
+}

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/VirtualMachineImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/VirtualMachineImpl.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -1602,5 +1606,9 @@ public class VirtualMachineImpl extends MirrorImpl implements VirtualMachine,
 	@Override
 	public boolean canBeModified() {
 		return true;
+	}
+
+	public boolean mayCreateVirtualThreads() {
+		return isJdwpVersionGreaterOrEqual(19, 0);
 	}
 }

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/ConnectMessages.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/ConnectMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,9 +8,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM - Initial API and implementation
  *     Google Inc - add support for accepting multiple connections
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.connect;
 
@@ -48,6 +53,8 @@ public class ConnectMessages extends NLS {
 	public static String SocketLaunchingConnectorImpl_Connection_argument_is_not_of_the_right_type_14;
 	public static String SocketLaunchingConnectorImpl_Necessary_connection_argument_is_null_15;
 	public static String SocketLaunchingConnectorImpl_Connection_argument_is_not_a_number_16;
+	public static String SocketLaunchingConnectorImpl_Include_virtual_threads_17;
+	public static String SocketLaunchingConnectorImpl_IncludeVirtualThreads_18;
 	public static String SocketListeningConnectorImpl_Port_number_at_which_to_listen_for_VM_connections_1;
 	public static String SocketListeningConnectorImpl_Port_2;
 	public static String SocketListeningConnectorImpl_Timeout_before_accept_returns_3;

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/ConnectMessages.properties
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/ConnectMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2018 IBM Corporation and others.
+# Copyright (c) 2000, 2022 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -8,9 +8,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# This is an implementation of an early-draft specification developed under the Java
+# Community Process (JCP) and is made available for testing and evaluation purposes
+# only. The code is not compatible with any specification of the JCP.
+#
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #     Google Inc - add support for accepting multiple connections
+#     Microsoft Corporation - supports virtual threads
 ###############################################################################
 
 PacketReceiveManager_Got_IOException_from_Virtual_Machine_1=Got IOException from Virtual Machine
@@ -47,6 +52,8 @@ SocketLaunchingConnectorImpl_Launches_target_using_Sun_Java_VM_command_line_and_
 SocketLaunchingConnectorImpl_Connection_argument_is_not_of_the_right_type_14=Connection argument is not of the right type
 SocketLaunchingConnectorImpl_Necessary_connection_argument_is_null_15=Necessary connection argument is null
 SocketLaunchingConnectorImpl_Connection_argument_is_not_a_number_16=Connection argument is not a number
+SocketLaunchingConnectorImpl_Include_virtual_threads_17=List of all threads includes virtual threads as well as platform threads. Virtual threads are a preview feature of the Java platform.
+SocketLaunchingConnectorImpl_IncludeVirtualThreads_18=Include Virtual Threads:
 SocketListeningConnectorImpl_Port_number_at_which_to_listen_for_VM_connections_1=Port number at which to listen for VM connections
 #For translation of separator ":" it should be consistent to the translated value of SocketConnectionLabelSeparator
 SocketListeningConnectorImpl_Port_2=Po&rt:

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketLaunchingConnectorImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketLaunchingConnectorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,10 +8,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Ivan Popov - Bug 184211: JDI connectors throw NullPointerException if used separately
  *     			from Eclipse
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.connect;
 
@@ -54,6 +59,12 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 	private boolean fSuspend;
 	/** Name of the Java VM launcher. */
 	private String fLauncher;
+	/**
+	 * List of all threads includes virtual threads as well as platform threads.
+	 * Virtual threads are a preview feature of the Java platform.
+	 * @since 3.20
+	 */
+	private boolean fIncludeVirtualThreads;
 
 	/**
 	 * Creates new SocketAttachingConnectorImpl.
@@ -108,6 +119,12 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 		strArg.setValue("java"); //$NON-NLS-1$
 		arguments.put(strArg.name(), strArg);
 
+		// Include Virtual Threads
+		BooleanArgumentImpl vthreadsArg = new BooleanArgumentImpl(
+				"includevirtualthreads", ConnectMessages.SocketLaunchingConnectorImpl_Include_virtual_threads_17, ConnectMessages.SocketLaunchingConnectorImpl_IncludeVirtualThreads_18, false); //$NON-NLS-1$
+		vthreadsArg.setValue(false);
+		arguments.put(vthreadsArg.name(), vthreadsArg);
+
 		return arguments;
 	}
 
@@ -152,6 +169,9 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 			attribute = "vmexec"; //$NON-NLS-1$
 			fLauncher = ((Connector.StringArgument) connectionArgs
 					.get(attribute)).value();
+			attribute = "includevirtualthreads"; //$NON-NLS-1$
+			fIncludeVirtualThreads = ((Connector.BooleanArgument) connectionArgs
+					.get(attribute)).booleanValue();
 		} catch (ClassCastException e) {
 			throw new IllegalConnectorArgumentsException(
 					ConnectMessages.SocketLaunchingConnectorImpl_Connection_argument_is_not_of_the_right_type_14,
@@ -190,6 +210,9 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 		// Add Debug options.
 		execString += " -Xdebug -Xnoagent -Djava.compiler=NONE"; //$NON-NLS-1$
 		execString += " -Xrunjdwp:transport=dt_socket,address=" + address + ",server=n,suspend=" + (fSuspend ? "y" : "n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		if (fIncludeVirtualThreads) { // The default value is 'n', add it only when explicitly enabled.
+			execString += ",includevirtualthreads=y"; //$NON-NLS-1$
+		}
 
 		// Add User specified options.
 		if (fOptions != null) {

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/jdwp/JdwpCommandPacket.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/jdwp/JdwpCommandPacket.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,9 +8,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Jesper Steen Møller <jesper@selskabet.org> - Bug 430839
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.jdwp;
 
@@ -137,6 +142,13 @@ public class JdwpCommandPacket extends JdwpPacket {
 	public static final int TR_SUSPEND_COUNT = 12 + (CSET_THREAD_REFERENCE << 8);
 	public static final int TR_OWNED_MONITOR_STACK_DEPTH = 13 + (CSET_THREAD_REFERENCE << 8);
 	public static final int TR_FORCE_EARLY_RETURN = 14 + (CSET_THREAD_REFERENCE << 8);
+	/**
+	 * IsVirtual is a preview API of the Java platform. Preview features may be removed in a future release, or upgraded to permanent features of the
+	 * Java platform. Since JDWP version 19.
+	 *
+	 * @since 3.20
+	 */
+	public static final int TR_IS_VIRTUAL = 15 + (CSET_THREAD_REFERENCE << 8);
 
 	/** Commands ThreadGroupReference. */
 	public static final int TGR_NAME = 1 + (CSET_THREAD_GROUP_REFERENCE << 8);

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/EventRequestImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/EventRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.request;
 
@@ -78,6 +83,14 @@ public abstract class EventRequestImpl extends MirrorImpl implements
 	public static final byte MODIF_KIND_STEP = 10;
 	public static final byte MODIF_KIND_INSTANCE = 11;
 	public static final byte MODIF_KIND_SOURCE_NAME_FILTER = 12;
+	/**
+	 * PlatformThreadsOnly is a preview API of the Java platform. Preview features may be removed in a future release, or upgraded to permanent
+	 * features of the Java platform. Since JDWP version 19. For thread start and thread end events, restrict the events so they are only sent for
+	 * platform threads.
+	 *
+	 * @since 3.20
+	 */
+	public static final byte MODIF_KIND_PLATFORMTHREADSONLY = 13;
 
 	/** Mapping of command codes to strings. */
 	private static HashMap<Integer, String> fStepSizeMap = null;
@@ -144,6 +157,13 @@ public abstract class EventRequestImpl extends MirrorImpl implements
 	 * @since 3.3
 	 */
 	protected ArrayList<String> fSourceNameFilters = null;
+
+	/**
+	 * Platform threads filter
+	 *
+	 * @since 3.20
+	 */
+	protected boolean fPlatformThreadsFilter = false;
 
 	/**
 	 * Creates new EventRequest.
@@ -602,6 +622,9 @@ public abstract class EventRequestImpl extends MirrorImpl implements
 				count += fSourceNameFilters.size();
 			}
 		}
+		if (fPlatformThreadsFilter) {
+			count++;
+		}
 		return count;
 	}
 
@@ -709,6 +732,18 @@ public abstract class EventRequestImpl extends MirrorImpl implements
 				}
 			}
 		}
+		if (fPlatformThreadsFilter && supportsPlatformThreadsFilter()) {
+			writeByte(MODIF_KIND_PLATFORMTHREADSONLY, "modifier", modifierKindMap(), outData); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Returns whether JDWP supports platform threads filter (a 19 preview feature).
+	 *
+	 * @return whether JDWP supports platform threads filter
+	 */
+	private boolean supportsPlatformThreadsFilter() {
+		return ((VirtualMachineImpl) virtualMachine()).mayCreateVirtualThreads();
 	}
 
 	/**

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadDeathRequestImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadDeathRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.request;
 
@@ -23,7 +28,7 @@ import com.sun.jdi.request.ThreadDeathRequest;
  * specification. See the com.sun.jdi package for more information.
  *
  */
-public class ThreadDeathRequestImpl extends EventRequestImpl implements
+public class ThreadDeathRequestImpl extends ThreadLifecycleRequestImpl implements
 		ThreadDeathRequest {
 	/**
 	 * Creates new ThreadDeathRequest.

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadLifecycleRequestImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadLifecycleRequestImpl.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdi.internal.request;
+
+import org.eclipse.jdi.internal.VirtualMachineImpl;
+
+public abstract class ThreadLifecycleRequestImpl extends EventRequestImpl {
+
+	protected ThreadLifecycleRequestImpl(String description, VirtualMachineImpl vmImpl) {
+		super(description, vmImpl);
+	}
+
+	/**
+	 * For thread start and thread end events, restrict the events so they are only sent for platform threads.
+	 *
+	 * @since 3.20
+	 */
+	public void addPlatformThreadsOnlyFilter() {
+		checkDisabled();
+		fPlatformThreadsFilter = true;
+	}
+}

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadStartRequestImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/ThreadStartRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,8 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
  *******************************************************************************/
 package org.eclipse.jdi.internal.request;
 
@@ -23,7 +28,7 @@ import com.sun.jdi.request.ThreadStartRequest;
  * specification. See the com.sun.jdi package for more information.
  *
  */
-public class ThreadStartRequestImpl extends EventRequestImpl implements
+public class ThreadStartRequestImpl extends ThreadLifecycleRequestImpl implements
 		ThreadStartRequest {
 	/**
 	 * Creates new ThreadStartRequest.

--- a/org.eclipse.jdt.debug/pom.xml
+++ b/org.eclipse.jdt.debug/pom.xml
@@ -6,6 +6,10 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
  
+  This is an implementation of an early-draft specification developed under the Java
+  Community Process (JCP) and is made available for testing and evaluation purposes
+  only. The code is not compatible with any specification of the JCP.
+ 
   Contributors:
      Igor Fedorenko - initial implementation
 -->
@@ -18,6 +22,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug</artifactId>
-  <version>3.19.300-SNAPSHOT</version>
+  <version>3.20.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>
Change-Id: I5554cc7a6f8639d080a6a05e031443e9f33027c2

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This PR is part of debugging support for project loom https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/38.

It references the changes to loom support in the jdk.jdi module of upstream openjdk. See https://github.com/openjdk/loom/commit/9583e3657e43cc1c6f2101a64534564db2a9bd84#diff-c204bc3f441034b640a0d3756084e13a6c3b7158f8184aa67ad4eea2cdbb5133 

It includes:
- [x] A new method in [com.sun.jdi.ThreadReference#isVirtual](https://download.java.net/java/early_access/loom/docs/api/jdk.jdi/com/sun/jdi/ThreadReference.html#isVirtual%28%29) tests if a thread is a virtual thread.
- [x] New methods in [com.sun.jdi.request.ThreadStartRequest#addPlatformThreadsOnlyFilter](https://download.java.net/java/early_access/loom/docs/api/jdk.jdi/com/sun/jdi/request/ThreadStartRequest.html#addPlatformThreadsOnlyFilter%28%29) and [com.sun.jdi.request.ThreadDeathRequest#addPlatformThreadsOnlyFilter](https://download.java.net/java/early_access/loom/docs/api/jdk.jdi/com/sun/jdi/request/ThreadDeathRequest.html#addPlatformThreadsOnlyFilter%28%29) allow debuggers to restrict thread start and end events to platform threads only.
- [x] ~~A new debug option `enumeratevthreads=y` to tell whether thread lists include virtual threads. In latest loom code, this option has been renamed to `includevirtualthreads`.~~
- [x] **Edited:** In OpenJDK JDK 19 Early-Access Build 29 (2022/6/30), it supports a new debug option `includevirtualthreads=y|n` to tell whether thread lists include virtual threads. If this option is not set, the default value is `n`.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
   **Yes, I use OpenJDK JDK 19 Early-Access Build 29 (2022/6/30) to test the new JDI capability, it works.**
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

