### PR TITLE
Add a new button to the InstalledJREsBlock 

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
@@ -48,6 +48,9 @@ public class JREMessages extends NLS {
 	public static String InstalledJREsBlock_14;
 	public static String InstalledJREsBlock_15;
 	public static String InstalledJREsBlock_16;
+	public static String InstalledJREsBlock_20;
+	public static String InstalledJREsBlock_Error;
+	public static String InstalledJREsBlock_SdkManNotInstalled;
 
 	public static String JREsComboBlock_1;
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
@@ -40,7 +40,11 @@ InstalledJREsBlock_14=Found {0} - Searching {1}
 InstalledJREsBlock_15=Installed &JREs:
 InstalledJREsBlock_16=Dupli&cate...
 InstalledJREsBlock_19={0} (contributed)
+InstalledJREsBlock_20=Add JREs from SDK&MAN!
 InstalledJREsBlock_7={0} (default)
+InstalledJREsBlock_Error=Error
+InstalledJREsBlock_SdkManNotInstalled=SDKMAN! is not installed!
+
 
 JREsComboBlock_1=Alternate &JRE:
 JREsComboBlock_10=JRE name not specified for JRE type: {0}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractVMInstall.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractVMInstall.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilder;
 
@@ -324,15 +325,10 @@ public abstract class AbstractVMInstall implements IVMInstall, IVMInstall2, IVMI
      */
     @Override
 	public void setVMArgs(String vmArgs) {
-        if (fVMArgs == null) {
-            if (vmArgs == null) {
-                // No change
-                return;
-            }
-        } else if (fVMArgs.equals(vmArgs)) {
-    		// No change
-    		return;
-    	}
+		if (Objects.equals(vmArgs, fVMArgs)) {
+			// No change
+			return;
+		}
         PropertyChangeEvent event = new PropertyChangeEvent(this, IVMInstallChangedListener.PROPERTY_VM_ARGUMENTS, fVMArgs, vmArgs);
         fVMArgs = vmArgs;
 		if (fNotify) {


### PR DESCRIPTION
which adds all the JREs installed by sdkman, if there are available

Change-Id: Id4e777ce3b2aa0271e1c222b586818ff890990bc

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
[sdkman](https://sdkman.io/) is a tool to install multiple JVMs (among others) locally, and switching between with a minimal effort.
This patch adds a new button to the JRE Preferences page, which adds all the JVMs installed by SDKMan to the available list of JREs.     

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install SDKMan
2. Install a couple of JREs with SDKMan
3. Start eclipse, navigate to preference page, and click on the new "Add JREs from SDKMan" button
4. Enjoy the newly added JREs!


## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

