### PR TITLE
Add ability to navigate from the AllReferences popup and from the AllInstances popup to the actual implementation

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableConcreteTypeAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableConcreteTypeAction.java
@@ -47,7 +47,7 @@ public class OpenVariableConcreteTypeAction extends OpenVariableTypeAction {
 	}
 
 	@Override
-	protected boolean openElement(IAction action, Object element) throws DebugException, CoreException {
+	public boolean openElement(IAction action, Object element) throws DebugException, CoreException {
 		if (element instanceof JDIVariable) {
 			final var jdiVariable = (JDIVariable) element;
 			if (isInterfaceType(jdiVariable)) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/AllInstancesActionDelegate.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/AllInstancesActionDelegate.java
@@ -34,7 +34,6 @@ import org.eclipse.jdt.internal.debug.core.model.JDIReferenceType;
 import org.eclipse.jdt.internal.debug.ui.DebugWorkingCopyManager;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jdt.internal.debug.ui.JavaWordFinder;
-import org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate;
 import org.eclipse.jdt.internal.debug.ui.actions.PopupInspectAction;
 import org.eclipse.jdt.internal.debug.ui.display.JavaInspectExpression;
 import org.eclipse.jdt.ui.JavaUI;
@@ -57,10 +56,7 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IEditorActionDelegate;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.IWorkbenchWindowActionDelegate;
 import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.part.PageBookView;
 import org.eclipse.ui.texteditor.IDocumentProvider;
@@ -73,9 +69,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  *
  * @since 3.3
  */
-public class AllInstancesActionDelegate  extends ObjectActionDelegate implements IEditorActionDelegate, IWorkbenchWindowActionDelegate {
-
-	private IWorkbenchWindow fWindow;
+public class AllInstancesActionDelegate extends BaseInstanceActionDelegate implements IEditorActionDelegate {
 
 	/* (non-Javadoc)
 	 * @see org.eclipse.ui.IActionDelegate#run(org.eclipse.jface.action.IAction)
@@ -101,7 +95,7 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 						    		IJavaElement[] selectedTypes = ((ICodeAssist)element).codeSelect(selectedWord.getOffset(), selectedWord.getLength());
 						    		// findWord() will only return one element, so only check the first element
 						    		if (selectedTypes.length > 0){
-						    			runForSelection(selectedTypes[0]);
+										runForSelection(action, selectedTypes[0]);
 						    			return;
 						    		}
 								} catch (JavaModelException e){
@@ -114,7 +108,7 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 
 				// Otherwise, get the first selected element and check if it is a type
 				} else if (selection instanceof IStructuredSelection){
-					runForSelection(((IStructuredSelection)selection).getFirstElement());
+					runForSelection(action, ((IStructuredSelection) selection).getFirstElement());
 					return;
 				}
 			}
@@ -128,7 +122,7 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 	 *
 	 * @param selectedElement a method, type, or variable
 	 */
-	protected void runForSelection(Object selectedElement){
+	protected void runForSelection(IAction action, Object selectedElement) {
 		if (selectedElement != null){
 
 			IJavaType type = null;
@@ -151,7 +145,7 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 								type = types[0];
 							} else {
 								// If the type is not known the the VM, open a pop-up dialog with 0 instances
-								displayNoInstances(target, itype.getFullyQualifiedName());
+								displayNoInstances(action, target, itype.getFullyQualifiedName());
 								return;
 							}
 						}
@@ -176,8 +170,7 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 			}
 
 			if(type instanceof JDIReferenceType) {
-				JDIReferenceType rtype = (JDIReferenceType) type;
-				displayInstaces((JDIDebugTarget)rtype.getDebugTarget(), rtype);
+				displayInstaces(action, (JDIReferenceType) type);
 				return;
 			}
 		}
@@ -190,33 +183,30 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 	 * @param target target
 	 * @param typeName resolve type name
 	 */
-	protected void displayNoInstances(IJavaDebugTarget target, String typeName) {
-		JDIAllInstancesValue aiv = new JDIAllInstancesValue((JDIDebugTarget)target, null);
-		InspectPopupDialog ipd = new InspectPopupDialog(getShell(),
-				getAnchor(),
-				PopupInspectAction.ACTION_DEFININITION_ID,
-				new JavaInspectExpression(NLS.bind(Messages.AllInstancesActionDelegate_2, new String[]{typeName}), aiv));
-		ipd.open();
+	protected void displayNoInstances(IAction action, IJavaDebugTarget target, String typeName) {
+		displayPopup(action, (JDIDebugTarget) target, null, typeName);
 	}
 
 	/**
 	 * Display instances of the given resolved type.
 	 *
-	 * @param target target
 	 * @param rtype resolved reference type
 	 */
-	protected void displayInstaces(IJavaDebugTarget target, JDIReferenceType rtype) {
+	protected void displayInstaces(IAction action, JDIReferenceType rtype) {
 		try{
-			JDIAllInstancesValue aiv = new JDIAllInstancesValue((JDIDebugTarget)rtype.getDebugTarget(), rtype);
-			InspectPopupDialog ipd = new InspectPopupDialog(getShell(),
-					getAnchor(),
-					PopupInspectAction.ACTION_DEFININITION_ID,
-					new JavaInspectExpression(NLS.bind(Messages.AllInstancesActionDelegate_2, new String[]{rtype.getName()}), aiv));
-			ipd.open();
+			displayPopup(action, (JDIDebugTarget) rtype.getDebugTarget(), rtype, rtype.getName());
 		} catch (DebugException e) {
 			JDIDebugUIPlugin.log(e);
 			report(Messages.AllInstancesActionDelegate_0,getPart());
 		}
+	}
+
+	private void displayPopup(IAction action, JDIDebugTarget target, JDIReferenceType rtype, String name) {
+		JDIAllInstancesValue aiv = new JDIAllInstancesValue(target, rtype);
+		InspectPopupDialog ipd = new InspectPopupDialog(getShell(), getAnchor(), PopupInspectAction.ACTION_DEFININITION_ID, new JavaInspectExpression(NLS.bind(Messages.AllInstancesActionDelegate_2, new String[] {
+				name }), aiv));
+		ipd.open();
+		ipd.getTreeViewer().addDoubleClickListener(event -> handleDoubleClick(action, event));
 	}
 
 	 /**
@@ -336,14 +326,6 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 		setActivePart(action, targetEditor);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.ui.IWorkbenchWindowActionDelegate#init(org.eclipse.ui.IWorkbenchWindow)
-	 */
-	@Override
-	public void init(IWorkbenchWindow window) {
-		fWindow = window;
-	}
-
 	/**
 	 * @return the shell to use for new popups or <code>null</code>
 	 */
@@ -353,23 +335,6 @@ public class AllInstancesActionDelegate  extends ObjectActionDelegate implements
 		}
 		if (getWorkbenchWindow() != null){
 			return getWorkbenchWindow().getShell();
-		}
-		return null;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate#getPart()
-	 */
-	@Override
-	protected IWorkbenchPart getPart() {
-		IWorkbenchPart part = super.getPart();
-		if (part != null){
-			return part;
-		} else if (fWindow != null){
-			IWorkbenchPage page = fWindow.getActivePage();
-			if(page != null) {
-				return page.getActivePart();
-			}
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/AllReferencesActionDelegate.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/AllReferencesActionDelegate.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.debug.core.IJavaObject;
 import org.eclipse.jdt.debug.core.IJavaVariable;
 import org.eclipse.jdt.internal.debug.core.model.JDIReferenceListValue;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
-import org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate;
 import org.eclipse.jdt.internal.debug.ui.actions.PopupInspectAction;
 import org.eclipse.jdt.internal.debug.ui.display.JavaInspectExpression;
 import org.eclipse.jface.action.IAction;
@@ -35,18 +34,13 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.IWorkbenchWindowActionDelegate;
 
 /**
  * Action to browse all references to selected object.
  *
  * @since 3.3
  */
-public class AllReferencesActionDelegate extends ObjectActionDelegate implements IWorkbenchWindowActionDelegate{
-
-	protected IWorkbenchWindow fWindow;
+public class AllReferencesActionDelegate extends BaseInstanceActionDelegate {
 
 	@Override
 	public void run(IAction action) {
@@ -60,6 +54,8 @@ public class AllReferencesActionDelegate extends ObjectActionDelegate implements
 						PopupInspectAction.ACTION_DEFININITION_ID,
 						new JavaInspectExpression(NLS.bind(Messages.AllReferencesActionDelegate_1,new String[]{var.getName()}),referenceList));
 				ipd.open();
+				ipd.getTreeViewer().addDoubleClickListener(doubleClick -> handleDoubleClick(action, doubleClick));
+
 			} catch (DebugException e) {
 				JDIDebugUIPlugin.statusDialog(e.getStatus());
 			}
@@ -87,14 +83,6 @@ public class AllReferencesActionDelegate extends ObjectActionDelegate implements
 		return control.toDisplay(0, 0);
     }
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.ui.IWorkbenchWindowActionDelegate#init(org.eclipse.ui.IWorkbenchWindow)
-	 */
-	@Override
-	public void init(IWorkbenchWindow window) {
-		fWindow = window;
-	}
-
 	/**
 	 * @return the shell to use for new popups or <code>null</code>
 	 */
@@ -104,20 +92,6 @@ public class AllReferencesActionDelegate extends ObjectActionDelegate implements
 		}
 		if (getWorkbenchWindow() != null){
 			return getWorkbenchWindow().getShell();
-		}
-		return null;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate#getPart()
-	 */
-	@Override
-	protected IWorkbenchPart getPart() {
-		IWorkbenchPart part = super.getPart();
-		if (part != null){
-			return part;
-		} else if (fWindow != null){
-			return fWindow.getActivePage().getActivePart();
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/BaseInstanceActionDelegate.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/BaseInstanceActionDelegate.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Zsombor Gegesy and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Zsombor Gegesy - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.debug.ui.heapwalking;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.jdt.debug.core.IJavaVariable;
+import org.eclipse.jdt.internal.debug.core.model.JDIFieldVariable;
+import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
+import org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate;
+import org.eclipse.jdt.internal.debug.ui.actions.OpenVariableConcreteTypeAction;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.IWorkbenchWindowActionDelegate;
+
+abstract class BaseInstanceActionDelegate extends ObjectActionDelegate implements IWorkbenchWindowActionDelegate {
+
+	protected IWorkbenchWindow fWindow;
+
+	@Override
+	public void init(IWorkbenchWindow window) {
+		this.fWindow = window;
+	}
+
+	protected void handleDoubleClick(IAction action, DoubleClickEvent event) {
+		var selection = ((IStructuredSelection) event.getSelection()).getFirstElement();
+		openInEditor(action, selection);
+	}
+
+	private void openInEditor(IAction action, Object selection) {
+		if (selection instanceof JDIFieldVariable) {
+			var openAction = new OpenVariableConcreteTypeAction();
+			openAction.setActivePart(action, getPart());
+			try {
+				openAction.openElement(action, selection);
+			} catch (CoreException e) {
+				JDIDebugUIPlugin.log(e);
+			}
+		} else if (selection instanceof IJavaVariable) {
+			try {
+				var openAction = new OpenVariableConcreteTypeAction();
+				openAction.setActivePart(action, getPart());
+				openAction.openElement(action, selection);
+			} catch (DebugException e) {
+				JDIDebugUIPlugin.log(e);
+			} catch (CoreException e) {
+				JDIDebugUIPlugin.log(e);
+			}
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.jdt.internal.debug.ui.actions.ObjectActionDelegate#getPart()
+	 */
+	@Override
+	protected IWorkbenchPart getPart() {
+		IWorkbenchPart part = super.getPart();
+		if (part != null) {
+			return part;
+		} else if (fWindow != null) {
+			return fWindow.getActivePage().getActivePart();
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/InstanceCountActionDelegate.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/heapwalking/InstanceCountActionDelegate.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.internal.debug.core.model.JDIReferenceType;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.osgi.util.NLS;
 
@@ -31,7 +32,7 @@ public class InstanceCountActionDelegate extends AllInstancesActionDelegate {
 	 * @see org.eclipse.jdt.internal.debug.ui.heapwalking.AllInstancesActionDelegate#displayInstaces(org.eclipse.jdt.debug.core.IJavaDebugTarget, org.eclipse.jdt.internal.debug.core.model.JDIReferenceType)
 	 */
 	@Override
-	protected void displayInstaces(IJavaDebugTarget target, JDIReferenceType rtype) {
+	protected void displayInstaces(IAction action, JDIReferenceType rtype) {
 		try {
 			displayNumInstances(rtype.getName(), rtype.getInstanceCount());
 		} catch (CoreException e) {
@@ -44,7 +45,7 @@ public class InstanceCountActionDelegate extends AllInstancesActionDelegate {
 	 * @see org.eclipse.jdt.internal.debug.ui.heapwalking.AllInstancesActionDelegate#displayNoInstances(org.eclipse.jdt.debug.core.IJavaDebugTarget, java.lang.String)
 	 */
 	@Override
-	protected void displayNoInstances(IJavaDebugTarget target, String typeName) {
+	protected void displayNoInstances(IAction action, IJavaDebugTarget target, String typeName) {
 		displayNumInstances(typeName, 0);
 	}
 


### PR DESCRIPTION
basically, adding a double click listener to the AllReferencesActionDelegate and AllInstancesActionDelegate, and a minor refactor)
 Depends on https://github.com/eclipse-platform/eclipse.platform.debug/pull/52

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Clicking on a field or a class in All Instances popup or All references popup will navigate to the source code of that field or class

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
