### PR TITLE
Add jdi.tests also to run for Java 19

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2012, 2022 Eclipse Foundation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+  This is an implementation of an early-draft specification developed under the Java
+  Community Process (JCP) and is made available for testing and evaluation purposes
+  only. The code is not compatible with any specification of the JCP.
+  
+ 
+  Contributors:
+     IBM Corporation - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.jdt.debug</artifactId>
+    <groupId>eclipse.jdt.debug</groupId>
+    <version>4.25.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse.jdt</groupId>
+  <artifactId>org.eclipse.jdt.debug.jdi.tests</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+  <properties>
+    <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>
+    <testSuite>${project.artifactId}</testSuite>
+    <testClass>org.eclipse.debug.jdi.tests.AutomatedSuite</testClass>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <useUIHarness>true</useUIHarness>
+          <useUIThread>true</useUIThread>
+          <appArgLine>-consoleLog</appArgLine>
+          <dependencies>
+            <dependency>
+              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
+              <type>eclipse-plugin</type>
+              <artifactId>org.eclipse.equinox.event</artifactId>
+              <version>0.0.0</version>
+            </dependency>
+          </dependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+  	<profile>
+		<id>test-on-javase-19</id>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<version>1.1</version>
+					<executions>
+						<execution>
+							<phase>validate</phase>
+							<goals>
+								<goal>toolchain</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<toolchains>
+							<jdk>
+								<id>JavaSE-19</id>
+							</jdk>
+						</toolchains>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+  </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,11 @@
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
+  
+   This is an implementation of an early-draft specification developed under the Java
+ 	Community Process (JCP) and is made available for testing and evaluation purposes
+ 	only. The code is not compatible with any specification of the JCP.
+ 
  
   Contributors:
      Igor Fedorenko - initial implementation
@@ -61,5 +66,6 @@
     <module>org.eclipse.jdt.launching.ui.macosx</module>
     <module>org.eclipse.jdt.debug.tests</module>
     <module>org.eclipse.jdt.debug.ui</module>
+    <module>org.eclipse.jdt.debug.jdi.tests</module>
   </modules>
 </project>


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/38

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
