### PR TITLE
Don't use nested argfiles to launch Java processes (#84)

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/LongClassPathTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/LongClassPathTests.java
@@ -30,6 +30,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -38,6 +39,8 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.testplugin.DebugElementKindEventWaiter;
+import org.eclipse.jdt.debug.testplugin.DebugEventWaiter;
 import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.debug.tests.AbstractDebugTest;
 import org.eclipse.jdt.internal.launching.LaunchingPlugin;
@@ -55,11 +58,11 @@ import junit.framework.TestSuite;
  *
  */
 public class LongClassPathTests extends AbstractDebugTest {
-	private static final String MAIN_TYPE_NAME = "test.classpath.Main";
-	private static final IPath CLASSPATH_PROJECT_CONTENT_PATH = new Path("testresources/classpathProject");
-	private IJavaProject javaProject;
-	private ILaunchConfiguration launchConfiguration;
-	private IJavaThread thread;
+	protected static final String MAIN_TYPE_NAME = "test.classpath.Main";
+	protected static final IPath CLASSPATH_PROJECT_CONTENT_PATH = new Path("testresources/classpathProject");
+	protected IJavaProject javaProject;
+	protected ILaunchConfiguration launchConfiguration;
+	protected IJavaThread thread;
 
 	public LongClassPathTests(String name) {
 		super(name);
@@ -100,7 +103,7 @@ public class LongClassPathTests extends AbstractDebugTest {
 	 */
 	public void testVeryLongClasspathWithClasspathOnlyJar() throws Exception {
 		// Given
-		javaProject = createJavaProjectClone("testVeryLongClasspathWithClasspathOnlyJar", CLASSPATH_PROJECT_CONTENT_PATH.toString(), JavaProjectHelper.JAVA_SE_1_6_EE_NAME, true);
+		javaProject = createJavaProjectClone("test ä VeryLongClasspathWithClasspathOnlyJar", CLASSPATH_PROJECT_CONTENT_PATH.toString(), JavaProjectHelper.JAVA_SE_1_6_EE_NAME, true);
 		launchConfiguration = createLaunchConfigurationStopInMain(javaProject, MAIN_TYPE_NAME);
 		int minClasspathLength = 300000;
 		setLongClasspath(javaProject, minClasspathLength);
@@ -182,7 +185,7 @@ public class LongClassPathTests extends AbstractDebugTest {
 		resumeAndExit(thread);
 	}
 
-	private Optional<File> getTempFile(ILaunch launch) {
+	protected Optional<File> getTempFile(ILaunch launch) {
 		IProcess process = launch.getProcesses()[0];
 		String tempFile = process.getAttribute(LaunchingPlugin.ATTR_LAUNCH_TEMP_FILES);
 		if (tempFile == null) {
@@ -191,7 +194,7 @@ public class LongClassPathTests extends AbstractDebugTest {
 		return Optional.of(new File(tempFile));
 	}
 
-	private boolean isArgumentFileSupported(ILaunchConfiguration launchConfiguration) throws CoreException {
+	protected boolean isArgumentFileSupported(ILaunchConfiguration launchConfiguration) throws CoreException {
 		IVMInstall vmInstall = JavaRuntime.computeVMInstall(launchConfiguration);
 		if (vmInstall instanceof AbstractVMInstall) {
 			AbstractVMInstall install = (AbstractVMInstall) vmInstall;
@@ -209,7 +212,7 @@ public class LongClassPathTests extends AbstractDebugTest {
 		return configurationWorkingCopy.doSave();
 	}
 
-	private ILaunchConfiguration createLaunchConfigurationStopInMain(IJavaProject javaProject, String mainTypeName) throws Exception, CoreException {
+	protected ILaunchConfiguration createLaunchConfigurationStopInMain(IJavaProject javaProject, String mainTypeName) throws Exception, CoreException {
 		ILaunchConfiguration launchConfiguration;
 		launchConfiguration = createLaunchConfiguration(javaProject, mainTypeName);
 		ILaunchConfigurationWorkingCopy wc = launchConfiguration.getWorkingCopy();
@@ -218,7 +221,7 @@ public class LongClassPathTests extends AbstractDebugTest {
 		return launchConfiguration;
 	}
 
-	private void setLongClasspath(IJavaProject javaProject, int minClassPathLength) throws Exception {
+	protected void setLongClasspath(IJavaProject javaProject, int minClassPathLength) throws Exception {
 		StringBuilder sb = new StringBuilder();
 		List<IClasspathEntry> classpathEntries = new ArrayList<>();
 		int i = 0;
@@ -240,4 +243,17 @@ public class LongClassPathTests extends AbstractDebugTest {
 		javaProject.setRawClasspath(classpathEntries.toArray(new IClasspathEntry[classpathEntries.size()]), null);
 	}
 
+	/**
+	 * Increased timeout
+	 *
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected IJavaThread launchAndSuspend(ILaunchConfiguration config) throws Exception {
+		DebugEventWaiter waiter = new DebugElementKindEventWaiter(DebugEvent.SUSPEND, IJavaThread.class);
+		waiter.setTimeout(DEFAULT_TIMEOUT * 2);
+		waiter.setEnableUIEventLoopProcessing(enableUIEventLoopProcessingInWaiter());
+		Object suspendee = launchAndWait(config, waiter);
+		return (IJavaThread) suspendee;
+	}
 }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/LongCommandLineTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/LongCommandLineTests.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.launching;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Test JVM startup with long classpath / system properties by explicitly enabling {@link IJavaLaunchConfigurationConstants.ATTR_USE_ARGFILE} option
+ * in the "Arguments" part of the process launch configuration
+ */
+public class LongCommandLineTests extends LongClassPathTests {
+
+	static final int MIN_CLASSPATH_LENGTH = 300000;
+	boolean createLongArguments;
+
+	public LongCommandLineTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		TestSuite suite = new TestSuite();
+		suite.addTest(new LongCommandLineTests("testVeryLongClasspathWithArgumentFile"));
+		suite.addTest(new LongCommandLineTests("testVeryLongSystemPropertiesWithArgumentFile"));
+		return suite;
+	}
+
+	/*
+	 * Test will create lot of "-Dfoo=12345" system arguments for the started JVM and check if the startup works with argument file
+	 */
+	public void testVeryLongSystemPropertiesWithArgumentFile() throws Exception {
+		createLongArguments = true;
+
+		javaProject = createJavaProjectClone("test ä VeryLongSystemPropertiesWithArgumentFile", CLASSPATH_PROJECT_CONTENT_PATH.toString(), JavaProjectHelper.JAVA_SE_9_EE_NAME, true);
+		launchConfiguration = createLaunchConfigurationStopInMain(javaProject, MAIN_TYPE_NAME);
+		assumeTrue(isArgumentFileSupported(launchConfiguration));
+
+		// Given
+		waitForBuild();
+
+		// When
+		thread = launchAndSuspend(launchConfiguration);
+
+		// Then
+		File tempFile = getTempFile(thread.getLaunch()).orElseThrow(() -> new RuntimeException("No temp file"));
+		assertTrue("No temp file created: " + tempFile, tempFile.exists());
+		assertTrue("Unexpected temp file name: " + tempFile, tempFile.getName().endsWith(".txt"));
+		String valueString = doEval(thread, "java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toString()").getValueString();
+		assertTrue("Unexpected small system arguments list: " + valueString, valueString.length() >= MIN_CLASSPATH_LENGTH);
+
+		// When
+		resumeAndExit(thread);
+
+		// Then
+		if (!Platform.getOS().equals(Platform.OS_WIN32)) {
+			// On windows, temp file deletion may fail
+			assertFalse(tempFile.exists());
+		}
+	}
+
+	private void setLongVmArgumentsList(ILaunchConfigurationWorkingCopy wc, int minArgumentsLength) throws Exception {
+		final String keyArgs = IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS;
+		String args = wc.getAttribute(keyArgs, "");
+		StringBuilder sb = new StringBuilder(args);
+		while (sb.length() < minArgumentsLength) {
+			sb.append(" ");
+			sb.append("-Dfoo=1234567890_1234567890_1234567890_1234567890_1234567890_1234567890_1234567890_1234567890");
+		}
+		args += sb.toString();
+		wc.setAttribute(keyArgs, args);
+	}
+
+	@Override
+	protected ILaunchConfiguration createLaunchConfigurationStopInMain(IJavaProject javaProject, String mainTypeName) throws Exception, CoreException {
+		ILaunchConfiguration launchConfiguration;
+		launchConfiguration = createLaunchConfiguration(javaProject, mainTypeName);
+		ILaunchConfigurationWorkingCopy wc = launchConfiguration.getWorkingCopy();
+		wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, true);
+		// Always use argfile option
+		wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_USE_ARGFILE, true);
+		// Only set if required by particular test
+		if (createLongArguments) {
+			setLongVmArgumentsList(wc, MIN_CLASSPATH_LENGTH);
+		}
+		launchConfiguration = wc.doSave();
+		return launchConfiguration;
+	}
+
+}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
@@ -54,7 +54,7 @@ import org.eclipse.jdt.launching.IVMInstall2;
  * env variable. The modulepath is replaced by an argument file if necessary.
  *
  */
-public class ClasspathShortener {
+public class ClasspathShortener implements IProcessTempFileCreator {
 	private static final String CLASSPATH_ENV_VAR_PREFIX = "CLASSPATH="; //$NON-NLS-1$
 	public static final int ARG_MAX_LINUX = 2097152;
 	public static final int ARG_MAX_WINDOWS = 32767;
@@ -136,11 +136,7 @@ public class ClasspathShortener {
 		return cmdLine.toArray(new String[cmdLine.size()]);
 	}
 
-	/**
-	 * The files that were created while shortening the path. They can be deleted once the process is terminated
-	 *
-	 * @return created files
-	 */
+	@Override
 	public List<File> getProcessTempFiles() {
 		return new ArrayList<>(processTempFiles);
 	}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/CommandLineShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/CommandLineShortener.java
@@ -41,7 +41,7 @@ import org.eclipse.jdt.launching.IVMInstall2;
 /**
  * Shortens the command line by writing all commands into an arguments file.
  */
-public class CommandLineShortener {
+public class CommandLineShortener implements IProcessTempFileCreator {
 	public static String getJavaVersion(IVMInstall vmInstall) {
 		if (vmInstall instanceof IVMInstall2) {
 			IVMInstall2 install = (IVMInstall2) vmInstall;
@@ -153,11 +153,7 @@ public class CommandLineShortener {
 		return timeStamp;
 	}
 
-	/**
-	 * The files that were created while shortening the path. They can be deleted once the process is terminated
-	 *
-	 * @return created files
-	 */
+	@Override
 	public List<File> getProcessTempFiles() {
 		return new ArrayList<>(processTempFiles);
 	}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/IProcessTempFileCreator.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/IProcessTempFileCreator.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - extracted interface
+ *******************************************************************************/
+package org.eclipse.jdt.internal.launching;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Internal interface to access process temp files
+ */
+interface IProcessTempFileCreator {
+
+	/**
+	 * Necessary files that were created for starting the process. They can be deleted once the process is terminated
+	 *
+	 * @return created files
+	 */
+	List<File> getProcessTempFiles();
+
+}


### PR DESCRIPTION
This is fix for regression from 91ca97311c9424031826c33bac43fcb9fbaac274
, see [1].

The Oracle's tool guide [2] explicitly states:

> Use of the at sign (@) to recursively interpret files isn’t supported.

That was obviously not considered while bug 565902 patching [1].

Changed the code in the way that is either uses explicit argfiles option
if enabled in the launch config, or tries to shorten command line with
more sophisticated approach that also supports Java versions without
@argfiles support (Java < 9). Regression tests added.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=565902
[2] https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-4856361B-8BFD-4964-AE84-121F5F6CF111

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/84