### PR TITLE
Ignore IllegalStateException on class files without sources (#105)

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
@@ -416,14 +416,13 @@ public class JDIStackFrame extends JDIDebugElement implements IJavaStackFrame {
 			ASTParser parser = ASTParser.newParser(AST.JLS11);
 			parser.setResolveBindings(true);
 			parser.setSource(type.getTypeRoot());
-			CompilationUnit cu = (CompilationUnit) parser.createAST(null);
-			List<Location> allLineLocations;
 			try {
-				allLineLocations = getUnderlyingMethod().allLineLocations();
+				CompilationUnit cu = (CompilationUnit) parser.createAST(null);
+				List<Location> allLineLocations = getUnderlyingMethod().allLineLocations();
 				int lineNo = allLineLocations.get(0).lineNumber();
 				cu.accept(new LambdaASTVisitor(false, underlyingThisObject, getUnderlyingMethod().isStatic(), cu, lineNo));
-			} catch (AbsentInformationException e) {
-				// Nothing to be done
+			} catch (AbsentInformationException | IllegalStateException e) {
+				// Nothing to be done - either no source or no line numbers
 			}
 		} catch (CoreException e) {
 			logError(e);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/105