### PR TITLE
Consistently use AST.getJLSLatest() in debugger code (#107)

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugHover.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugHover.java
@@ -482,7 +482,7 @@ public class JavaDebugHover implements IJavaEditorTextHover, ITextHoverExtension
 	private ASTNode findNodeAtRegion(ITypeRoot typeRoot, IRegion hoverRegion) {
 		ASTNode root = SharedASTProviderCore.getAST(typeRoot, SharedASTProviderCore.WAIT_NO, null);
 		if (root == null) {
-			ASTParser parser = ASTParser.newParser(AST.JLS15);
+			ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 			parser.setSource(typeRoot);
 			parser.setFocalPosition(hoverRegion.getOffset());
 			root = parser.createAST(null);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/RunToLineAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/RunToLineAdapter.java
@@ -74,7 +74,7 @@ public class RunToLineAdapter implements IRunToLineTarget {
 						@Override
 						public void run() {
 							lineNumber[0] = textSelection.getStartLine() + 1;
-							ASTParser parser = ASTParser.newParser(AST.JLS15);
+							ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 							parser.setSource(document.get().toCharArray());
 							Map<String, String> options = JavaCore.getOptions();
 							options.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -486,7 +486,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 	private CompilationUnit parseCompilationUnit(char[] source,
 			String unitName, IJavaProject project, Map<String, String> extraCompileOptions) {
-		ASTParser parser = ASTParser.newParser(AST.JLS15);
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(source);
 		parser.setUnitName(unitName);
 		parser.setProject(project);
@@ -685,7 +685,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 						|| problemId == IProblem.NotVisibleMethod
 						|| problemId == IProblem.NotVisibleConstructor
 						|| problemId == IProblem.NotVisibleField
-						|| problemId == IProblem.NotVisibleType 
+						|| problemId == IProblem.NotVisibleType
 						|| problemId == IProblem.UnexpectedStaticModifierForMethod) {
 					continue;
 				}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JavaDebugUtils.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JavaDebugUtils.java
@@ -249,7 +249,7 @@ public class JavaDebugUtils {
 					try {
 						Integer.parseInt(innerTypeName.substring(0, 1)); // throws NFE if not an integer
 						// perform expensive lookup for anonymous types:
-						ASTParser parser = ASTParser.newParser(AST.JLS4);
+						ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 						parser.setResolveBindings(true);
 						parser.setSource(type.getTypeRoot());
 						CompilationUnit cu = (CompilationUnit) parser.createAST(null);

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/hcr/CompilationUnitDelta.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/hcr/CompilationUnitDelta.java
@@ -161,7 +161,7 @@ public class CompilationUnitDelta {
 		char[] buffer = readString(input);
 		if (buffer != null) {
 			if (fParser == null) {
-				fParser = ASTParser.newParser(AST.JLS4);
+				fParser = ASTParser.newParser(AST.getJLSLatest());
 			}
 			fParser.setSource(buffer);
 			fParser.setProject(cu.getJavaProject());

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
@@ -413,7 +413,7 @@ public class JDIStackFrame extends JDIDebugElement implements IJavaStackFrame {
 			if (type == null) {
 				return;
 			}
-			ASTParser parser = ASTParser.newParser(AST.JLS11);
+			ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 			parser.setResolveBindings(true);
 			parser.setSource(type.getTypeRoot());
 			CompilationUnit cu = (CompilationUnit) parser.createAST(null);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/107