### PR TITLE
[19]Make sure JDI addPlatformThreadsOnlyFilter() is skipped in old JDK version

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ThreadReferenceTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ThreadReferenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,11 +8,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.debug.jdi.tests;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import com.sun.jdi.ClassNotLoadedException;
@@ -26,7 +31,10 @@ import com.sun.jdi.ReferenceType;
 import com.sun.jdi.StackFrame;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
+import com.sun.jdi.event.ThreadDeathEvent;
 import com.sun.jdi.event.ThreadStartEvent;
+import com.sun.jdi.request.ThreadDeathRequest;
+import com.sun.jdi.request.ThreadStartRequest;
 
 /**
  * Tests for JDI com.sun.jdi.ThreadReference
@@ -232,5 +240,41 @@ public class ThreadReferenceTest extends AbstractJDITest {
 	 */
 	public void testJDIThreadGroup() {
 		assertNotNull("1", fThread.threadGroup());
+	}
+
+	/**
+	 * Test JDI addPlatformThreadsOnlyFilter() is skipped in old JDK version (<=18).
+	 */
+	public void testJDIPlatformThreadsOnlyFilter() {
+		// Make sure the entire VM is not suspended before we start a new thread
+		// (otherwise this new thread will start suspended and we will never get the
+		// ThreadStart event)
+		fVM.resume();
+
+		// Trigger a thread start event
+		ThreadStartRequest threadStartRequest = fVM.eventRequestManager().createThreadStartRequest();
+		try {
+			java.lang.reflect.Method method = threadStartRequest.getClass().getMethod("addPlatformThreadsOnlyFilter");
+			method.invoke(threadStartRequest);
+		} catch (NoSuchMethodException | SecurityException e) {
+			fail("1");
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			fail("2");
+		}
+		ThreadStartEvent startEvent = (ThreadStartEvent) triggerAndWait(threadStartRequest, "ThreadStartEvent", true, 3000);
+		assertNotNull("3", startEvent);
+
+		// Trigger a thread death event
+		ThreadDeathRequest threadDeathRequest = fVM.eventRequestManager().createThreadDeathRequest();
+		try {
+			java.lang.reflect.Method method = threadDeathRequest.getClass().getMethod("addPlatformThreadsOnlyFilter");
+			method.invoke(threadDeathRequest);
+		} catch (NoSuchMethodException | SecurityException e) {
+			fail("4");
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			fail("5");
+		}
+		ThreadDeathEvent deathEvent = (ThreadDeathEvent) triggerAndWait(threadDeathRequest, "ThreadDeathEvent", true, 3000);
+		assertNotNull("6", deathEvent);
 	}
 }

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/EventRequestImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/request/EventRequestImpl.java
@@ -622,7 +622,7 @@ public abstract class EventRequestImpl extends MirrorImpl implements
 				count += fSourceNameFilters.size();
 			}
 		}
-		if (fPlatformThreadsFilter) {
+		if (fPlatformThreadsFilter && supportsPlatformThreadsFilter()) {
 			count++;
 		}
 		return count;


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>
Change-Id: Ice8a560f1a6e37ad88dbda2a8e76ed306e333479

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This is a bug fix PR. It makes sure the new Virtual Threads JDI capability `addPlatformThreadsOnlyFilter()` is skipped when running in JDK 18 and lower.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Without this PR, run the following JDI test code on JDK 11, it will throw JDI ERROR 113 (An unexpected internal error has occurred).
```java
        ThreadStartRequest threadStartRequest = vm.eventRequestManager().createThreadStartRequest();
        threadStartRequest.setSuspendPolicy(EventRequest.SUSPEND_NONE);
        ((ThreadStartRequestImpl) threadStartRequest).addPlatformThreadsOnlyFilter();
        threadStartRequest.enable();       
```

With this PR, the test code above just ignores the operation `addPlatformThreadsOnlyFilter`.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
