### PR TITLE
Module stack trace lines not parsed correctly Stack Traces Console #119

### DIFF
--- a/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.ui; singleton:=true
-Bundle-Version: 3.12.800.qualifier
+Bundle-Version: 3.12.900.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3503,7 +3503,7 @@ M4 = Platform-specific fourth key
          point="org.eclipse.ui.console.consolePatternMatchListeners">
       <consolePatternMatchListener
             class="org.eclipse.jdt.internal.debug.ui.console.JavaConsoleTracker"
-            regex="\([\w\.\\/]*${java_extensions_regex}\S*\)"
+            regex="\([\w\.\\/@]*${java_extensions_regex}\S*\)"
             qualifier="${java_extensions_regex}"
             flags="UNICODE_CHARACTER_CLASS"
             id="org.eclipse.jdt.debug.ui.JavaConsoleTracker">

--- a/org.eclipse.jdt.debug.ui/pom.xml
+++ b/org.eclipse.jdt.debug.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.ui</artifactId>
-  <version>3.12.800-SNAPSHOT</version>
+  <version>3.12.900-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <code.ignoredWarnings>-warn:+resource,-deprecation,unavoidableGenericProblems</code.ignoredWarnings>

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
@@ -274,6 +274,7 @@ public class JavaStackTraceHyperlink implements IHyperlink {
             // get File name (w/o .java)
             String typeName = linkText.substring(start + 1, end);
             typeName = JavaCore.removeJavaLikeExtension(typeName);
+			typeName = removeModuleInfo(typeName);
 
             String qualifier = linkText.substring(0, start);
             // remove the method name
@@ -372,4 +373,21 @@ public class JavaStackTraceHyperlink implements IHyperlink {
 		}
 	}
 
+	/**
+	 * {@code jstack} can produce stack trace lines such as:
+	 *
+	 * <pre>
+	 *     at java.util.StringJoiner.compactElts(java.base@11.0.10/StringJoiner.java:248)
+	 * </pre>
+	 *
+	 * We remove the module part, since otherwise the type is not determined correctly by this class.
+	 */
+	private static String removeModuleInfo(String typeName) {
+		int atIndex = typeName.lastIndexOf('@');
+		int slashIndex = typeName.lastIndexOf('/');
+		if (atIndex >= 0 && atIndex < slashIndex && slashIndex + 1 < typeName.length()) {
+			typeName = typeName.substring(slashIndex + 1);
+		}
+		return typeName;
+	}
 }


### PR DESCRIPTION
This change adjusts the regexp used for Java stack trace lines in the Java Stack Traces Console, to include the symbol '@' which can be present in stack trace lines printed by jstack. E.g.:

at java.lang.String.join(java.base@11.0.10/String.java:2400)

In addition, JavaStackTraceHyperlink is adjusted to correctly identify the type in such stack trace lines.

Fixes: #119
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
