### PR TITLE
Fix NPE in JavaVariableLabelProvider.determineSerializationMode

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
@@ -220,16 +220,12 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 	 * @param value preference value for PREF_SHOW_DETAILS
 	 */
 	private void determineSerializationMode(String value) {
-		switch (value) {
-			case IJDIPreferencesConstants.INLINE_ALL:
-				fSerializeMode = SERIALIZE_NONE;
-				break;
-			case IJDIPreferencesConstants.INLINE_FORMATTERS:
-				fSerializeMode = SERIALIZE_SOME;
-				break;
-			default:
-				fSerializeMode = SERIALIZE_ALL;
-				break;
+		if (IJDIPreferencesConstants.INLINE_ALL.equals(value)) {
+			fSerializeMode = SERIALIZE_NONE;
+		} else if (IJDIPreferencesConstants.INLINE_FORMATTERS.equals(value)) {
+			fSerializeMode = SERIALIZE_SOME;
+		} else {
+			fSerializeMode = SERIALIZE_ALL;
 		}
 	}
 


### PR DESCRIPTION
If the user in the 'Detail Formatters' preference page, set back the 'Show variable details' to 'In detail pane only' - which is the default value for that field, the PreferenceChangeEvent.newValue will contain null, instead of the default string value. Which triggers a NPE from the switch statement:

```
java.lang.NullPointerException: Cannot invoke "String.hashCode()" because "value" is null
	at org.eclipse.jdt.internal.debug.ui.variables.JavaVariableLabelProvider.determineSerializationMode(JavaVariableLabelProvider.java:189)
	at org.eclipse.jdt.internal.debug.ui.variables.JavaVariableLabelProvider.preferenceChange(JavaVariableLabelProvider.java:260)
	at org.eclipse.core.internal.preferences.EclipsePreferences$2.run(EclipsePreferences.java:841)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.core.internal.preferences.EclipsePreferences.firePreferenceEvent(EclipsePreferences.java:844)
	at org.eclipse.core.internal.preferences.EclipsePreferences.remove(EclipsePreferences.java:951)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.setValue(ScopedPreferenceStore.java:606)
	at org.eclipse.jdt.internal.debug.ui.JavaDetailFormattersPreferencePage.performOk(JavaDetailFormattersPreferencePage.java:355)
	at org.eclipse.jface.preference.PreferenceDialog$7.run(PreferenceDialog.java:905)

```
## What it does
Handle the case, where the string is null

## How to test

Open the 'Detail Formatters' preference page, set the 'Show varialbe details' to various values, and press the Apply and Close button. Notice, that it works, without an NPE.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
