### PR TITLE
Streamline maven-toolchains-plugin used

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -66,7 +66,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-toolchains-plugin</artifactId>
-					<version>1.1</version>
 					<executions>
 						<execution>
 							<phase>validate</phase>

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -55,7 +55,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-toolchains-plugin</artifactId>
-					<version>1.1</version>
 					<executions>
 						<execution>
 							<phase>validate</phase>


### PR DESCRIPTION
Instead of sticking to ancient version just use the version specified in eclipse-parent-pom.
