### PR TITLE
Convert OpenFromClipboardTests to JUnit 4

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -153,6 +153,7 @@ import org.eclipse.jdt.debug.tests.variables.TestIntegerAccessUnboxing15;
 import org.eclipse.jdt.debug.tests.variables.TestLogicalStructures;
 import org.eclipse.jdt.debug.tests.variables.TestLogicalStructuresJava9;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
@@ -332,7 +333,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(ModelPresentationTests.class));
 
 	// Open from Clipboard action tests - Need to use #suite() because the test has a custom setup
-		addTest(OpenFromClipboardTests.suite());
+		addTest(new JUnit4TestAdapter(OpenFromClipboardTests.class));
 
 	//add the complete eval suite
 		addTest(new TestSuite(GeneralEvalTests.class));


### PR DESCRIPTION
## What it does
Simplifies test setup to ease understand test instability as seen in https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/28

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
