### PR TITLE
FileHashing: avoid getCanonicalFile()

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/FileHashing.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/FileHashing.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -53,16 +55,16 @@ public class FileHashing {
 	}
 
 	private static class CacheKey {
-		public final File file;
+		public final Object file;
 
 		private final long length;
 
 		private final long lastModified;
 
-		public CacheKey(File file) throws IOException {
-			this.file = file.getCanonicalFile();
-			this.length = file.length();
-			this.lastModified = file.lastModified();
+		public CacheKey(Object fileKey, BasicFileAttributes attributes) {
+			this.file = fileKey;
+			this.length = attributes.size();
+			this.lastModified = attributes.lastModifiedTime().toMillis();
 		}
 
 		@Override
@@ -141,12 +143,17 @@ public class FileHashing {
 		}
 
 		@Override
-		public Object hash(File file) {
-			if (file == null || !file.isFile()) {
+		public HashCode hash(File file) {
+			if (file == null) {
 				return null;
 			}
 			try {
-				CacheKey cacheKey = new CacheKey(file);
+				BasicFileAttributes attributes = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+				if (!attributes.isRegularFile()) {
+					return null;
+				}
+				Object key= file.getAbsoluteFile().toPath().toAbsolutePath().normalize();
+				CacheKey cacheKey = new CacheKey(key, attributes);
 				synchronized (cache) {
 					HashCode hashCode = cache.get(cacheKey);
 					if (hashCode != null) {


### PR DESCRIPTION
getCanonicalFile() is slow on windows / JDK17 - can costs even more then calculating the SHA1 of the file content, which it is supposed to avoid.

* Instead use normalized path. It does not matter that multiple files could be the same due to symbolic links, it will just recalculate their SHA1 for all of them - which is still faster.
* Also read all file attributes at once.
