### PR TITLE
Disable GC for exception in ExceptionEvent until event is processed

### DIFF
--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/event/ExceptionEventImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/event/ExceptionEventImpl.java
@@ -40,6 +40,8 @@ public class ExceptionEventImpl extends LocatableEventImpl implements
 	private ObjectReferenceImpl fException;
 	/** Location of catch, or 0 if not caught. */
 	private LocationImpl fCatchLocation;
+	/** Whether garbage collection has been re-enabled for the exception. */
+	private boolean fExceptionCollectionEnabled;
 
 	/**
 	 * Creates new ExceptionEventImpl.
@@ -60,6 +62,8 @@ public class ExceptionEventImpl extends LocatableEventImpl implements
 		event.readThreadAndLocation(target, dataInStream);
 		event.fException = ObjectReferenceImpl.readObjectRefWithTag(target,
 				dataInStream);
+		event.fException.disableCollection();
+		event.fExceptionCollectionEnabled = false;
 		event.fCatchLocation = LocationImpl.read(target, dataInStream);
 		return event;
 	}
@@ -78,5 +82,15 @@ public class ExceptionEventImpl extends LocatableEventImpl implements
 	@Override
 	public ObjectReference exception() {
 		return fException;
+	}
+
+	/**
+	 * Enables garbage collection for the exception in the event. GC for the exception is initially disabled, until the exception event is processed.
+	 */
+	public void enableExceptionGC() {
+		if (!fExceptionCollectionEnabled && fException != null) {
+			fException.enableCollection();
+			fExceptionCollectionEnabled = true;
+		}
 	}
 }


### PR DESCRIPTION
This change disables garbage collection for
ExceptionEventImpl.fException, until the event is processed by listeners in EventDispatcher.dispatch().

Fixes: #167

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
