### PR TITLE
Catch and log exceptions from IJDIEventListener during event dispatch

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/EventDispatcher.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/EventDispatcher.java
@@ -153,7 +153,11 @@ public class EventDispatcher implements Runnable {
 					}
 				}
 				vote = true;
-				resume = listener.handleEvent(event, fTarget, !resume, eventSet) && resume;
+				try {
+					resume = listener.handleEvent(event, fTarget, !resume, eventSet) && resume;
+				} catch (Throwable t) {
+					logHandleEventError(listener, event, t);
+				}
 				continue;
 			}
 
@@ -187,7 +191,11 @@ public class EventDispatcher implements Runnable {
 						.get(event.request());
 				if (listener != null) {
 					vote = true;
-					resume = listener.handleEvent(event, fTarget, !resume, eventSet) && resume;
+					try {
+						resume = listener.handleEvent(event, fTarget, !resume, eventSet) && resume;
+					} catch (Throwable t) {
+						logHandleEventError(listener, event, t);
+					}
 					continue;
 				}
 			}
@@ -411,4 +419,7 @@ public class EventDispatcher implements Runnable {
 		}
 	}
 
+	private static void logHandleEventError(IJDIEventListener listener, Event event, Throwable t) {
+		JDIDebugPlugin.logError("Exception occurred while notifying listener: " + listener + ", with event: " + event, t); //$NON-NLS-1$ //$NON-NLS-2$
+	}
 }


### PR DESCRIPTION
IF IJDIEventListener.handleEvent() throws an exception during EventDispatcher.dispatch(), the debugger breaks. Stepping, resuming, terminating, etc. doesn't work.

This change adds a try-catch block around
IJDIEventListener.handleEvent() in EventDispatcher.dispatch(), to ensure faulty listeners don't break the debugger.

Fixes: #172

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
