### PR TITLE
Fix #91: Stack trace detection not working in colored console

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaDebugStackTraceConsoleTest.java
@@ -213,6 +213,31 @@ public class JavaDebugStackTraceConsoleTest extends AbstractJavaStackTraceConsol
 				new String[] { "somewhere1.somewhere2.Some1Class105", "line: 5" }, matchTexts);
 	}
 
+	public void testStackTraceDetectionWithColors() throws Exception {
+		String exception = ""
+				+ "Caused by\033[m: java.lang.NullPointerException: \033[1;31mCannot invoke \"org.eclipse.equinox.internal.provisional.p2.core.eventbus.IProvisioningEventBus.addListener(org.eclipse.equinox.internal.provisional.p2.core.eventbus.ProvisioningListener)\" because \"this.eventBus\" is null\033[m\n"
+				+ "    \033[1mat\033[m org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.<init> (\033[1mAbstractRepositoryManager.java:107\033[m)\n"
+				+ "    \033[1mat\033[m org.eclipse.equinox.internal.p2.artifact.repository.ArtifactRepositoryManager.<init> (\033[1mArtifactRepositoryManager.java:41\033[m)\n"
+				// ...
+				+ "    \033[1mat\033[m java.lang.reflect.Method.invoke (\033[1mMethod.java:568\033[m)\n"
+				+ "    \033[1mat\033[m org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (\033[1mLauncher.java:282\033[m)\n"
+				+ "    \033[1mat\033[m org.codehaus.plexus.classworlds.launcher.Launcher.launch (\033[1mLauncher.java:225\033[m)\n"
+				+ "    \033[1mat\033[m org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (\033[1mLauncher.java:406\033[m)\n"
+				+ "    \033[1mat\033[m org.codehaus.plexus.classworlds.launcher.Launcher.main (\033[1mLauncher.java:347\033[m)\n";
+		consoleDocumentWithText(exception);
+
+		Position[] positions = allLinkPositions();
+		int[] offsets = new int[positions.length];
+		for (int i = 0; i < offsets.length; i++) {
+			offsets[i] = positions[i].getOffset();
+		}
+
+		String[] matchTexts = linkTextsAtPositions(offsets);
+		String[] expected = { "java.lang.NullPointerException", "AbstractRepositoryManager.java:107", "ArtifactRepositoryManager.java:41",
+				"Method.java:568", "Launcher.java:282", "Launcher.java:225", "Launcher.java:406", "Launcher.java:347" };
+		assertArrayEquals("Wrong hyperlinks, listing all links: " + allLinks(), expected, matchTexts);
+	}
+
 	private static String getSelectedText(IEditorPart editor) {
 		ITextEditor textEditor = (ITextEditor) editor;
 		ISelectionProvider selectionProvider = textEditor.getSelectionProvider();

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3503,7 +3503,7 @@ M4 = Platform-specific fourth key
          point="org.eclipse.ui.console.consolePatternMatchListeners">
       <consolePatternMatchListener
             class="org.eclipse.jdt.internal.debug.ui.console.JavaConsoleTracker"
-            regex="\([\w\.\\/@]*${java_extensions_regex}\S*\)"
+            regex="\(${ansi_escape_regex}[\w\.\\/@]*${java_extensions_regex}\S*${ansi_escape_regex}\)"
             qualifier="${java_extensions_regex}"
             flags="UNICODE_CHARACTER_CLASS"
             id="org.eclipse.jdt.debug.ui.JavaConsoleTracker">
@@ -3517,7 +3517,7 @@ M4 = Platform-specific fourth key
       </consolePatternMatchListener>
       <consolePatternMatchListener
             class="org.eclipse.jdt.internal.debug.ui.console.JavaNativeConsoleTracker"
-            regex="\(Native Method\)"
+            regex="\(${ansi_escape_regex}Native Method${ansi_escape_regex}\)"
             qualifier="Native Method"
             id="org.eclipse.jdt.debug.ui.JavaNativeConsoleTracker">
          <enablement>
@@ -3890,4 +3890,15 @@ M4 = Platform-specific fourth key
        </enabledWhen>
     </handler>
  </extension>
+
+ <extension
+       point="org.eclipse.core.variables.valueVariables">
+    <!-- For convenience, to use when we detect stack-trace links -->
+    <variable
+          initialValue="(\033\[[\d;]*[A-HJKSTfimnsu])*"
+          name="ansi_escape_regex"
+          readOnly="true">
+    </variable>
+ </extension>
+
 </plugin>

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaConsoleTracker.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaConsoleTracker.java
@@ -54,12 +54,22 @@ public class JavaConsoleTracker implements IPatternMatchListenerDelegate {
      * @see org.eclipse.ui.console.IPatternMatchListenerDelegate#matchFound(org.eclipse.ui.console.PatternMatchEvent)
      */
     @Override
-	public void matchFound(PatternMatchEvent event) {
+    public void matchFound(PatternMatchEvent event) {
         try {
-            int offset = event.getOffset();
-            int length = event.getLength();
+            int offset = event.getOffset() + 1; // skip the leading (
+            int length = event.getLength() - 2; // don't count the leading ( and trailing )
+
+            String text = fConsole.getDocument().get(offset, length);
+            // Remove the ANSI escape sequences
+            String textNew = text.replaceAll(JavaStackTraceHyperlink.ANSI_ESCAPE_REGEX, ""); //$NON-NLS-1$
+            int delta = text.indexOf(textNew);
+            if (delta != -1) {
+                offset += delta;
+                length = textNew.length();
+            }
+
             IHyperlink link = new JavaStackTraceHyperlink(fConsole);
-            fConsole.addHyperlink(link, offset+1, length-2);
+            fConsole.addHyperlink(link, offset, length);
         } catch (BadLocationException e) {
         }
     }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
@@ -60,7 +60,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  * A hyper-link from a stack trace line of the form "*(*.java:*)"
  */
 public class JavaStackTraceHyperlink implements IHyperlink {
-
+	final static String ANSI_ESCAPE_REGEX = "\033\\[[\\d;]*[A-HJKSTfimnsu]"; //$NON-NLS-1$
 	private final TextConsole fConsole;
 	private final AtomicReference<String> generatedLink;
 	private static final String REGEX_FOR_NORMAL = "([a-zA-Z0-9\\$]+)\\.([a-zA-Z0-9]+)\\(([^)]*)\\)"; //$NON-NLS-1$
@@ -103,6 +103,7 @@ public class JavaStackTraceHyperlink implements IHyperlink {
 		int lineNumber;
 		try {
 			String linkText = getLinkText();
+			linkText = linkText.replaceAll(ANSI_ESCAPE_REGEX, ""); //$NON-NLS-1$
 			generatedLink.set(linkText);
 			typeName = getTypeName(linkText);
 			lineNumber = getLineNumber(linkText);


### PR DESCRIPTION
## What it does

Removes the ANSI escape sequences before detecting links.

## How to test

See https://github.com/eclipse-platform/eclipse.platform/issues/535

The easiest way to reproduce was to create a new project and `println` the stack trace.

Attached a small file reproducing the problem.
I've tested with ANSI Support enabled and disabled, and I've checked that the links work and jump at the proper line.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

[Main.java.zip](https://github.com/eclipse-jdt/eclipse.jdt.debug/files/9895052/Main.java.zip)
