### PR TITLE
POC for Android tests for JDI

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>
     <testSuite>${project.artifactId}</testSuite>
-    <testClass>org.eclipse.debug.jdi.tests.AutomatedSuite</testClass>
+    <testClass>org.eclipse.debug.jdi.tests.AutomatedSuiteAndroidDalvik</testClass>
   </properties>
   <build>
     <outputDirectory>bin</outputDirectory>

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuiteAndroidDalvik.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuiteAndroidDalvik.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Microsoft Corporation - supports virtual threads
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import junit.framework.TestSuite;
+
+/**
+ */
+public class AutomatedSuiteAndroidDalvik extends TestSuite {
+
+	/**
+	 * returns an instance of AutomatedSuite
+	 * @return a new test suite
+	 */
+	public static TestSuite suite() {
+		return new AutomatedSuiteAndroidDalvik();
+	}
+
+	/**
+	 * runs the specified tests
+	 */
+	public AutomatedSuiteAndroidDalvik() {
+		AbstractJDITest.parseArgs(new String[] {"-verbose", "-launcher", "AndroidDalvikVMLauncher"});
+
+		addTest(new TestSuite(AccessibleTest.class));
+		addTest(new TestSuite(ArrayReferenceTest.class));
+		addTest(new TestSuite(ArrayTypeTest.class));
+		addTest(new TestSuite(BooleanValueTest.class));
+		// addTest(new TestSuite(BreakpointRequestTest.class));
+		// addTest(new TestSuite(ByteValueTest.class));
+		// addTest(new TestSuite(CharValueTest.class));
+		// addTest(new TestSuite(ClassLoaderReferenceTest.class));
+		// addTest(new TestSuite(ClassPrepareEventTest.class));
+		// addTest(new TestSuite(ClassPrepareRequestTest.class));
+		// addTest(new TestSuite(ClassTypeTest.class));
+		// addTest(new TestSuite(DoubleValueTest.class));
+		// addTest(new TestSuite(EventRequestManagerTest.class));
+		// addTest(new TestSuite(EventRequestTest.class));
+		// addTest(new TestSuite(EventTest.class));
+		// addTest(new TestSuite(ExceptionEventTest.class));
+		// addTest(new TestSuite(ExceptionRequestTest.class));
+		// addTest(new TestSuite(FieldTest.class));
+		// addTest(new TestSuite(FloatValueTest.class));
+		// addTest(new TestSuite(HotCodeReplacementTest.class));
+		// addTest(new TestSuite(IntegerValueTest.class));
+		// addTest(new TestSuite(InterfaceTypeTest.class));
+		// addTest(new TestSuite(LocalVariableTest.class));
+		// addTest(new TestSuite(LocatableTest.class));
+		// addTest(new TestSuite(LocationTest.class));
+		// addTest(new TestSuite(LongValueTest.class));
+		// addTest(new TestSuite(MethodTest.class));
+		// addTest(new TestSuite(MethodEntryRequestTest.class));
+		// addTest(new TestSuite(MethodExitRequestTest.class));
+		// addTest(new TestSuite(MirrorTest.class));
+
+		// addTest(new TestSuite(ModificationWatchpointEventTest.class));
+
+		// addTest(new TestSuite(ObjectReferenceTest.class));
+		// addTest(new TestSuite(PrimitiveValueTest.class));
+		// addTest(new TestSuite(ReferenceTypeTest.class));
+		// addTest(new TestSuite(ShortValueTest.class));
+		// addTest(new TestSuite(StackFrameTest.class));
+		// addTest(new TestSuite(StepEventTest.class));
+		// addTest(new TestSuite(StringReferenceTest.class));
+		// addTest(new TestSuite(ThreadDeathEventTest.class));
+		// addTest(new TestSuite(ThreadGroupReferenceTest.class));
+		// addTest(new TestSuite(ThreadReferenceTest.class));
+		// addTest(new TestSuite(ThreadStartEventTest.class));
+		// addTest(new TestSuite(TypeComponentTest.class));
+		// addTest(new TestSuite(TypeTest.class));
+		// addTest(new TestSuite(ValueTest.class));
+
+		// addTest(new TestSuite(WatchpointEventTest.class));
+		// addTest(new TestSuite(WatchpointRequestTest.class));
+
+		// addTest(new TestSuite(VirtualMachineExitTest.class));
+		// addTest(new TestSuite(VMDisconnectEventTest.class));
+		// addTest(new TestSuite(VMDisposeTest.class));
+
+		// // Java 1.6 capability tests
+		// addTest(new TestSuite(HeapWalkingTests.class));
+		// addTest(new TestSuite(ConstantPoolTests.class));
+		// addTest(new TestSuite(SourceNameFilterTests.class));
+		// addTest(new TestSuite(MethodReturnValuesTests.class));
+		// addTest(new TestSuite(ForceEarlyReturnTests.class));
+		// addTest(new TestSuite(MonitorFrameInfoTests.class));
+		// addTest(new TestSuite(ProvideArgumentsTests.class));
+		// addTest(new TestSuite(ContendedMonitorTests.class));
+
+		// // Java 19 capability tests
+		// if (Runtime.version().feature() >= 19) {
+		// 	addTest(new TestSuite(VirtualThreadTest.class));
+		// }
+	}
+
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Add ability to run jdi tests on Android to validate compatibility with Dalvik.

When a test targets Dalvik VM, it compiles the test program to a dex file, pushes the file to the Android device/emulator and start a VM there with a port forward for debugging.

## How to test
Requires `d8` and `adb` in PATH and exactly one Android emulator or device attached.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
