### PR TITLE
Execute ProjectClasspathVariableTests with ProjecExplorer

### DIFF
--- a/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.tests; singleton:=true
-Bundle-Version: 3.11.1900.qualifier
+Bundle-Version: 3.11.2000.qualifier
 Bundle-ClassPath: javadebugtests.jar
 Bundle-Activator: org.eclipse.jdt.debug.testplugin.JavaTestPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.tests</artifactId>
-  <version>3.11.1900-SNAPSHOT</version>
+  <version>3.11.2000-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/ProjectClasspathVariableTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/ProjectClasspathVariableTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.jdt.debug.tests.AbstractDebugTest;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartSite;
@@ -46,31 +47,28 @@ public class ProjectClasspathVariableTests extends AbstractDebugTest {
 	 * @param resource resource to select or <code>null</code> if empty
 	 */
 	protected void setSelection(final IResource resource) {
-		Runnable r = new Runnable() {
-			@Override
-			public void run() {
-				IWorkbenchPage page = DebugUIPlugin.getActiveWorkbenchWindow().getActivePage();
-				assertNotNull("the active workbench window page should not be null", page);
-				IViewPart part;
-				try {
-					part = page.showView("org.eclipse.ui.views.ResourceNavigator");
-					assertNotNull("the part org.eclipse.ui.views.ResourceNavigator should not be null", part);
-					ISelection selection = null;
-					if (resource == null) {
-						selection = new StructuredSelection();
-					} else {
-						selection = new StructuredSelection(resource);
-					}
-					IWorkbenchPartSite site = part.getSite();
-					assertNotNull("The part site for org.eclipse.ui.views.ResourceNavigator should not be null ", site);
-					ISelectionProvider provider = site.getSelectionProvider();
-					assertNotNull("the selection provider should not be null for org.eclipse.ui.views.ResourceNavigator", provider);
-					provider.setSelection(selection);
-				} catch (PartInitException e) {
-					assertNotNull("Failed to open navigator view", null);
+		Runnable r = () -> {
+			IWorkbenchPage page = DebugUIPlugin.getActiveWorkbenchWindow().getActivePage();
+			assertNotNull("the active workbench window page should not be null", page);
+			IViewPart part;
+			try {
+				part = page.showView(IPageLayout.ID_PROJECT_EXPLORER);
+				assertNotNull("the part 'Project Explorer' should not be null", part);
+				ISelection selection = null;
+				if (resource == null) {
+					selection = new StructuredSelection();
+				} else {
+					selection = new StructuredSelection(resource);
 				}
-
+				IWorkbenchPartSite site = part.getSite();
+				assertNotNull("The part site for 'Project Explorer' should not be null ", site);
+				ISelectionProvider provider = site.getSelectionProvider();
+				assertNotNull("the selection provider should not be null for 'Project Explorer'", provider);
+				provider.setSelection(selection);
+			} catch (PartInitException e) {
+				assertNotNull("Failed to open 'Project Explorer' view", null);
 			}
+
 		};
 		DebugUIPlugin.getStandardDisplay().syncExec(r);
 	}


### PR DESCRIPTION
## What it does
Navigator view is deprecated and testing with it is not helping anyone.

## How to test
Tests still work

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
