### PR TITLE
Ensure that the mac os parts are installed together

### DIFF
--- a/org.eclipse.jdt.launching.ui.macosx/META-INF/p2.inf
+++ b/org.eclipse.jdt.launching.ui.macosx/META-INF/p2.inf
@@ -1,5 +1,4 @@
 # ensure that the applicable implementation fragment gets installed (bug 361901)
 requires.0.namespace = org.eclipse.equinox.p2.iu
 requires.0.name = org.eclipse.swt.cocoa.macosx.x86_64
-#requires.0.range = [$version$,$version$]
-requires.0.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=x86_64))
+requires.0.filter = (osgi.os=macosx)

--- a/org.eclipse.jdt.launching/META-INF/p2.inf
+++ b/org.eclipse.jdt.launching/META-INF/p2.inf
@@ -1,0 +1,4 @@
+# ensure that the mac os parts are installed together
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.jdt.launching.macosx
+requires.0.filter = (&(osgi.os=macosx)(!(org.eclipse.jdt.buildtime=true)))

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,22 @@
       </repositories>
     </profile>
   </profiles>
+  
+  <build>
+	  <plugins>
+	      <plugin>
+	        <groupId>org.eclipse.tycho</groupId>
+	        <artifactId>target-platform-configuration</artifactId>
+	        <configuration>
+	            <dependency-resolution>
+	                <profileProperties>
+	                    <org.eclipse.jdt.buildtime>true</org.eclipse.jdt.buildtime>
+	                </profileProperties>
+	            </dependency-resolution>
+	        </configuration>
+	    	</plugin>
+	  </plugins>
+  </build>
 
   <modules>
     <module>org.eclipse.jdt.debug</module>


### PR DESCRIPTION
Currently it seems if one only uses org.eclipse.jdt.launching on macos this fails with "Unbound classpath container" because the bundle org.eclipse.jdt.launching.macosx is required.

This adds a p2.inf file that adds a requirement on this at install time.

@merks @akurtakov @iloveeclipse please give this a review, I tried to adapt the SWT approach as much as possible here, I also adapted the existing p2.inf as it previously only contained a filter for x86 but not arm64, as no native code is involved here I think a simple filter for macos is sufficient.