### PR TITLE
Adopt SourceLocationTests to find JRE_CONTAINER

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/sourcelookup/SourceLocationTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/sourcelookup/SourceLocationTests.java
@@ -40,7 +40,7 @@ import org.eclipse.jdt.launching.sourcelookup.PackageFragmentRootSourceLocation;
 public class SourceLocationTests extends AbstractDebugTest {
 
 	public static final String JRE_CONTAINER_1_4_CPE_NAME = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4";
-	public static final String JRE_CONTAINER_1_7_CPE_NAME = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7";
+	public static final String JRE_CONTAINER_1_8_CPE_NAME = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8";
 
 	public SourceLocationTests(String name) {
 		super(name);
@@ -165,7 +165,7 @@ public class SourceLocationTests extends AbstractDebugTest {
 		IClasspathEntry lib = null;
 		for (int i = 0; i < cpes.length; i++) {
 			if (cpes[i].getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
-				if (cpes[i].getPath().equals(new Path(JRE_CONTAINER_1_7_CPE_NAME))) {
+				if (cpes[i].getPath().equals(new Path(JRE_CONTAINER_1_8_CPE_NAME))) {
 					lib = cpes[i];
 					break;
 				}
@@ -206,7 +206,7 @@ public class SourceLocationTests extends AbstractDebugTest {
 		IClasspathEntry lib = null;
 		for (int i = 0; i < cpes.length; i++) {
 			if (cpes[i].getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
-				if (cpes[i].getPath().equals(new Path(JRE_CONTAINER_1_7_CPE_NAME))) {
+				if (cpes[i].getPath().equals(new Path(JRE_CONTAINER_1_8_CPE_NAME))) {
 					lib = cpes[i];
 					break;
 				}

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,6 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
  
-  * This is an implementation of an early-draft specification developed under the Java
-  * Community Process (JCP) and is made available for testing and evaluation purposes
-  * only. The code is not compatible with any specification of the JCP.
- 
   Contributors:
      Igor Fedorenko - initial implementation
 -->
@@ -39,10 +35,6 @@
   <profiles>
     <profile>
       <id>build-individual-bundles</id>
-      <properties>
-      	<eclipse-p2-repo.url>http://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
-      	<skipAPIAnalysis>true</skipAPIAnalysis>
-      </properties>
       <repositories>
         <repository>
           <releases>


### PR DESCRIPTION
This was a regression from ab8481645dc85775232f1c8cff7dce34e104204f.

- Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/212 
- Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/215
