### PR TITLE
Fix for "snippetsupport.jar, if rebuilt, breaks snippet editor" (#217)

### DIFF
--- a/org.eclipse.jdt.debug.ui/Snippet Support/org/eclipse/jdt/internal/debug/ui/snippeteditor/ScrapbookMain1.java
+++ b/org.eclipse.jdt.debug.ui/Snippet Support/org/eclipse/jdt/internal/debug/ui/snippeteditor/ScrapbookMain1.java
@@ -29,5 +29,13 @@ public class ScrapbookMain1 {
 	public static void eval(Class<?> clazz) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		Method method=clazz.getDeclaredMethod("nop", new Class[0]); //$NON-NLS-1$
 		method.invoke(null, new Object[0]);
+		// XXX: if changing this class, make sure to check if
+		// org.eclipse.jdt.internal.debug.ui.snippeteditor.JavaSnippetEditor.SCRAPBOOK_MAIN1_LAST_LINE is still valid
+		// and points to the last line of this method with "method.invoke()" call.
+		// This class is (as of today) MANUALLY compiled and built into org.eclipse.jdt.debug.ui/snippetsupport.jar
+		// which is (as of today) checked into git and NOT rebuilt automatically.
+
+		// See also org.eclipse.jdt.debug.tests.ui.JavaSnippetEditorTest.testEvaluation()
+		// that should catch the inconsistency between JavaSnippetEditor and this code
 	}
 }


### PR DESCRIPTION
The actual fix consists in `==` replaced with `>=` in `lineNumber >= SCRAPBOOK_MAIN1_LAST_LINE`, so we match also if the line moved down (as already happened), the rest is just a bit of (necessary) cleanup.

The fix will not work if the line will be moved up, but for that case we have the `JavaSnippetEditorTest.testEvaluation()` test that should catch the (breaking) inconsistency between `JavaSnippetEditor` and the compiled `ScrapbookMain1` class.

Note: `SCRAPBOOK_MAIN1_LAST_LINE` is still pointing to line 28 (and not 31) to avoid unneeded extra re-compilation / checkin of `org.eclipse.jdt.debug.ui/snippetsupport.jar`
which is (as of today) checked into git and NOT rebuilt automatically.

The content of `snippetsupport.jar` was built and checked into git last time via 051fce25278ddaccf5c402484bf105ce2a390160 and doesn't match *current* content of ScrapbookMain1 that was updated later via 205c5a0c1fcd1d7b72a0af85c79632f7b522d90a without rebuilding the jar file.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/217