### PR TITLE
Ignore 'this' by checking the name of the variable

### DIFF
--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/MethodImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/MethodImpl.java
@@ -561,9 +561,7 @@ public class MethodImpl extends TypeComponentImpl implements Method, Locatable {
 				int slot = readInt("slot", replyData); //$NON-NLS-1$
 				boolean isArgument = slot < fArgumentSlotsCount;
 
-				// Note that for instance methods, the first slot contains the
-				// this reference.
-				if (isStatic() || slot > 0) {
+				if (!name.equals("this")) { //$NON-NLS-1$
 					LocalVariableImpl localVar = new LocalVariableImpl(
 							virtualMachineImpl(), this, codeIndex, name,
 							signature, genericSignature, length, slot,


### PR DESCRIPTION
## What it does
Fix #179, Missing variables when debugging Android apps

- While getting the list of variables for a method, we were skipping the first slot assuming it was a reference to this.
- Though that is not always the case when testing with Android dex files.
- Instead of assuming `this` is at the first slot, check the name of the variable.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->


<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Tested locally, the issue that was reported earlier no longer occurs.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
