### PR TITLE
Limit launch config name length to 10 characters

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchingUtils.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchingUtils.java
@@ -24,6 +24,7 @@ import org.eclipse.debug.core.ILaunch;
  */
 public class JavaLaunchingUtils {
 
+	public static final int MAX_LAUNCH_CONFIG_NAME_LENGTH = 10;
 
 	/**
 	 * Returns the argument file for a launch within the given temp directory
@@ -37,6 +38,9 @@ public class JavaLaunchingUtils {
 	 * @return Created file
 	 */
 	public static File createFileForArgument(String timeStamp, File processTempFilesDir, String launchConfigName, String optionalString) {
+		if (launchConfigName.length() > MAX_LAUNCH_CONFIG_NAME_LENGTH) {
+			launchConfigName = launchConfigName.substring(0, MAX_LAUNCH_CONFIG_NAME_LENGTH);
+		}
 		String child = String.format(org.eclipse.jdt.internal.launching.LaunchingPlugin.LAUNCH_TEMP_FILE_PREFIX
 				+ optionalString, launchConfigName, timeStamp);
 		File argumentsFile = new File(processTempFilesDir, child);


### PR DESCRIPTION
The `createFileForArgument` method in `JavaLaunchingUtils` was generating file names that were too long. This caused some unexpected behavior. To fix this, the maximum launch config name length is limited to 10 characters. If the launch config name is longer than 10 characters, it is truncated to the first 10 characters.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/97
cc @SarikaSinha 