### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,15 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+
+jobs:
+    check:
+       uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishTestResults.yml@master
+
+
+
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,9 @@ pipeline {
 			post {
 				always {
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
-					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
 					junit '**/target/surefire-reports/*.xml'
+					discoverGitReferenceBuild referenceJob: 'eclipse.jdt.debug-github/master'
+					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
- Configure Jenkins build to report differences compared to master branch
- Add unit-tests workflow for test results publishing on github

See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2596