### PR TITLE
Store classpath files outside of workspace. Fixes #240

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMDebugger.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMDebugger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -146,6 +146,9 @@ public class StandardVMDebugger extends StandardVMRunner {
 	@Override
 	public String showCommandLine(VMRunnerConfiguration configuration, ILaunch launch, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor);
+
+		String tempOutputDir = createOutputDir();
+		configuration.setWorkingDirectory(tempOutputDir);
 
 		CommandDetails cmd = getCommandLine(configuration, launch, subMonitor);
 		if (subMonitor.isCanceled()) {


### PR DESCRIPTION
classpath files are stored below user's directory in order to have them accessible easily, for later usage and removal

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
In the dialog Run Configurations, click on "Show Comandline". If there are many or long classpaths, they are collected in a file in order not to exceed the maximum command length (on a Linux system check with `getconf ARG_MAX`). This is also done for actually launching the run, but in that case these files are removed on terminating. When just showing the command line these files remain, in order to have them accessible later (i.e. after closing the dialog). In order not to fill up the workspace this change saves the files outside, below user's home directory.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a project with many JAR files and long paths to them. When the command length of the OS is about to be exceeded, the resulting command changes from listing all files as parameters (-classpath) to a single entry like

`@/home/.../.temp-Main--module-path-arg-1681985065801.txt`

Up to now this file resides in the workspace; with this change it is located at `eclipse-temp` in user's home directory. 

## Author checklist

- [ x] I have thoroughly tested my changes
- [ x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
