### PR TITLE
Delete classpath argument files upon shutdown. Fixes #240

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.20.0.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
@@ -312,7 +312,6 @@ public class ClasspathShortener implements IProcessTempFileCreator {
 			Files.writeString(argFile.toPath(), arg, systemCharset);
 			argFile.deleteOnExit();
 			file = argFile;
-			// createOrUpdateGitIgnore();
 		} catch (IOException e) {
 			throw new CoreException(new Status(IStatus.ERROR, LaunchingPlugin.getUniqueIdentifier(), IStatus.ERROR, "Cannot create " + option //$NON-NLS-1$
 					+ " argument file", e)); //$NON-NLS-1$

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
@@ -32,6 +32,7 @@ import java.util.jar.Manifest;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -66,6 +67,7 @@ public class ClasspathShortener implements IProcessTempFileCreator {
 	private String[] envp;
 	private File processTempFilesDir;
 	private final List<File> processTempFiles = new ArrayList<>();
+	private static final String ARGFILE_TEMPDIR_NAME = "temp"; //$NON-NLS-1$
 
 	/**
 	 *
@@ -291,7 +293,13 @@ public class ClasspathShortener implements IProcessTempFileCreator {
 		String path = cmdLine.get(modulePathArgumentIndex);
 		File file;
 		try {
-			File argFile = JavaLaunchingUtils.createFileForArgument(getLaunchTimeStamp(), processTempFilesDir, getLaunchConfigurationName(), "%s" //$NON-NLS-1$
+			IPath stateLocation = LaunchingPlugin.getDefault().getStateLocation();
+			IPath argFileTmpIPath = stateLocation.append(ARGFILE_TEMPDIR_NAME);
+			File argFileTmpDir = argFileTmpIPath.toFile();
+			if (!argFileTmpDir.exists()) {
+				Files.createDirectory(argFileTmpDir.toPath());
+			}
+			File argFile = JavaLaunchingUtils.createFileForArgument(getLaunchTimeStamp(), argFileTmpDir, getLaunchConfigurationName(), "%s" //$NON-NLS-1$
 					+ option + "-arg-%s.txt"); //$NON-NLS-1$
 
 			String arg = option + " " + quoteWindowsPath(path); //$NON-NLS-1$
@@ -302,7 +310,9 @@ public class ClasspathShortener implements IProcessTempFileCreator {
 						+ systemCharset.displayName() + ".", null)); //$NON-NLS-1$
 			}
 			Files.writeString(argFile.toPath(), arg, systemCharset);
+			argFile.deleteOnExit();
 			file = argFile;
+			// createOrUpdateGitIgnore();
 		} catch (IOException e) {
 			throw new CoreException(new Status(IStatus.ERROR, LaunchingPlugin.getUniqueIdentifier(), IStatus.ERROR, "Cannot create " + option //$NON-NLS-1$
 					+ " argument file", e)); //$NON-NLS-1$

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.20.0-SNAPSHOT</version>
+  <version>3.20.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

View also [original issue](https://github.com/eclipse-platform/eclipse.platform.debug/issues/84) for more information.

## What it does
In the dialog Run Configurations, click on "Show Comandline". If there are many or long classpaths, they are collected in a file in order not to exceed the maximum command length (on a Linux system check with `getconf ARG_MAX`). This is also done for actually launching the run, but in that case these files are removed on terminating the launch. When just showing the command line these files remain, in order to have them accessible later (i.e. after closing the dialog). In this case, i.e. without any process, the GUI has no access to these files. This change marks the files as to be deleted on shutdown of the JVM, and handles them via a .gitignore in order to prevent accidentally committing them.

## How to test
Create a project with many JAR files and long paths to them. When the command length of the OS is about to be exceeded, the resulting command changes from listing all files as parameters (-classpath) to a single entry like

`@/home/.../.temp-Main--module-path-arg-1681985065801.txt`

The files resulting from just showing the commandline are deleted when the JVM is terminated.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
