### PR TITLE
Avoid potential Threadlocal.set(null) memory leak

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
@@ -1616,8 +1616,8 @@ public final class JavaRuntime {
 		} finally {
 			intCount--;
 			if (intCount == 0) {
-				fgProjects.set(null);
-				fgEntryCount.set(null);
+				fgProjects.remove();
+				fgEntryCount.remove();
 			} else {
 				fgEntryCount.set(Integer.valueOf(intCount));
 			}


### PR DESCRIPTION
Threadlocal.set(null) keeps a reference to ThreadLocal.this 
see https://rules.sonarsource.com/java/RSPEC-5164