### PR TITLE
Remove use of OPTION_JdtDebugCompileMode with OPTION_IgnoreUnnamedModuleForSplitPackage

### DIFF
--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -390,7 +390,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			Map<String, String> extraOptions = Collections.emptyMap();
 			// if target runtime is above java 1.8 then switch the compiler to debug mode to ignore java 9 module system
 			if (JavaCore.compareJavaVersions(((IJavaDebugTarget) frame.getDebugTarget()).getVersion(), JavaCore.VERSION_1_8) > 0) {
-				extraOptions = Collections.singletonMap(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
+				extraOptions = Collections.singletonMap(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, JavaCore.ENABLED);
 			}
 
 			unit = parseCompilationUnit(

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JavaLogicalStructure.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JavaLogicalStructure.java
@@ -141,7 +141,7 @@ public class JavaLogicalStructure implements ILogicalStructureType, ILogicalStru
 		 */
 		public IJavaValue evaluate(String snippet) throws DebugException {
 			Map<String, String> compileOptions =
-					Collections.singletonMap(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
+					Collections.singletonMap(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, JavaCore.ENABLED);
 			ICompiledExpression compiledExpression = fEvaluationEngine
 					.getCompiledExpression(snippet, fEvaluationType, compileOptions);
 			if (compiledExpression.hasErrors()) {

--- a/org.eclipse.jdt.debug/pom.xml
+++ b/org.eclipse.jdt.debug/pom.xml
@@ -5,7 +5,7 @@
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
- 
+
   Contributors:
      Igor Fedorenko - initial implementation
 -->
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug</artifactId>
-  <version>3.21.0-SNAPSHOT</version>
+  <version>3.21.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
This change replaces use of `OPTION_JdtDebugCompileMode` with `OPTION_IgnoreUnnamedModuleForSplitPackage`, since the latter does what we need better and doesn't cause the side effects that the first option causes. Goal is to later on remove `OPTION_JdtDebugCompileMode` in JDT core.

Fixes: #260

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
