### PR TITLE
Avoid reusing of not thread-safe SimpleDateFormat

### DIFF
--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -15,10 +15,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.eval.ast.engine;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,7 +188,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	private void traceCaller(String snippet, IThread thread) {
 		if (JDIDebugOptions.DEBUG_AST_EVAL_THREAD_TRACE) {
 			StringBuilder buf = new StringBuilder();
-			buf.append(JDIDebugOptions.FORMAT.format(new Date()));
+			buf.append(JDIDebugOptions.FORMAT.format(Instant.now()));
 			buf.append(" : Evaluation Request Trace - Expression: "); //$NON-NLS-1$
 			buf.append(snippet);
 			buf.append("\n\tThread: "); //$NON-NLS-1$
@@ -780,7 +780,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 		public void run() {
 			if (JDIDebugOptions.DEBUG_AST_EVAL) {
 				StringBuilder buf = new StringBuilder();
-				buf.append(JDIDebugOptions.FORMAT.format(new Date()));
+				buf.append(JDIDebugOptions.FORMAT.format(Instant.now()));
 				buf.append(" : AST Evaluation"); //$NON-NLS-1$
 				buf.append("\n\tExpression: "); //$NON-NLS-1$
 				buf.append(fExpression.getSnippet());

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/MirrorImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/MirrorImpl.java
@@ -18,7 +18,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import org.eclipse.jdi.Bootstrap;
@@ -209,7 +209,7 @@ public class MirrorImpl implements Mirror {
 		long recieved = System.currentTimeMillis();
 		if (JDIDebugOptions.DEBUG_JDI_REQUEST_TIMES) {
 			StringBuilder buf = new StringBuilder();
-			buf.append(JDIDebugOptions.FORMAT.format(new Date(sent)));
+			buf.append(JDIDebugOptions.FORMAT.format(Instant.ofEpochMilli(sent)));
 			buf.append(" JDI Request: "); //$NON-NLS-1$
 			buf.append(commandPacket.toString());
 			buf.append("\n\tResponse Time: "); //$NON-NLS-1$

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JDIDebugOptions.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JDIDebugOptions.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.core;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Hashtable;
 
 import org.eclipse.osgi.service.debug.DebugOptions;
@@ -61,7 +61,7 @@ public class JDIDebugOptions implements DebugOptionsListener {
 	}
 
 	// used to format debug messages
-	public static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"); //$NON-NLS-1$
+	public static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
 
 	/* (non-Javadoc)
 	 * @see org.eclipse.osgi.service.debug.DebugOptionsListener#optionsChanged(org.eclipse.osgi.service.debug.DebugOptions)


### PR DESCRIPTION
  SimpleDateFormat.format(new Date());
returns same string as immutable and thread-safe
  DateTimeFormatter.format(new Date().toInstant())
