### PR TITLE
Change how JrtPackageFragmentRoots are printed in Source tab

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/sourcelookup/WorkbenchAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/sourcelookup/WorkbenchAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
 import org.eclipse.jdt.launching.sourcelookup.containers.ClasspathContainerSourceContainer;
 import org.eclipse.jdt.launching.sourcelookup.containers.ClasspathVariableSourceContainer;
 import org.eclipse.jdt.launching.sourcelookup.containers.JavaProjectSourceContainer;
@@ -36,6 +37,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
  *
  * @since 3.0
  */
+@SuppressWarnings("restriction")
 public class WorkbenchAdapter implements IWorkbenchAdapter {
 	/* (non-Javadoc)
 	 * @see org.eclipse.ui.model.IWorkbenchAdapter#getChildren(java.lang.Object)
@@ -93,21 +95,38 @@ public class WorkbenchAdapter implements IWorkbenchAdapter {
 			PackageFragmentRootSourceContainer container = (PackageFragmentRootSourceContainer) o;
 			IPackageFragmentRoot fragmentRoot = container.getPackageFragmentRoot();
 			IPath path = fragmentRoot.getPath();
-			if (path.segmentCount() > 0) {
+			if (fragmentRoot instanceof JrtPackageFragmentRoot jrtPackageFragmentRoot) {
 				StringBuilder buffer = new StringBuilder();
-				buffer.append(path.lastSegment());
-				if (path.segmentCount() > 1) {
+				buffer.append(jrtPackageFragmentRoot.getElementName());
+				if (path.segmentCount() > 0) {
 					buffer.append(" - "); //$NON-NLS-1$
 					if (path.getDevice() != null) {
 						buffer.append(path.getDevice());
 					}
 					String[] segments = path.segments();
-					for (int i = 0; i < segments.length - 1; i++) {
+					for (String segment : segments) {
 						buffer.append(File.separatorChar);
-						buffer.append(segments[i]);
+						buffer.append(segment);
 					}
+					return buffer.toString();
 				}
-				return buffer.toString();
+			} else {
+				if (path.segmentCount() > 0) {
+					StringBuilder buffer = new StringBuilder();
+					buffer.append(path.lastSegment());
+					if (path.segmentCount() > 1) {
+						buffer.append(" - "); //$NON-NLS-1$
+						if (path.getDevice() != null) {
+							buffer.append(path.getDevice());
+						}
+						String[] segments = path.segments();
+						for (int i = 0; i < segments.length - 1; i++) {
+							buffer.append(File.separatorChar);
+							buffer.append(segments[i]);
+						}
+					}
+					return buffer.toString();
+				}
 			}
 		}
 		return ""; //$NON-NLS-1$


### PR DESCRIPTION
- currently all JrtPackageFragmentRoots are printed using the path which is the same for all modules extracted from a jrt-fs.jar
- change this to print the module name followed by the full jrt-fs.jar path
- fixes #267 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Changes how the JRT modules are printed in the launching Source tab.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Take a Java 9 or higher Java application and create a launch configuration.  In the launch configuration dialog, select the Source tab and click to expand the Default item.  There should be multiple unique modules shown instead of multiple references to the jrt-fs.jar.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
