### PR TITLE
[trivial] Fixed "Redundant specification of type arguments" warnings

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDI Tests
 Bundle-SymbolicName: org.eclipse.jdt.debug.jdi.tests; singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.1.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse
 Require-Bundle: org.junit,

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.jdi.tests</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <code.ignoredWarnings>${tests.ignoredWarnings}</code.ignoredWarnings>

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ClassTypeTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ClassTypeTest.java
@@ -200,7 +200,7 @@ public class ClassTypeTest extends AbstractJDITest {
 		Exception good = null;
 		Exception oops = null;
 		try {
-			fType.invokeMethod(thread, inv2, new ArrayList<Value>(), 0);
+			fType.invokeMethod(thread, inv2, new ArrayList<>(), 0);
 		} catch (InvocationException exc) {
 			good = exc;
 		} catch (Exception exc) {

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/HeapWalkingTests.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/HeapWalkingTests.java
@@ -75,7 +75,7 @@ public class HeapWalkingTests extends AbstractJDITest {
 	public void testGetInstanceCountsUnsupported() {
 		if(is16OrGreater()) {
 			try {
-				fVM.instanceCounts(new ArrayList<ReferenceType>());
+				fVM.instanceCounts(new ArrayList<>());
 			}
 			catch(UnsupportedOperationException uoe) {
 				fail("Threw unsupported exception in 1.6 VM");
@@ -83,7 +83,7 @@ public class HeapWalkingTests extends AbstractJDITest {
 		}
 		else {
 			try {
-				fVM.instanceCounts(new ArrayList<ReferenceType>());
+				fVM.instanceCounts(new ArrayList<>());
 				fail("No exception for non 1.6 VM");
 			}
 			catch(UnsupportedOperationException uoe) {}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ObjectReferenceTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ObjectReferenceTest.java
@@ -260,7 +260,7 @@ public class ObjectReferenceTest extends AbstractJDITest {
 		Method inv = ct.concreteMethodByName("invoke4", "()J");
 		Exception good = null, oops = null;
 		try {
-			fObject.invokeMethod(thread, inv, new ArrayList<Value>(), 0);
+			fObject.invokeMethod(thread, inv, new ArrayList<>(), 0);
 		} catch (ClassNotLoadedException exc) {
 			oops = exc;
 		} catch (IncompatibleThreadStateException exc) {

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ThreadReferenceTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ThreadReferenceTest.java
@@ -26,7 +26,6 @@ import com.sun.jdi.ObjectReference;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.StackFrame;
 import com.sun.jdi.ThreadReference;
-import com.sun.jdi.Value;
 import com.sun.jdi.event.ThreadDeathEvent;
 import com.sun.jdi.event.ThreadStartEvent;
 import com.sun.jdi.request.ThreadDeathRequest;
@@ -194,7 +193,7 @@ public class ThreadReferenceTest extends AbstractJDITest {
 				threadDeathClass.newInstance(
 					thread,
 					constructor,
-					new java.util.LinkedList<Value>(),
+					new java.util.LinkedList<>(),
 					ClassType.INVOKE_SINGLE_THREADED);
 			threadDeath.disableCollection();
 			// This object is going to be used for the lifetime of the VM.

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/WatchpointEventTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/WatchpointEventTest.java
@@ -20,7 +20,6 @@ import com.sun.jdi.StringReference;
 import com.sun.jdi.event.AccessWatchpointEvent;
 import com.sun.jdi.event.ModificationWatchpointEvent;
 import com.sun.jdi.event.WatchpointEvent;
-import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.EventRequestManager;
 
 /**
@@ -80,9 +79,9 @@ public class WatchpointEventTest extends AbstractJDITest {
 		// Delete the event requests we created in this test
 		EventRequestManager requestManager = fVM.eventRequestManager();
 		requestManager.deleteEventRequests(
-			new ArrayList<EventRequest>(requestManager.accessWatchpointRequests()));
+			new ArrayList<>(requestManager.accessWatchpointRequests()));
 		requestManager.deleteEventRequests(
-			new ArrayList<EventRequest>(requestManager.modificationWatchpointRequests()));
+			new ArrayList<>(requestManager.modificationWatchpointRequests()));
 
 		// Set the value of the "fBool" field back to its original value
 		resetField();


### PR DESCRIPTION
Reported by official SDK build since 4.29 for whatever reason

See for example
https://download.eclipse.org/eclipse/downloads/drops4/I20230621-1800/compilelogs/plugins/org.eclipse.jdt.debug.jdi.tests_1.1.0.v20230328-1614/@dot.html#OTHER_WARNINGS