### PR TITLE
Records with inner records breaks breakpoint toggling

### DIFF
--- a/org.eclipse.jdt.debug.tests/java16_/a/b/c/RecordInnerTests.java
+++ b/org.eclipse.jdt.debug.tests/java16_/a/b/c/RecordInnerTests.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package a.b.c;
+public record Test(int a, int b) {
+
+	  public void x() {
+	    return; // <- Toggling a breakpoint here toggles it on TestInner
+	  }
+
+	  public int y() {
+	    return a + b; // <- Toggling a breakpoint here toggles it on TestInner
+	  }
+
+	  public record TestInner() {
+		  static int c;
+		  public void getI() {
+		   System.out.println(c);
+		  }
+		 
+	  }
+
+	  public int z() {
+	    return a + b; // <- Toggling a breakpoint here toggles it here as expected
+	  }
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/RecordBreakpointTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/RecordBreakpointTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -51,6 +51,20 @@ public class RecordBreakpointTests extends AbstractDebugTest {
 			// create a classLoad breakpoint to test
 			IJavaLineBreakpoint lineBreakpoint = createLineBreakpoint(17, "a.b.c.RecordTests");
 			assertEquals("wrong type name", "a.b.c.RecordTests", lineBreakpoint.getTypeName());
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			removeAllBreakpoints();
+		}
+	}
+
+	public void testInnerRecordLineBreakpoint() throws Exception {
+
+		try {
+			// create a classLoad breakpoint to test
+			IJavaLineBreakpoint lineBreakpoint = createLineBreakpoint(18, "a.b.c.RecordInnerTests");
+			assertEquals("wrong type name", "a.b.c.RecordInnerTests", lineBreakpoint.getTypeName());
+			assertEquals("Breakpoint not at line number 18", 18, lineBreakpoint.getLineNumber());
 		} catch (Exception e) {
 			throw e;
 		} finally {

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -341,6 +341,7 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 		int startPosition = node.getStartPosition();
 		int startLine = lineNumber(startPosition);
 		int endLine = lineNumber(startPosition + node.getLength() - 1);
+		int inputEndLine = fInputOffset != -1 ? lineNumber(fInputOffset) : -1;
 
 		// if we already found a correct location
 		// no need to check the element inside if the line number doesn't match.
@@ -359,7 +360,8 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 		// breakpoint is requested on this line or on a previous line, this is a
 		// valid
 		// location
-		if (isCode && (fLineNumber <= startLine)) {
+		// Need to check also that this Node is within the input boundary - applicable for Record
+		if (isCode && (fLineNumber <= startLine) && (inputEndLine == -1 || startLine <= inputEndLine)) {
 			fLineLocation = startLine;
 			fLocationFound = true;
 			fLocationType = LOCATION_LINE;


### PR DESCRIPTION
fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/270

Boundary for Breakpoint should be checked

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
