### PR TITLE
Remove whitespace in URL in 2 .exsd files

### DIFF
--- a/org.eclipse.jdt.launching/schema/vmInstallTypes.exsd
+++ b/org.eclipse.jdt.launching/schema/vmInstallTypes.exsd
@@ -93,7 +93,7 @@ A UI for managing &lt;code&gt;IVMInstall&lt;/code&gt;s is provided by the Java D
       </appInfo>
       <documentation>
          Abstract implementations of IVMInstall and IVMInstallType are provided.  The Java development tooling defines a VM
-install type for the standard 1.1.* level JRE, and an install type for JREs conforming to standard command line options (1.2, 1.3, 1.4, 5.0, 6.0, and 7.0 level JREs). As well an install type is provided for JREs defined by an &lt;a href=&quot; http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment description&lt;/a&gt; file.
+install type for the standard 1.1.* level JRE, and an install type for JREs conforming to standard command line options (1.2, 1.3, 1.4, 5.0, 6.0, and 7.0 level JREs). As well an install type is provided for JREs defined by an &lt;a href=&quot;http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment description&lt;/a&gt; file.
       </documentation>
    </annotation>
 

--- a/org.eclipse.jdt.launching/schema/vmInstalls.exsd
+++ b/org.eclipse.jdt.launching/schema/vmInstalls.exsd
@@ -79,7 +79,7 @@
          <attribute name="home" type="string" use="required">
             <annotation>
                <documentation>
-                  Path to the home installation directory for this VM install. Paths must be absolute and may use string substitution variables such as ${eclipse_home}. Since 3.4, this attribute may reference a VM definition file in addition to a home directory. The Execution Environment VM type included with the SDK supports &lt;a href=&quot; http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment descriptions&lt;/a&gt;. When an execution environment description file is specified, any library elements are ignored. In this case, libraries are defined by the execution environment description file.
+                  Path to the home installation directory for this VM install. Paths must be absolute and may use string substitution variables such as ${eclipse_home}. Since 3.4, this attribute may reference a VM definition file in addition to a home directory. The Execution Environment VM type included with the SDK supports &lt;a href=&quot;http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment descriptions&lt;/a&gt;. When an execution environment description file is specified, any library elements are ignored. In this case, libraries are defined by the execution environment description file.
                </documentation>
             </annotation>
          </attribute>


### PR DESCRIPTION
The spaces might be the reason the test `LinkTest.testAllLinks()` is failing (see [Ed's comment](https://github.com/eclipse-platform/eclipse.platform/issues/561#issuecomment-1623618975) in #561).

Sadly the easiest way to test this is by merging this PR and then letting the tests run in the repository  [eclipse.platform](https://github.com/eclipse-platform/eclipse.platform). [This guide](https://github.com/eclipse-platform/eclipse.platform/tree/master/ua/infocenter-web) was intended to show how to run the tests locally, but it is outdated/unclear (any hints on how to improve the guide are also appreciated and I can test them and push them in another PR).