### PR TITLE
Fix html links in VMInstall(Type) Extension-Point documentation

### DIFF
--- a/org.eclipse.jdt.launching/schema/vmInstallTypes.exsd
+++ b/org.eclipse.jdt.launching/schema/vmInstallTypes.exsd
@@ -93,7 +93,7 @@ A UI for managing &lt;code&gt;IVMInstall&lt;/code&gt;s is provided by the Java D
       </appInfo>
       <documentation>
          Abstract implementations of IVMInstall and IVMInstallType are provided.  The Java development tooling defines a VM
-install type for the standard 1.1.* level JRE, and an install type for JREs conforming to standard command line options (1.2, 1.3, 1.4, 5.0, 6.0, and 7.0 level JREs). As well an install type is provided for JREs defined by an &lt;a href=&quot; http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment description&lt;/a&gt; file.
+install type for the standard 1.1.* level JRE, and an install type for JREs conforming to standard command line options (1.2, 1.3, 1.4, 5.0, 6.0, and 7.0 level JREs). As well an install type is provided for JREs defined by an &lt;a href=&quot;http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment description&lt;/a&gt; file.
       </documentation>
    </annotation>
 

--- a/org.eclipse.jdt.launching/schema/vmInstalls.exsd
+++ b/org.eclipse.jdt.launching/schema/vmInstalls.exsd
@@ -79,7 +79,7 @@
          <attribute name="home" type="string" use="required">
             <annotation>
                <documentation>
-                  Path to the home installation directory for this VM install. Paths must be absolute and may use string substitution variables such as ${eclipse_home}. Since 3.4, this attribute may reference a VM definition file in addition to a home directory. The Execution Environment VM type included with the SDK supports &lt;a href=&quot; http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment descriptions&lt;/a&gt;. When an execution environment description file is specified, any library elements are ignored. In this case, libraries are defined by the execution environment description file.
+                  Path to the home installation directory for this VM install. Paths must be absolute and may use string substitution variables such as ${eclipse_home}. Since 3.4, this attribute may reference a VM definition file in addition to a home directory. The Execution Environment VM type included with the SDK supports &lt;a href=&quot;http://wiki.eclipse.org/Execution_Environment_Descriptions&quot;&gt;execution environment descriptions&lt;/a&gt;. When an execution environment description file is specified, any library elements are ignored. In this case, libraries are defined by the execution environment description file.
                </documentation>
             </annotation>
          </attribute>


### PR DESCRIPTION
## What it does
Remove the space in the extension-point documentation that is likely causing a test-failure in the eclipse.platform git repo.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
