### PR TITLE
Add ExecutionEnvironmentDescription(Map) constructor and simplify EEDescription implementation

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/EEDefinitionTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/EEDefinitionTests.java
@@ -17,7 +17,6 @@ package org.eclipse.jdt.debug.tests.core;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -160,7 +159,7 @@ public class EEDefinitionTests extends AbstractDebugTest {
 		File file = getEEFile();
 		assertNotNull("Missing EE file", file);
 		ExecutionEnvironmentDescription ee = new ExecutionEnvironmentDescription(file);
-		URL location = EEVMType.getJavadocLocation(ee.getProperties());
+		URL location = EEVMType.getJavadocLocation(ee);
 		URL expectedLocation = null;
 		try {
 			expectedLocation = new URL("http://a.javadoc.location");
@@ -180,7 +179,7 @@ public class EEDefinitionTests extends AbstractDebugTest {
 		File file = getEEFile();
 		assertNotNull("Missing EE file", file);
 		ExecutionEnvironmentDescription ee = new ExecutionEnvironmentDescription(file);
-		URL location = EEVMType.getIndexLocation(ee.getProperties());
+		URL location = EEVMType.getIndexLocation(ee);
 		URL expectedLocation = null;
 		try {
 			expectedLocation = new URL("http://a.index.location");
@@ -274,18 +273,17 @@ public class EEDefinitionTests extends AbstractDebugTest {
 		File file = getEEFile();
 		assertNotNull("Missing EE file", file);
 		ExecutionEnvironmentDescription desc = new ExecutionEnvironmentDescription(file);
-		Map<String, String> map = desc.getProperties();
 
 		// validate expected properties
-		validateProperty(ExecutionEnvironmentDescription.EXECUTABLE, "jrew.txt" , map);
-		validateProperty(ExecutionEnvironmentDescription.EXECUTABLE_CONSOLE, "jre.txt", map);
-		validateProperty("-XspecialArg:123", "", map);
-		validateProperty("-XspecialArg2", "456", map);
+		validateProperty(ExecutionEnvironmentDescription.EXECUTABLE, "jrew.txt", desc);
+		validateProperty(ExecutionEnvironmentDescription.EXECUTABLE_CONSOLE, "jre.txt", desc);
+		validateProperty("-XspecialArg:123", "", desc);
+		validateProperty("-XspecialArg2", "456", desc);
 
 	}
 
-	protected void validateProperty(String key, String value, Map<String, String> properties) {
-		assertEquals("Unexpeted value for: " + key, value, properties.get(key));
+	protected void validateProperty(String key, String value, ExecutionEnvironmentDescription ee) {
+		assertEquals("Unexpeted value for: " + key, value, ee.getProperty(key));
 	}
 
 	/**
@@ -295,6 +293,6 @@ public class EEDefinitionTests extends AbstractDebugTest {
 		File file = getEEFile();
 		assertNotNull("Missing EE file", file);
 		ExecutionEnvironmentDescription ee = new ExecutionEnvironmentDescription(file);
-		validateProperty("-Dee.empty", "", ee.getProperties());
+		validateProperty("-Dee.empty", "", ee);
 	}
 }

--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EEVMType.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EEVMType.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -56,11 +55,11 @@ public class EEVMType extends AbstractVMInstallType {
 	 * Returns the default javadoc location specified in the properties or <code>null</code>
 	 * if none.
 	 *
-	 * @param properties properties map
+	 * @param eeDescription the execution-environment to query
 	 * @return javadoc location specified in the properties or <code>null</code> if none
 	 */
-	public static URL getJavadocLocation(Map<String, String> properties) {
-		String javadoc = getProperty(ExecutionEnvironmentDescription.JAVADOC_LOC, properties);
+	public static URL getJavadocLocation(ExecutionEnvironmentDescription eeDescription) {
+		String javadoc = eeDescription.getProperty(ExecutionEnvironmentDescription.JAVADOC_LOC);
 		if (javadoc != null && javadoc.length() > 0){
 			try{
 				URL url = new URL(javadoc);
@@ -77,7 +76,7 @@ public class EEVMType extends AbstractVMInstallType {
 				return null;
 			}
 		}
-		String version = getProperty(ExecutionEnvironmentDescription.LANGUAGE_LEVEL, properties);
+		String version = eeDescription.getProperty(ExecutionEnvironmentDescription.LANGUAGE_LEVEL);
 		if (version != null) {
 			return StandardVMType.getDefaultJavadocLocation(version);
 		}
@@ -88,12 +87,12 @@ public class EEVMType extends AbstractVMInstallType {
 	 * Returns the default index location specified in the properties or <code>null</code>
 	 * if none.
 	 *
-	 * @param properties properties map
+	 * @param eeDescription the execution-environment to query
 	 * @return index location specified in the properties or <code>null</code> if none
 	 * @since 3.7.0
 	 */
-	public static URL getIndexLocation(Map<String, String> properties) {
-		String index = getProperty(ExecutionEnvironmentDescription.INDEX_LOC, properties);
+	public static URL getIndexLocation(ExecutionEnvironmentDescription eeDescription) {
+		String index = eeDescription.getProperty(ExecutionEnvironmentDescription.INDEX_LOC);
 		if (index != null && index.length() > 0){
 			try{
 				URL url = new URL(index);
@@ -129,18 +128,6 @@ public class EEVMType extends AbstractVMInstallType {
 			}
 		}
 		return Status.OK_STATUS;
-	}
-
-	/**
-	 * Returns the specified property value from the given map, as a {@link String},
-	 * or <code>null</code> if none.
-	 *
-	 * @param property the name of the property
-	 * @param properties property map
-	 * @return value or <code>null</code>
-	 */
-	private static String getProperty(String property, Map<String, String> properties) {
-		return properties.get(property);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.java
@@ -46,8 +46,6 @@ public class LaunchingMessages extends NLS {
 	public static String EEVMType_5;
 	public static String EEVMType_6;
 
-	public static String ExecutionEnvironmentDescription_0;
-
 	public static String ExecutionEnvironmentDescription_1;
 
 	public static String JavaLocalApplicationLaunchConfigurationDelegate_Verifying_launch_attributes____1;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
@@ -60,7 +60,7 @@ JavaRuntime_25=JRE
 JavaRuntime_32=Unable to restore classpath entry.
 LaunchingPlugin_32=Unable to create runtime classpath entry for unknown type {0}
 LaunchingPlugin_34=Unable to create XML parser.
-LaunchingPlugin_35=Build path specifies execution environment {0}. There are no JREs installed in the workspace that are strictly compatible with this environment. 
+LaunchingPlugin_35=Build path specifies execution environment {0}. There are no JREs installed in the workspace that are strictly compatible with this environment.
 LaunchingPlugin_36=Build path specifies execution environment {0}. A compatible JRE is available but has been overridden.
 LaunchingPlugin_37=Build path
 LaunchingPlugin_38=Build path specifies execution environment {0}. There are no compatible JREs installed in the workspace.
@@ -190,7 +190,6 @@ EEVMType_3=Install location (-Djava.home) does not exist: {0}
 EEVMType_4=Unable to validate install location
 EEVMType_5=Problem with EE file -Dee.source.map property. Wildcards in source location do not match wildcards in library location. Entry was: {0}
 EEVMType_6=Problem with EE file -Dee.source.map property. Library location and source location must be separated by a ''='' character. Entry was: {0}
-ExecutionEnvironmentDescription_0=Description file not found {0}
 ExecutionEnvironmentDescription_1=Error reading description file {0}
 MacInstalledJREs_0=Parsing installed VM information
 MacInstalledJREs_1=Found installed JRE: {0} ({1})

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
@@ -3431,7 +3431,7 @@ public final class JavaRuntime {
 			standin.setInstallLocation(new File(home));
 			standin.setLibraryLocations(description.getLibraryLocations());
 			standin.setVMArgs(description.getVMArguments());
-			standin.setJavadocLocation(EEVMType.getJavadocLocation(description.getProperties()));
+			standin.setJavadocLocation(EEVMType.getJavadocLocation(description));
 			standin.setAttribute(EEVMInstall.ATTR_EXECUTION_ENVIRONMENT_ID, description.getProperty(ExecutionEnvironmentDescription.CLASS_LIB_LEVEL));
 			File exe = description.getExecutable();
 			if (exe == null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
@@ -310,7 +310,7 @@ public final class ExecutionEnvironmentDescription {
 				arguments.append(key);
 				if (!value.isEmpty()) {
 					arguments.append('=');
-					value = resolveHome(value, eeHome);
+					value = resolveHome(value, eeHome); // TODO: remove once getProperties() has been removed
 					if (value.indexOf(' ') > -1) {
 						arguments.append('"').append(value).append('"');
 					} else {
@@ -597,7 +597,7 @@ public final class ExecutionEnvironmentDescription {
 	 * @return javadoc location or <code>null</code> if none
 	 */
 	private URL getJavadocLocation() {
-		return EEVMType.getJavadocLocation(fProperties);
+		return EEVMType.getJavadocLocation(this);
 	}
 
 	/**
@@ -607,6 +607,6 @@ public final class ExecutionEnvironmentDescription {
 	 * @since 3.7.0
 	 */
 	private URL getIndexLocation() {
-		return EEVMType.getIndexLocation(fProperties);
+		return EEVMType.getIndexLocation(this);
 	}
 }

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
@@ -195,7 +195,19 @@ public final class ExecutionEnvironmentDescription {
 	 * @throws CoreException if unable to read or parse the file
 	 */
 	public ExecutionEnvironmentDescription(File eeFile) throws CoreException {
-		this.fProperties = loadProperties(eeFile);
+		this.fProperties = resolveEEHome(loadProperties(eeFile));
+	}
+
+	/**
+	 * Creates an execution environment description based on the given execution environment description properties. The contained properties are
+	 * defined in <code>https://wiki.eclipse.org/Execution_Environment_Descriptions</code>.
+	 *
+	 * @param eeProperties execution environment description properties
+	 * @throws CoreException if unable to read or parse the file
+	 * @since 3.21
+	 */
+	public ExecutionEnvironmentDescription(Map<String, String> eeProperties) {
+		this.fProperties = resolveEEHome(new LinkedHashMap<>(eeProperties)); // defensive copy
 	}
 
 	/**
@@ -375,10 +387,13 @@ public final class ExecutionEnvironmentDescription {
 					eeFile.getPath() }), e));
 		}
 		properties.putIfAbsent(EE_HOME, eeFile.getParentFile().getAbsolutePath());
-		// resolve things with ${ee.home} in them
-		String eeHome = properties.get(EE_HOME);
-		properties.replaceAll((k, value) -> value != null ? resolveHome(value, eeHome) : ""); //$NON-NLS-1$
 		return properties;
+	}
+
+	private static Map<String, String> resolveEEHome(Map<String, String> eeProperties) { // resolve things with ${ee.home} in them
+		String eeHome = eeProperties.get(EE_HOME);
+		eeProperties.replaceAll((k, value) -> value != null ? resolveHome(value, eeHome) : ""); //$NON-NLS-1$
+		return eeProperties;
 	}
 
 	/**

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.20.200-SNAPSHOT</version>
+  <version>3.21.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
This PR consists of two commits to enhance `ExecutionEnvironmentDescription`.
1. commits simplifies the code to read EE-files during construction of `ExecutionEnvironmentDescription` and applies a few more minor code clean-ups
2. commit adds a new constructor `ExecutionEnvironmentDescription(Map)` that allows to create a EEDescription from a Map directly.
One use-case for this are for example PDE's API-tools that generate the EE file in (at least) one case, just to let the `EEDescription` read it again.


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
