### PR TITLE
Fixes #290 - complete the removal of com.ibm.icu dependency

### DIFF
--- a/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -48,7 +48,6 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.console;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.jdt.core.manipulation;bundle-version="[1.16.0,2.0.0)",
  org.eclipse.search;bundle-version="[3.5.0,4.0.0)",
- com.ibm.icu,
  org.eclipse.ui.forms;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.resources,
  org.eclipse.debug.core;bundle-version="[3.12.0,4.0.0)"

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDISourceViewer.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDISourceViewer.java
@@ -14,6 +14,8 @@
 package org.eclipse.jdt.internal.debug.ui;
 
 
+import java.text.Bidi;
+
 import org.eclipse.jdt.internal.debug.ui.display.DisplayViewerConfiguration;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.text.IJavaPartitions;
@@ -45,8 +47,6 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-
-import com.ibm.icu.text.Bidi;
 
 /**
  * A source viewer configured to display Java source. This
@@ -360,7 +360,6 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 
 		int segmentIndex= 1;
 		int[] segments= new int[lineLength + 1];
-		byte[] levels= bidi.getLevels();
 		int nPartitions= linePartitioning.length;
 		for (int partitionIndex= 0; partitionIndex < nPartitions; partitionIndex++) {
 
@@ -368,7 +367,8 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 			int lineOffset= partition.getOffset() - lineStart;
 			//Assert.isTrue(lineOffset >= 0 && lineOffset < lineLength);
 
-			if (lineOffset > 0 && isMismatchingLevel(levels[lineOffset], baseLevel) && isMismatchingLevel(levels[lineOffset - 1], baseLevel)) {
+			if (lineOffset > 0 && isMismatchingLevel(bidi.getLevelAt(lineOffset), baseLevel)
+					&& isMismatchingLevel(bidi.getLevelAt(lineOffset - 1), baseLevel)) {
 				// Indicate a Bidi segment at the partition start - provided
 				// levels of both character at the current offset and its
 				// preceding character mismatch the base paragraph level.
@@ -379,7 +379,8 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 			if (IDocument.DEFAULT_CONTENT_TYPE.equals(partition.getType())) {
 				int partitionEnd= Math.min(lineLength, lineOffset + partition.getLength());
 				while (++lineOffset < partitionEnd) {
-					if (isMismatchingLevel(levels[lineOffset], baseLevel) && String.valueOf(lineText.charAt(lineOffset)).matches(BIDI_DELIMITERS)) {
+					if (isMismatchingLevel(bidi.getLevelAt(lineOffset), baseLevel)
+							&& String.valueOf(lineText.charAt(lineOffset)).matches(BIDI_DELIMITERS)) {
 						// For default content types, indicate a segment before
 						// a delimiting character with a mismatching embedding
 						// level.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Completes the removal of dependency on com.ibm.icu

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I am not sure how to test this, however, reading the code for java.text and com.ibm.icu.text shows that getLevelAt should be a reasonable replacement for getLevels(). 

## Author checklist

- [ ] I have thoroughly tested my changes - No, I am not 100% sure how to test this
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
