### PR TITLE
Fix UnsupportedOperationException in DetectVMInstallationsJob

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.internal.launching;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,7 +63,7 @@ class DetectVMInstallationsJob extends Job {
 		// for MacOS, system installed VMs need a special command to locate
 		if (Platform.OS_MACOSX.equals(Platform.getOS())) {
 			try {
-				systemVMs = Arrays.asList(MacInstalledJREs.getInstalledJREs(monitor));
+				systemVMs = new ArrayList<>(Arrays.asList(MacInstalledJREs.getInstalledJREs(monitor)));
 				systemVMs.removeIf(t -> knownVMs.contains(t.getInstallLocation()));
 				for (VMStandin systemVM : systemVMs) {
 					candidates.removeIf(t -> t.equals(systemVM.getInstallLocation()));


### PR DESCRIPTION
- fixes #289

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes UnsupportedOperationException thrown in DetectVMInstallationsJob on Mac

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start up Eclipse a second time after JVMs are populated.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
