### PR TITLE
DetectVMInstallationsJob: defer detection until needed.

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingPlugin.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingPlugin.java
@@ -57,7 +57,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -583,14 +582,6 @@ public class LaunchingPlugin extends Plugin implements DebugOptionsListener, IEc
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.PRE_DELETE | IResourceChangeEvent.PRE_CLOSE);
 		DebugPlugin.getDefault().getLaunchManager().addLaunchListener(this);
 		DebugPlugin.getDefault().addDebugEventListener(this);
-		boolean forcedDisableVMDetection = Boolean.getBoolean(DetectVMInstallationsJob.class.getSimpleName() + ".disabled"); //$NON-NLS-1$
-		IEclipsePreferences instanceNode = InstanceScope.INSTANCE.getNode(getBundle().getSymbolicName());
-		IEclipsePreferences defaultNode = DefaultScope.INSTANCE.getNode(getBundle().getSymbolicName());
-		boolean defaultValue = defaultNode.getBoolean(PREF_DETECT_VMS_AT_STARTUP, true);
-		if (!forcedDisableVMDetection && instanceNode.getBoolean(PREF_DETECT_VMS_AT_STARTUP, defaultValue)) {
-			new DetectVMInstallationsJob().schedule();
-		}
-
 		AdvancedSourceLookupSupport.start();
 	}
 

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -79,6 +80,7 @@ import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.launching.CompositeId;
 import org.eclipse.jdt.internal.launching.DefaultEntryResolver;
 import org.eclipse.jdt.internal.launching.DefaultProjectClasspathEntry;
+import org.eclipse.jdt.internal.launching.DetectVMInstallationsJob;
 import org.eclipse.jdt.internal.launching.EEVMInstall;
 import org.eclipse.jdt.internal.launching.EEVMType;
 import org.eclipse.jdt.internal.launching.JREContainerInitializer;
@@ -328,7 +330,7 @@ public final class JavaRuntime {
 	public static final String CLASSPATH_ATTR_LIBRARY_PATH_ENTRY =  LaunchingPlugin.getUniqueIdentifier() + ".CLASSPATH_ATTR_LIBRARY_PATH_ENTRY"; //$NON-NLS-1$
 
 	// lock for VM initialization
-	private static Object fgVMLock = new Object();
+	private static final Object fgVMLock = new Object();
 	private static boolean fgInitializingVMs = false;
 
 	private static HashSet<Object> fgVMTypes = null;
@@ -351,26 +353,26 @@ public final class JavaRuntime {
 	/**
 	 * Default classpath and source path providers.
 	 */
-	private static IRuntimeClasspathProvider fgDefaultClasspathProvider = new StandardClasspathProvider();
-	private static IRuntimeClasspathProvider fgDefaultSourcePathProvider = new StandardSourcePathProvider();
+	private static final IRuntimeClasspathProvider fgDefaultClasspathProvider = new StandardClasspathProvider();
+	private static final IRuntimeClasspathProvider fgDefaultSourcePathProvider = new StandardSourcePathProvider();
 
 	/**
 	 * VM change listeners
 	 */
-	private static ListenerList<IVMInstallChangedListener> fgVMListeners = new ListenerList<>();
+	private static final ListenerList<IVMInstallChangedListener> fgVMListeners = new ListenerList<>();
 
 	/**
 	 * Cache of already resolved projects in container entries. Used to avoid
 	 * cycles in project dependencies when resolving classpath container entries.
 	 * Counters used to know when entering/exiting to clear cache
 	 */
-	private static ThreadLocal<List<IJavaProject>> fgProjects = new ThreadLocal<>(); // Lists
-	private static ThreadLocal<Integer> fgEntryCount = new ThreadLocal<>(); // Integers
+	private static final ThreadLocal<List<IJavaProject>> fgProjects = new ThreadLocal<>(); // Lists
+	private static final ThreadLocal<Integer> fgEntryCount = new ThreadLocal<>(); // Integers
 
     /**
      *  Set of IDs of VMs contributed via vmInstalls extension point.
      */
-    private static Set<String> fgContributedVMs = new HashSet<>();
+	private static final Set<String> fgContributedVMs = ConcurrentHashMap.newKeySet();
 
 	/**
 	 * This class contains only static methods, and is not intended
@@ -3268,8 +3270,7 @@ public final class JavaRuntime {
 							VMStandin vmStandin = (VMStandin) vmListIterator.next();
 							vmStandin.convertToRealVM();
 						}
-
-
+						DetectVMInstallationsJob.initialize();
 					} catch (IOException e) {
 						LaunchingPlugin.log(e);
 					}

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -51,11 +51,6 @@
           <plugin>
              <groupId>org.eclipse.tycho</groupId>
              <artifactId>tycho-surefire-plugin</artifactId>
-             <configuration>
-               <systemProperties>
-                 <DetectVMInstallationsJob.disabled>true</DetectVMInstallationsJob.disabled>
-               </systemProperties>
-             </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
So that it does not run in jdt.core tests at all

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1190
