### PR TITLE
Improve lambda type check by name for java21. Fix #300

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/LambdaUtils.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/LambdaUtils.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +42,7 @@ import com.sun.jdi.Method;
 public class LambdaUtils {
 
 	private static final String LAMBDA_METHOD_PREFIX = "lambda$"; //$NON-NLS-1$
+	private static final Pattern LAMBDA_TYPE_PATTERN = Pattern.compile(".*\\$\\$Lambda[\\$,\\.].*"); //$NON-NLS-1$
 
 	/**
 	 * Inspects the top stack frame of the context; if that frame is a lambda frame, looks for a variable with the specified name in that frame and
@@ -205,7 +207,8 @@ public class LambdaUtils {
 	 * @since 3.15
 	 */
 	public static boolean isLambdaField(IVariable variable) throws DebugException {
-		return (variable instanceof IJavaFieldVariable) && ((IJavaFieldVariable) variable).getDeclaringType().getName().contains("$Lambda$"); //$NON-NLS-1$
+		return (variable instanceof IJavaFieldVariable) && 
+			LAMBDA_TYPE_PATTERN.matcher(((IJavaFieldVariable) variable).getDeclaringType().getName()).matches();
 	}
 
 	/**


### PR DESCRIPTION

## What it does
The lambda type check is improved to support naming patterns for both java 21 and prior versions. The naming patterns are as follows

Java 21: Bug575551$$Lambda.0x000000e8010079d8
Pre Java 21: Bug575551$$Lambda$20.0x0000000801005be0

## How to test
Run the LambdaVariableTest with both Java 21 and Java 17.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
