### PR TITLE
Touch bundles affected by changed bytecode generation

### DIFF
--- a/org.eclipse.jdt.debug.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.debug.ui/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 567095 - Comparator errors in I20200917-1800
 Bug 569538 - Comparator error in I20201208-0300
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
