### PR TITLE
Revert "Remove Y-builds reference in pom.xml (#315)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
   <profiles>
     <profile>
       <id>build-individual-bundles</id>
+      <properties>
+        <eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.29-Y-builds</eclipse-p2-repo.url>
+        <skipAPIAnalysis>true</skipAPIAnalysis>
+      </properties>
       <repositories>
         <repository>
           <releases>


### PR DESCRIPTION
This reverts commit 505e0cfc789d02dda6947c7d23dcddb5865fc807.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
