### PR TITLE
Javadoc error fix for new ExecutionEnvironmentDescription constructor

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java
@@ -203,7 +203,6 @@ public final class ExecutionEnvironmentDescription {
 	 * defined in <code>https://wiki.eclipse.org/Execution_Environment_Descriptions</code>.
 	 *
 	 * @param eeProperties execution environment description properties
-	 * @throws CoreException if unable to read or parse the file
 	 * @since 3.21
 	 */
 	public ExecutionEnvironmentDescription(Map<String, String> eeProperties) {


### PR DESCRIPTION
See https://download.eclipse.org/eclipse/downloads/drops4/I20230925-1800/compilelogs/jdt.doc.isv.javadoc.txt

```
../../../eclipse.jdt.debug/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/ExecutionEnvironmentDescription.java:206: error: exception not thrown: org.eclipse.core.runtime.CoreException
	 * @throws CoreException if unable to read or parse the file ^
```

Regression from cc2c11c5c55636a71ab20d1d0805dbd7c5baece5 / #282 

