### PR TITLE
Modernize some ui code

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaApplicationLaunchShortcut.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaApplicationLaunchShortcut.java
@@ -90,12 +90,12 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 		List<IJavaElement> list= new ArrayList<>(objects.length);
 		for (int i = 0; i < objects.length; i++) {
 			Object object = objects[i];
-			if (object instanceof IAdaptable) {
-				IJavaElement element = ((IAdaptable) object).getAdapter(IJavaElement.class);
+			if (object instanceof IAdaptable adapt) {
+				IJavaElement element = adapt.getAdapter(IJavaElement.class);
 				if (element != null) {
-					if (element instanceof IMember) {
+					if (element instanceof IMember member) {
 						// Use the declaring type if available
-						IJavaElement type= ((IMember)element).getDeclaringType();
+						IJavaElement type= member.getDeclaringType();
 						if (type != null) {
 							element= type;
 						}
@@ -107,9 +107,6 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 		return list.toArray(new IJavaElement[list.size()]);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#createConfiguration(org.eclipse.jdt.core.IType)
-	 */
 	@Override
 	protected ILaunchConfiguration createConfiguration(IType type) {
 		ILaunchConfiguration config = null;
@@ -134,9 +131,6 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 		return config;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#getConfigurationType()
-	 */
 	@Override
 	protected ILaunchConfigurationType getConfigurationType() {
 		return getLaunchManager().getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_JAVA_APPLICATION);
@@ -151,9 +145,6 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 		return DebugPlugin.getDefault().getLaunchManager();
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#findTypes(java.lang.Object[], org.eclipse.jface.operation.IRunnableContext)
-	 */
 	@Override
 	protected IType[] findTypes(Object[] elements, IRunnableContext context) throws InterruptedException, CoreException {
 		try {
@@ -180,8 +171,7 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 	 * @return the smallest enclosing <code>IType</code> of the specified object if it is a main method or <code>null</code> if it is not
 	 */
 	private IType isMainMethod(Object o) {
-		if(o instanceof IAdaptable) {
-			IAdaptable adapt = (IAdaptable) o;
+		if(o instanceof IAdaptable adapt) {
 			IJavaElement element = adapt.getAdapter(IJavaElement.class);
 			if(element != null && element.getElementType() == IJavaElement.METHOD) {
 				try {
@@ -196,25 +186,16 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 		return null;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#getTypeSelectionTitle()
-	 */
 	@Override
 	protected String getTypeSelectionTitle() {
 		return LauncherMessages.JavaApplicationLaunchShortcut_0;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#getEditorEmptyMessage()
-	 */
 	@Override
 	protected String getEditorEmptyMessage() {
 		return LauncherMessages.JavaApplicationLaunchShortcut_1;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.debug.ui.launchConfigurations.JavaLaunchShortcut#getSelectionEmptyMessage()
-	 */
 	@Override
 	protected String getSelectionEmptyMessage() {
 		return LauncherMessages.JavaApplicationLaunchShortcut_2;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaConnectTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaConnectTab.java
@@ -92,9 +92,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 	private IVMConnector fConnector;
 	private final IVMConnector[] fConnectors = JavaRuntime.getVMConnectors();
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Font font = parent.getFont();
@@ -165,11 +162,11 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 			String key = keys.next();
 			Connector.Argument arg = fArgumentMap.get(key);
 			FieldEditor field = null;
-			if (arg instanceof Connector.IntegerArgument) {
-				store.setDefault(arg.name(), ((Connector.IntegerArgument)arg).intValue());
+			if (arg instanceof Connector.IntegerArgument integerArg) {
+				store.setDefault(arg.name(), integerArg.intValue());
 				field = new IntegerFieldEditor(arg.name(), arg.label(), fArgumentComposite);
-			} else if (arg instanceof Connector.SelectedArgument) {
-				List<String> choices = ((Connector.SelectedArgument)arg).choices();
+			} else if (arg instanceof Connector.SelectedArgument selectedArg) {
+				List<String> choices = selectedArg.choices();
 				String[][] namesAndValues = new String[choices.size()][2];
 				Iterator<String> iter = choices.iterator();
 				int count = 0;
@@ -184,8 +181,8 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 			} else if (arg instanceof Connector.StringArgument) {
 				store.setDefault(arg.name(), arg.value());
 				field = new StringFieldEditor(arg.name(), arg.label(), fArgumentComposite);
-			} else if (arg instanceof Connector.BooleanArgument) {
-				store.setDefault(arg.name(), ((Connector.BooleanArgument)arg).booleanValue());
+			} else if (arg instanceof Connector.BooleanArgument bool) {
+				store.setDefault(arg.name(), bool.booleanValue());
 				field = new BooleanFieldEditor(arg.name(), arg.label(), fArgumentComposite);
 			}
 			if(field != null) {
@@ -200,9 +197,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		updateLaunchConfigurationDialog();
 	}
 
-	 /* (non-Javadoc)
-	 * @see org.eclipse.jdt.internal.debug.ui.launcher.AbstractJavaMainTab#initializeFrom(org.eclipse.debug.core.ILaunchConfiguration)
-	 */
 	@Override
 	public void initializeFrom(ILaunchConfiguration config) {
 		super.initializeFrom(config);
@@ -261,9 +255,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		catch (CoreException ce) {JDIDebugUIPlugin.log(ce);}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#performApply(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy config) {
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText().trim());
@@ -304,9 +295,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		initializeHardCodedDefaults(config);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setDefaults(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy config) {
 		IJavaElement javaElement = getContext();
@@ -326,8 +314,7 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 	 */
 	private void initializeName(IJavaElement javaElement, ILaunchConfigurationWorkingCopy config) {
 		String name = EMPTY_STRING;
-		if (javaElement instanceof IMember) {
-			IMember member = (IMember)javaElement;
+		if (javaElement instanceof IMember member) {
 			if (member.isBinary()) {
 				javaElement = member.getClassFile();
 			}
@@ -344,10 +331,8 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 					// Simply grab the first main type found in the searched element and set the module name
 					name = types[0].getFullyQualifiedName('.');
 				}
-			} catch (InterruptedException ie) {
+			} catch (InterruptedException|InvocationTargetException ie) {
 				JDIDebugUIPlugin.log(ie);
-			} catch (InvocationTargetException ite) {
-				JDIDebugUIPlugin.log(ite);
 			}
 			if (name.isEmpty()) {
 				name = javaElement.getElementName();
@@ -376,9 +361,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_CONNECTOR, JavaRuntime.getDefaultVMConnector().getIdentifier());
 	}
 
-	 /* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.AbstractLaunchConfigurationTab#isValid(org.eclipse.debug.core.ILaunchConfiguration)
-	 */
 	@Override
 	public boolean isValid(ILaunchConfiguration config) {
 		setErrorMessage(null);
@@ -395,8 +377,8 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 			String key = keys.next();
 			Connector.Argument arg = fArgumentMap.get(key);
 			FieldEditor editor = fFieldEditorMap.get(key);
-			if (editor instanceof StringFieldEditor) {
-				String value = ((StringFieldEditor)editor).getStringValue();
+			if (editor instanceof StringFieldEditor stringEditor) {
+				String value = stringEditor.getStringValue();
 				if (!arg.isValid(value)) {
 					StringBuilder label = new StringBuilder(LegacyActionTools.removeMnemonics(arg.label()));
 					if (label.lastIndexOf(ConnectMessages.SocketConnectionLabelSeparator) == label.length() - 1) {
@@ -410,25 +392,17 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		return true;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getName()
-	 */
 	@Override
 	public String getName() {
 		return LauncherMessages.JavaConnectTab_Conn_ect_20;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.AbstractLaunchConfigurationTab#getImage()
-	 */
 	@Override
 	public Image getImage() {
 		return DebugUITools.getImage(IDebugUIConstants.IMG_LCL_DISCONNECT);
 	}
 
 	/**
-	 * @see org.eclipse.debug.ui.AbstractLaunchConfigurationTab#getId()
-	 *
 	 * @since 3.3
 	 */
 	@Override
@@ -444,9 +418,6 @@ public class JavaConnectTab extends AbstractJavaMainTab implements IPropertyChan
 		return fConnector;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.util.IPropertyChangeListener#propertyChange(org.eclipse.jface.util.PropertyChangeEvent)
-	 */
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		updateLaunchConfigurationDialog();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaMainTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaMainTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -86,9 +86,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 	private Button fConsiderInheritedMainButton;
 	private Button fStopInMainCheckButton;
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Composite comp = SWTFactory.createComposite(parent, parent.getFont(), 1, 1, GridData.FILL_BOTH);
@@ -100,9 +97,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), IJavaDebugHelpContextIds.LAUNCH_CONFIGURATION_DIALOG_MAIN_TAB);
 	}
 
-	/**
-	 * @see org.eclipse.jdt.internal.debug.ui.launcher.SharedJavaMainTab#createMainTypeExtensions(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	protected void createMainTypeExtensions(Composite parent) {
 		fSearchExternalJarsCheckButton = SWTFactory.createCheckButton(parent, LauncherMessages.JavaMainTab_E_xt__jars_6, null, false, 2);
@@ -115,17 +109,11 @@ public class JavaMainTab extends SharedJavaMainTab {
 		fStopInMainCheckButton.addSelectionListener(getDefaultListener());
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.AbstractLaunchConfigurationTab#getImage()
-	 */
 	@Override
 	public Image getImage() {
 		return JavaUI.getSharedImages().getImage(ISharedImages.IMG_OBJS_CLASS);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getName()
-	 */
 	@Override
 	public String getName() {
 		return LauncherMessages.JavaMainTab__Main_19;
@@ -174,11 +162,7 @@ public class JavaMainTab extends SharedJavaMainTab {
 		try {
 			types = engine.searchMainMethods(getLaunchConfigurationDialog(), searchScope, fConsiderInheritedMainButton.getSelection());
 		}
-		catch (InvocationTargetException e) {
-			setErrorMessage(e.getMessage());
-			return;
-		}
-		catch (InterruptedException e) {
+		catch (InvocationTargetException|InterruptedException e) {
 			setErrorMessage(e.getMessage());
 			return;
 		}
@@ -195,9 +179,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.internal.debug.ui.launcher.AbstractJavaMainTab#initializeFrom(org.eclipse.debug.core.ILaunchConfiguration)
-	 */
 	@Override
 	public void initializeFrom(ILaunchConfiguration config) {
 		super.initializeFrom(config);
@@ -207,9 +188,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 		updateExternalJars(config);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.AbstractLaunchConfigurationTab#isValid(org.eclipse.debug.core.ILaunchConfiguration)
-	 */
 	@Override
 	public boolean isValid(ILaunchConfiguration config) {
 		setErrorMessage(null);
@@ -245,9 +223,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 		return true;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#performApply(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy config) {
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText().trim());
@@ -280,9 +255,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setDefaults(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy config) {
 		IJavaElement javaElement = getContext();
@@ -296,8 +268,6 @@ public class JavaMainTab extends SharedJavaMainTab {
 	}
 
 	/*
-	 * (non-Javadoc)
-	 * @see org.eclipse.jdt.internal.debug.ui.launcher.SharedJavaMainTab#initializeAttributes()
 	 * @since 3.9
 	 */
 	@Override

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -54,15 +54,11 @@ public class MainMethodSearchEngine{
 			return fResult;
 		}
 
-		/* (non-Javadoc)
-		 * @see org.eclipse.jdt.core.search.SearchRequestor#acceptSearchMatch(org.eclipse.jdt.core.search.SearchMatch)
-		 */
 		@Override
 		public void acceptSearchMatch(SearchMatch match) throws CoreException {
 			Object enclosingElement = match.getElement();
-			if (enclosingElement instanceof IMethod) { // defensive code
+			if (enclosingElement instanceof IMethod curr) { // defensive code
 				try {
-					IMethod curr= (IMethod) enclosingElement;
 					if (curr.isMainMethod()) {
 						IType declaringType = curr.getDeclaringType();
 						fResult.add(declaringType);


### PR DESCRIPTION
## What it does
A prep cleanup work for support of instance main methods (https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1470 ) in debug UI to make functional changes easier to review.

## How to test
No functional change

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
