### PR TITLE
Disable DetectVMInstallationsJob in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
 						-Pbuild-individual-bundles -Ptest-on-javase-19 -Pbree-libs -Papi-check\
 						-Dcompare-version-with-baselines.skip=false \
 						-Dproject.build.sourceEncoding=UTF-8 \
+						-DDetectVMInstallationsJob.disabled=true \
 						-DtrimStackTrace=false
 					"""
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
 						-Dcompare-version-with-baselines.skip=false \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-DDetectVMInstallationsJob.disabled=true \
+						-Dtycho.apitools.debug \
 						-DtrimStackTrace=false
 					"""
 				}


### PR DESCRIPTION
That should reduce possible side effects on API analysis.

See https://github.com/eclipse-pde/eclipse.pde/issues/782
