### PR TITLE
Support JEP 445 main methods

### DIFF
--- a/org.eclipse.jdt.debug.tests/java21/Main1.java
+++ b/org.eclipse.jdt.debug.tests/java21/Main1.java
@@ -1,0 +1,5 @@
+public class Main1 {
+	public static void main() {
+		System.out.println("test");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/java21/Main2.java
+++ b/org.eclipse.jdt.debug.tests/java21/Main2.java
@@ -1,0 +1,7 @@
+public class Main2 {
+	
+	void main() {
+		System.out.println("test");
+	}
+	
+}

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -48,8 +48,8 @@
     </plugins>
   </build>
   <profiles>
-  	<profile>
-		<id>test-on-javase-19</id>
+	<profile>
+		<id>test-on-javase-21</id>
 		<build>
 			<plugins>
 				<plugin>
@@ -66,7 +66,7 @@
 					<configuration>
 						<toolchains>
 							<jdk>
-								<id>JavaSE-19</id>
+								<id>JavaSE-21</id>
 							</jdk>
 						</toolchains>
 					</configuration>

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
@@ -64,6 +64,7 @@ public class JavaProjectHelper {
 	public static final String JAVA_SE_1_8_EE_NAME = "JavaSE-1.8";
 	public static final String JAVA_SE_9_EE_NAME = "JavaSE-9";
 	public static final String JAVA_SE_16_EE_NAME = "JavaSE-16";
+	public static final String JAVA_SE_21_EE_NAME = "JavaSE-21";
 
 	/**
 	 * path to the test src for 'testprograms'
@@ -90,6 +91,10 @@ public class JavaProjectHelper {
 	 * path to the 16 test source
 	 */
 	public static final IPath TEST_16_SRC_DIR = new Path("java16_");
+	/**
+	 * path to the 21 test source
+	 */
+	public static final IPath TEST_21_SRC_DIR = new Path("java21");
 
 	/**
 	 * path to the compiler error java file

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -179,6 +179,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	public static final String ONE_EIGHT_PROJECT_NAME = "OneEight";
 	public static final String NINE_PROJECT_NAME = "Nine";
 	public static final String ONESIX_PROJECT_NAME = "One_Six";
+	public static final String TWENTYONE_PROJECT_NAME = "Two_One";
 	public static final String BOUND_JRE_PROJECT_NAME = "BoundJRE";
 	public static final String CLONE_SUFFIX = "Clone";
 
@@ -233,6 +234,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	private static boolean loaded18 = false;
 	private static boolean loaded9 = false;
 	private static boolean loaded16_ = false;
+	private static boolean loaded21 = false;
 	private static boolean loadedEE = false;
 	private static boolean loadedJRE = false;
 	private static boolean loadedMulti = false;
@@ -266,6 +268,8 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		loaded9 = pro.exists();
 		pro = ResourcesPlugin.getWorkspace().getRoot().getProject(ONESIX_PROJECT_NAME);
 		loaded16_ = pro.exists();
+		pro = ResourcesPlugin.getWorkspace().getRoot().getProject(TWENTYONE_PROJECT_NAME);
+		loaded21 = pro.exists();
 		pro = ResourcesPlugin.getWorkspace().getRoot().getProject(BOUND_JRE_PROJECT_NAME);
 		loadedJRE = pro.exists();
 		pro = ResourcesPlugin.getWorkspace().getRoot().getProject(BOUND_EE_PROJECT_NAME);
@@ -576,6 +580,36 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 			handleProjectCreationException(e, ONESIX_PROJECT_NAME, jp);
 		}
 	}
+	
+	/**
+	 * Creates the Java 21 compliant project
+	 */
+	synchronized void assert21Project() {
+		IJavaProject jp = null;
+		ArrayList<ILaunchConfiguration> cfgs = new ArrayList<>(1);
+		try {
+			if (!loaded21) {
+				jp = createProject(TWENTYONE_PROJECT_NAME, JavaProjectHelper.TEST_21_SRC_DIR.toString(), JavaProjectHelper.JAVA_SE_21_EE_NAME, false);
+				jp.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+				cfgs.add(createLaunchConfiguration(jp, "Main1"));
+				cfgs.add(createLaunchConfiguration(jp, "Main2"));
+				loaded21 = true;
+				waitForBuild();
+			}
+		} catch (Exception e) {
+			try {
+				if (jp != null) {
+					jp.getProject().delete(true, true, null);
+					for (int i = 0; i < cfgs.size(); i++) {
+						cfgs.get(i).delete();
+					}
+				}
+			} catch (CoreException ce) {
+				// ignore
+			}
+			handleProjectCreationException(e, TWENTYONE_PROJECT_NAME, jp);
+		}
+	}
 
 	/**
 	 * Creates the 'BoundJRE' project used for the JRE testing
@@ -865,6 +899,16 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	protected IJavaProject get9Project() {
 		assert9Project();
 		return getJavaProject(NINE_PROJECT_NAME);
+	}
+	
+	 /**
+	 * Returns the 'Two_One' project, used for Java 21 tests.
+	 *
+	 * @return the test project
+	 */
+	protected IJavaProject get21Project() {
+		assert21Project();
+		return getJavaProject(TWENTYONE_PROJECT_NAME);
 	}
 
 	/**

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -105,6 +105,7 @@ import org.eclipse.jdt.debug.tests.launching.ClasspathShortenerTests;
 import org.eclipse.jdt.debug.tests.launching.ConfigurationEncodingTests;
 import org.eclipse.jdt.debug.tests.launching.ConfigurationResourceMappingTests;
 import org.eclipse.jdt.debug.tests.launching.ContributedTabTests;
+import org.eclipse.jdt.debug.tests.launching.InstanceMainMethodsTests;
 import org.eclipse.jdt.debug.tests.launching.LaunchConfigurationManagerTests;
 import org.eclipse.jdt.debug.tests.launching.LaunchConfigurationTests;
 import org.eclipse.jdt.debug.tests.launching.LaunchDelegateTests;
@@ -192,6 +193,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(ConfigurationEncodingTests.class));
 		addTest(new TestSuite(LaunchConfigurationManagerTests.class));
 		addTest(new TestSuite(LaunchConfigurationTests.class));
+		addTest(new TestSuite(InstanceMainMethodsTests.class));
 		addTest(new TestSuite(ProjectClasspathVariableTests.class));
 
 	//mac specific tests

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/InstanceMainMethodsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/InstanceMainMethodsTests.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.launching;
+
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.core.IJavaDebugTarget;
+import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+
+public class InstanceMainMethodsTests extends AbstractDebugTest {
+
+	public InstanceMainMethodsTests(String name) {
+		super(name);
+	}
+
+	@Override
+	protected IJavaProject getProjectContext() {
+		return super.get21Project();
+	}
+
+	public void testStaticMainWithoutArgs() throws Exception {
+		String type = "Main1";
+		IJavaDebugTarget target = null;
+		IProcess process = null;
+		try {
+			target = launchAndTerminate(type);
+			process = target.getProcess();
+		} finally {
+			if (target != null) {
+				terminateAndRemove(target);
+			}
+		}
+		assertNotNull("Missing VM process.", process);
+		assertEquals("Process finished with error code", 0, process.getExitValue());
+	}
+	
+	public void testDefaultMainWithoutArgs() throws Exception {
+		String type = "Main2";
+		IJavaDebugTarget target = null;
+		IProcess process = null;
+		try {
+			target = launchAndTerminate(type);
+			process = target.getProcess();
+		} finally {
+			if (target != null) {
+				terminateAndRemove(target);
+			}
+		}
+		assertNotNull("Missing VM process.", process);
+		assertEquals("Process finished with error code", 0, process.getExitValue());
+	}
+
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
@@ -59,7 +59,7 @@ public class MainMethodSearchEngine{
 			Object enclosingElement = match.getElement();
 			if (enclosingElement instanceof IMethod curr) { // defensive code
 				try {
-					if (curr.isMainMethod()) {
+					if (curr.isMainMethodCandidate()) {
 						IType declaringType = curr.getDeclaringType();
 						fResult.add(declaringType);
 					}
@@ -86,7 +86,7 @@ public class MainMethodSearchEngine{
 			searchTicks = 25;
 		}
 
-		SearchPattern pattern = SearchPattern.createPattern("main(String[]) void", IJavaSearchConstants.METHOD, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE); //$NON-NLS-1$
+		SearchPattern pattern = SearchPattern.createPattern("main void", IJavaSearchConstants.METHOD, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE); //$NON-NLS-1$
 		SearchParticipant[] participants = new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 		MethodCollector collector = new MethodCollector();
 		IProgressMonitor searchMonitor = new SubProgressMonitor(pm, searchTicks);

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchableTester.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchableTester.java
@@ -196,7 +196,7 @@ public class JavaLaunchableTester extends PropertyTester {
 	private boolean hasMainMethod(IType type) throws JavaModelException {
 		IMethod[] methods = type.getMethods();
 		for (int i= 0; i < methods.length; i++) {
-			if(methods[i].isMainMethod()) {
+			if(methods[i].isMainMethodCandidate()) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## What it does
Using isMainMethodCandidate ensures there is at least one main method so JVM will be able to launch.

## How to test
Create a class with public/protected/default non-static main method with or without String[] args and verify that Run As/Debug As works.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
