### PR TITLE
Change Jenkinsfile to use Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk17-latest'
+		jdk 'temurin-jdk21-latest'
 	}
 	stages {
 		stage('Build') {
@@ -18,7 +18,7 @@ pipeline {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
 					sh """
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-Pbuild-individual-bundles -Ptest-on-javase-19 -Pbree-libs -Papi-check\
+						-Pbuild-individual-bundles -Ptest-on-javase-21 -Pbree-libs -Papi-check\
 						-Dcompare-version-with-baselines.skip=false \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-DDetectVMInstallationsJob.disabled=true \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk21-latest'
+		jdk 'openjdk-jdk21-latest'
 	}
 	stages {
 		stage('Build') {

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -60,7 +60,7 @@
   </build>
   <profiles>
   	<profile>
-		<id>test-on-javase-19</id>
+		<id>test-on-javase-21</id>
 		<build>
 			<plugins>
 				<plugin>

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -77,7 +77,7 @@
 					<configuration>
 						<toolchains>
 							<jdk>
-								<id>JavaSE-19</id>
+								<id>JavaSE-21</id>
 							</jdk>
 						</toolchains>
 					</configuration>

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
@@ -117,7 +117,7 @@ public class VirtualThreadTest extends AbstractJDITest {
 		if (!outputFolder.exists()) {
 			outputFolder.mkdir();
 		}
-		String[] options = new String[] { "--enable-preview", "--release", "19", "-d", outputFolder.getAbsolutePath(), "-g", "-proc:none" };
+		String[] options = new String[] { ""--release", "21", "-d", outputFolder.getAbsolutePath(), "-g", "-proc:none" };
 		final StringWriter output = new StringWriter();
 		CompilationTask task = compiler.getTask(output, fileManager, diagnosticCollector, Arrays.asList(options), null, javaFileObjects);
 		boolean result = task.call();

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VirtualThreadTest.java
@@ -117,7 +117,7 @@ public class VirtualThreadTest extends AbstractJDITest {
 		if (!outputFolder.exists()) {
 			outputFolder.mkdir();
 		}
-		String[] options = new String[] { ""--release", "21", "-d", outputFolder.getAbsolutePath(), "-g", "-proc:none" };
+		String[] options = new String[] { "--release", "21", "-d", outputFolder.getAbsolutePath(), "-g", "-proc:none" };
 		final StringWriter output = new StringWriter();
 		CompilationTask task = compiler.getTask(output, fileManager, diagnosticCollector, Arrays.asList(options), null, javaFileObjects);
 		boolean result = task.call();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Switches jdt debug Jenkinsfile to use Java 21.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See Jenkinsfile.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
