### PR TITLE
Run instance main method tests only on Java 21+

### DIFF
--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2022 IBM Corporation and others.
+ *  Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -164,6 +164,15 @@ public class JavaProjectHelper {
 	 */
 	public static boolean isJava19_Compatible() {
 		return isCompatible(19);
+	}
+	
+	/**
+	 * Returns if the currently running VM is version compatible with Java 21
+	 *
+	 * @return <code>true</code> if a Java 21 (or greater) VM is running <code>false</code> otherwise
+	 */
+	public static boolean isJava21_Compatible() {
+		return isCompatible(21);
 	}
 
 	/**

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -193,7 +193,9 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(ConfigurationEncodingTests.class));
 		addTest(new TestSuite(LaunchConfigurationManagerTests.class));
 		addTest(new TestSuite(LaunchConfigurationTests.class));
-		addTest(new TestSuite(InstanceMainMethodsTests.class));
+		if(JavaProjectHelper.isJava21_Compatible()) {
+			addTest(new TestSuite(InstanceMainMethodsTests.class));
+		}
 		addTest(new TestSuite(ProjectClasspathVariableTests.class));
 
 	//mac specific tests


### PR DESCRIPTION
## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/334

## How to test
There are no failures on Java 17 in the next I-build on MacOS.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
