### PR TITLE
Include java21 resource folder in jdt.debug.tests

### DIFF
--- a/org.eclipse.jdt.debug.tests/build.properties
+++ b/org.eclipse.jdt.debug.tests/build.properties
@@ -25,7 +25,8 @@ bin.includes = plugin.xml,\
                java7/,\
                java8/,\
                java9/,\
-               java16_/
+               java16_/,\
+               java21/
 source.javadebugtests.jar = test plugin/,\
                             tests/,\
                             console tests/


### PR DESCRIPTION
## What it does
Fixes running instance main methods on Java 21

## How to test
Next I-build tests are successful

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
