### PR TITLE
Remove accelerator key from command name (#338)

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.properties
+++ b/org.eclipse.jdt.debug.ui/plugin.properties
@@ -222,7 +222,7 @@ ActionDefinition.display.description=Display result of evaluating selected text
 ActionDefinition.inspect.name=Inspect
 ActionDefinition.inspect.description=Inspect result of evaluating selected text
 ActionDefinition.forceReturn.name=Force Return
-ActionDefinition.forceReturn.description=Forces return from method with value of selected expression 
+ActionDefinition.forceReturn.description=Forces return from method with value of selected expression
 ActionDefinition.watch.description=Create new watch expression
 ActionDefinition.watch.name=Watch
 ActionDefinition.allReferences.name=All References
@@ -239,9 +239,9 @@ ToggleTracepointAction.label=Toggle Tra&cepoint
 ToggleTracepointCommand.label=Toggle Tracepoint
 ToggleTracepointCommand.description=Creates or removes a tracepoint
 
-ToggleLambdaEntryBreakpointAction.label=Toggle Lambda Entry Breakpoint
-ToggleLambdaEntryBreakpointCommand.label=Toggle &Lambda Entry Breakpoint
-ToggleLambdaEntryBreakpointCommand.description=Creates or removes a lambda entry breakpoint  
+ToggleLambdaEntryBreakpointAction.label=Toggle &Lambda Entry Breakpoint
+ToggleLambdaEntryBreakpointCommand.label=Toggle Lambda Entry Breakpoint
+ToggleLambdaEntryBreakpointCommand.description=Creates or removes a lambda entry breakpoint
 
 AddBookmark.label=Add Boo&kmark...
 AddBookmark.tooltip=Add Bookmark...
@@ -256,7 +256,7 @@ appletTabGroupDescription.run=Run a Java applet
 
 java_type_name.description=Returns the fully qualified Java type name of the primary type in the selected resource.
 
-javaLikeExtensions.description=Regular expression matching registered Java-like file extensions 
+javaLikeExtensions.description=Regular expression matching registered Java-like file extensions
 
 Context.javaDebugging.name= Debugging Java
 Context.javaDebugging.description= Debugging Java programs


### PR DESCRIPTION
Fixes #338.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
* remove accelerator from command name, re-add it to the action name

## How to test
* ctrl-3, toggle
* open context menu on left-hand side editor ruler (with a Java file opened) for the action

## Author checklist
I've not tested in a runtime. I can't build because the 4.30-SNAPSHOT parent POM is missing and not retrievable from Maven for me.