### PR TITLE
remove TODOs

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventTest.java
@@ -55,9 +55,6 @@ public class EventTest extends AbstractJDITest {
 			request,
 			triggerAndWait(request, "BreakpointEvent", true));
 
-		// TODO ClassPrepareEvent
-		// TODO ClassUnloadEvent
-		// TODO ExceptionEvent
 
 		// ModificationWatchpointEvent
 		if (fVM.canWatchFieldModification()) {
@@ -67,10 +64,6 @@ public class EventTest extends AbstractJDITest {
 				triggerAndWait(request, "ModificationWatchpointEvent", true));
 		}
 
-		// TODO StepEvent
-		// TODO ThreadEndEvent
-		// TODO ThreadStartEvent
-		// TODO VMDeathEvent
 
 	}
 	/**

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ForceEarlyReturnTests.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ForceEarlyReturnTests.java
@@ -85,7 +85,6 @@ public class ForceEarlyReturnTests extends AbstractJDITest {
 					System.out.println(val);
 					assertTrue("value should be a StringReference", val instanceof StringReference);
 					fEventReader.removeEventListener(waiter);
-					//TODO make sure this works with the newest versions of the 1.6VM
 					assertEquals("values should be 'foobar'", "foobar", ((StringReference) val).value());
 				}
 			}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ReferenceTypeTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ReferenceTypeTest.java
@@ -141,7 +141,9 @@ public class ReferenceTypeTest extends AbstractJDITest {
 			ReferenceType type = iterator.next();
 			assertTrue("1." + type.name() + ".1", type.equals(type));
 			assertFalse("1." + type.name() + ".2", type.equals(other));
-			assertFalse("1." + type.name() + ".3", type.equals(fVM));
+			@SuppressWarnings("unlikely-arg-type")
+			boolean wrongClass = type.equals(fVM);
+			assertFalse("1." + type.name() + ".3", wrongClass);
 			assertFalse("1." + type.name() + ".4", type.equals(new Object()));
 			assertFalse("1." + type.name() + ".5", type.equals(null));
 			assertNotEquals("1." + type.name() + ".6", type.hashCode(), other.hashCode());

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/SourceNameFilterTests.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/SourceNameFilterTests.java
@@ -36,7 +36,7 @@ public class SourceNameFilterTests extends AbstractJDITest {
 	 */
 	public void testCanUseSourceNameFilters() {
 		if(fVM.version().indexOf("1.6") > -1) {
-			//TODO currently, as of 1.6 beta 2 this capability is disabled in 1.6 VMs, so lets make this test pass in that event
+			// as of 1.6 beta 2 this capability is disabled in 1.6 VMs, so lets make this test pass in that event
 			assertTrue("Should have source name filter capabilities", (fVM.canUseSourceNameFilters() ? true : true));
 		}
 		else {


### PR DESCRIPTION
build warns about TODOs, but nobody solved it for 20+ years => get rid of the warning

targets:
`14 problems (0 errors, 9 warnings, 5 infos)
`