### PR TITLE
Javadoc format fixes (part 2)

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/AppletParametersTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/AppletParametersTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -54,11 +54,12 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 
 /**
- * This tab appears for java applet launch configurations and allows the user to edit
- * applet-specific attributes such as width, height, name & applet parameters.
+ * This tab appears for java applet launch configurations and allows the user to edit applet-specific attributes such as width, height, name &amp;
+ * applet parameters.
  * <p>
  * This class may be instantiated.
  * </p>
+ *
  * @since 2.1
  * @noextend This class is not intended to be sub-classed by clients.
  */
@@ -73,17 +74,11 @@ public class AppletParametersTab extends JavaLaunchTab {
 
 	private class AppletTabListener extends SelectionAdapter implements ModifyListener {
 
-		/* (non-Javadoc)
-		 * @see org.eclipse.swt.events.ModifyListener#modifyText(org.eclipse.swt.events.ModifyEvent)
-		 */
 		@Override
 		public void modifyText(ModifyEvent e) {
 			updateLaunchConfigurationDialog();
 		}
 
-		/* (non-Javadoc)
-		 * @see org.eclipse.swt.events.SelectionListener#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-		 */
 		@Override
 		public void widgetSelected(SelectionEvent e) {
 			Object source= e.getSource();
@@ -119,9 +114,6 @@ public class AppletParametersTab extends JavaLaunchTab {
 	 */
 	private TableViewer fViewer;
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Composite comp = SWTFactory.createComposite(parent, 1, 1, GridData.FILL_HORIZONTAL);
@@ -248,9 +240,6 @@ public class AppletParametersTab extends JavaLaunchTab {
 	}
 
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#isValid(ILaunchConfiguration)
-	 */
 	@Override
 	public boolean isValid(ILaunchConfiguration launchConfig) {
 		setErrorMessage(null);
@@ -349,9 +338,6 @@ public class AppletParametersTab extends JavaLaunchTab {
 		return (Map<String, String>) fViewer.getInput();
 	}
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		try {
@@ -382,17 +368,11 @@ public class AppletParametersTab extends JavaLaunchTab {
 		return fHeightText.getText().trim();
 	}
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 	}
 
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#initializeFrom(ILaunchConfiguration)
-	 */
 	@Override
 	public void initializeFrom(ILaunchConfiguration config) {
 		try {
@@ -423,9 +403,6 @@ public class AppletParametersTab extends JavaLaunchTab {
 		fViewer.setInput(input);
 	}
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getName()
-	 */
 	@Override
 	public String getName() {
 		return LauncherMessages.appletlauncher_argumenttab_name;
@@ -441,25 +418,16 @@ public class AppletParametersTab extends JavaLaunchTab {
 		return "org.eclipse.jdt.debug.ui.appletParametersTab"; //$NON-NLS-1$
 	}
 
-	/**
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getImage()
-	 */
 	@Override
 	public Image getImage() {
 		return JavaDebugImages.get(JavaDebugImages.IMG_VIEW_ARGUMENTS_TAB);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#activated(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void activated(ILaunchConfigurationWorkingCopy workingCopy) {
 		// do nothing when activated
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#deactivated(org.eclipse.debug.core.ILaunchConfigurationWorkingCopy)
-	 */
 	@Override
 	public void deactivated(ILaunchConfigurationWorkingCopy workingCopy) {
 		// do nothing when de-activated

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/hcr/ThreadReference.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/hcr/ThreadReference.java
@@ -36,11 +36,11 @@ public interface ThreadReference {
 	 * <li>If yes, the VM checks to see whether there might be a <code>finally</code> or <code>synchronized</code> block enclosing the current
 	 * instruction.
 	 * <ul>
-	 * <li>If there is no enclosing <code>finally</code> block, the operation reduces to the above case.
+	 * <li>If there is no enclosing <code>finally</code> block, the operation reduces to the above case.ll
 	 * <li>If there is an enclosing <code>finally</code> block, the VM creates a VM exception and activates the <code>finally</code> block with it. If
 	 * this exception eventually causes the stack frame to be popped, the exception is caught by the VM itself, the return value is returned, and
 	 * execution continues back in the caller.
-	 * <ul>
+	 * </ul>
 	 * </ul>
 	 * <br/>
 	 * Note that a <code>finally</code> block manifests itself as (and is indistinguishable from) a <code>catch Throwable</code> block.

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/hcr/VirtualMachine.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/hcr/VirtualMachine.java
@@ -91,6 +91,7 @@ public interface VirtualMachine {
 	 * <li>send a class unload event,
 	 * <li>suspend the VM if it was requested by the class unload event request.
 	 * </ul>
+	 * </ul>
 	 * </ol>
 	 * <p>
 	 * Subsequent references to classes will work with the new class definition. Note the existing <code>com.sun.jdi.ReferenceType</code>,


### PR DESCRIPTION
Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1531 .
It's a pity that this takes multiple cycles but fixing one thing from the log uncovers the next.

