### PR TITLE
Add runtime keyword to Installed JREs preference page keyword list

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.properties
+++ b/org.eclipse.jdt.debug.ui/plugin.properties
@@ -307,7 +307,7 @@ allReferencesInView.label=Show &References
 allReferencesInView.tooltip=Shows references to each object in the variables view as an array of objects.
 
 preferenceKeywords.general=java debug suspend hot hcr timeout breakpoints code execution exceptions conditional evaluations source lookup
-preferenceKeywords.jres= debug java jdk 1.5 5.0 1.4 1.6 6.0 1.7 7.0 jres vms javadoc libraries source attachment
+preferenceKeywords.jres= debug java jdk 1.5 5.0 1.4 1.6 6.0 1.7 7.0 jres vms javadoc libraries source attachment runtime
 preferenceKeywords.detailFormatters= debug java details toString variables pane
 preferenceKeywords.logicalStructures=debug java logical structures variables details pane
 preferenceKeywords.stepFilters=debug java stepping filters through setter getter synthetic static initializer constructor


### PR DESCRIPTION
- fixes #364

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds additional keyword for searching for Installed JREs Preference page.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Type java runtime into preferences page search and verify that Installed JREs page is shown in results.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
