### PR TITLE
Replace deprecated SubProgressMonitor with IProgressMonitor

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AppletLaunchConfigurationUtils.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AppletLaunchConfigurationUtils.java
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -45,7 +44,6 @@ import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.osgi.util.NLS;
 
-@SuppressWarnings("deprecation")
 public class AppletLaunchConfigurationUtils {
 
 	/**
@@ -112,7 +110,7 @@ public class AppletLaunchConfigurationUtils {
 		HashSet<IType> result = new HashSet<>(5);
 		try {
 			IType javaLangApplet = AppletLaunchConfigurationUtils.getMainType("java.applet.Applet", project); //$NON-NLS-1$
-			ITypeHierarchy hierarchy = javaLangApplet.newTypeHierarchy(project, new SubProgressMonitor(monitor, 1));
+			ITypeHierarchy hierarchy = javaLangApplet.newTypeHierarchy(project, monitor.slice(1));
 			types = hierarchy.getAllSubtypes(javaLangApplet);
 			int length = types.length;
 			if (length != 0) {
@@ -218,7 +216,7 @@ public class AppletLaunchConfigurationUtils {
 					try {
 						for (int i= 0; i < nElements; i++) {
 							try {
-								collectTypes(elements[i], new SubProgressMonitor(pm, 1), result);
+								collectTypes(elements[i], pm.slice(1), result);
 							} catch (JavaModelException jme) {
 								JDIDebugUIPlugin.log(jme.getStatus());
 							}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AppletSelectionDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AppletSelectionDialog.java
@@ -22,7 +22,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
@@ -40,7 +39,6 @@ import org.eclipse.ui.dialogs.TwoPaneElementSelector;
 /**
  * A dialog to select a type that extends <code>java.applet.Applet</code>.
  */
-@SuppressWarnings("deprecation")
 public class AppletSelectionDialog extends TwoPaneElementSelector {
 
 	private final IRunnableContext fRunnableContext;
@@ -125,7 +123,7 @@ public class AppletSelectionDialog extends TwoPaneElementSelector {
 					monitor.beginTask(LauncherMessages.AppletSelectionDialog_Searching____1, projectCount);
 					for (int i = 0; i < projectCount; i++) {
 						IJavaProject javaProject = javaProjects[i];
-						SubProgressMonitor subMonitor = new SubProgressMonitor(monitor, 1);
+						IProgressMonitor subMonitor = monitor.slice(1);
 						results.addAll(AppletLaunchConfigurationUtils.collectAppletTypesInProject(subMonitor, javaProject));
 						monitor.worked(1);
 					}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/MainMethodSearchEngine.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -40,7 +39,6 @@ import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
-@SuppressWarnings("deprecation")
 public class MainMethodSearchEngine{
 
 	private class MethodCollector extends SearchRequestor {
@@ -89,7 +87,7 @@ public class MainMethodSearchEngine{
 		SearchPattern pattern = SearchPattern.createPattern("main void", IJavaSearchConstants.METHOD, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE); //$NON-NLS-1$
 		SearchParticipant[] participants = new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 		MethodCollector collector = new MethodCollector();
-		IProgressMonitor searchMonitor = new SubProgressMonitor(pm, searchTicks);
+		IProgressMonitor searchMonitor = pm.slice(searchTicks);
 		try {
 			new SearchEngine().search(pattern, participants, scope, collector, searchMonitor);
 		} catch (CoreException ce) {
@@ -98,7 +96,7 @@ public class MainMethodSearchEngine{
 
 		List<IType> result = collector.getResult();
 		if (includeSubtypes) {
-			IProgressMonitor subtypesMonitor = new SubProgressMonitor(pm, 75);
+			IProgressMonitor subtypesMonitor = pm.slice(75);
 			subtypesMonitor.beginTask(LauncherMessages.MainMethodSearchEngine_2, result.size());
 			Set<IType> set = addSubtypes(result, subtypesMonitor, scope);
 			return set.toArray(new IType[set.size()]);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/search/LaunchConfigurationQueryParticipant.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/search/LaunchConfigurationQueryParticipant.java
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -56,7 +55,6 @@ import org.eclipse.ui.PartInitException;
  *
  * @since 3.4.0
  */
-@SuppressWarnings("deprecation")
 public class LaunchConfigurationQueryParticipant implements IQueryParticipant {
 
 	/**
@@ -137,7 +135,7 @@ public class LaunchConfigurationQueryParticipant implements IQueryParticipant {
 				return;
 			}
 			monitor.worked(1);
-			searchLaunchConfigurations(query.getScope(), requestor, pattern, new SubProgressMonitor(monitor, 7));
+			searchLaunchConfigurations(query.getScope(), requestor, pattern, monitor.slice(7));
 		} finally {
 			monitor.done();
 		}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/SocketAttachConnector.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/SocketAttachConnector.java
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IDebugTarget;
@@ -47,7 +46,6 @@ import com.sun.jdi.connect.IllegalConnectorArgumentsException;
 /**
  * A standard socket attaching connector
  */
-@SuppressWarnings("deprecation")
 public class SocketAttachConnector implements IVMConnector {
 
 	/**
@@ -111,7 +109,7 @@ public class SocketAttachConnector implements IVMConnector {
 			monitor = new NullProgressMonitor();
 		}
 
-		IProgressMonitor subMonitor = new SubProgressMonitor(monitor, 1);
+		IProgressMonitor subMonitor = monitor.slice(1);
 		subMonitor.beginTask(LaunchingMessages.SocketAttachConnector_Connecting____1, 2);
 		subMonitor.subTask(LaunchingMessages.SocketAttachConnector_Configuring_connection____1);
 

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/Standard11xVMRunner.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/Standard11xVMRunner.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IProcess;
@@ -37,7 +36,6 @@ import org.eclipse.jdt.launching.VMRunnerConfiguration;
 /**
  * A 1.1.x VM runner
  */
-@SuppressWarnings("deprecation")
 public class Standard11xVMRunner extends StandardVMRunner {
 
 	public Standard11xVMRunner(IVMInstall vmInstance) {
@@ -52,7 +50,7 @@ public class Standard11xVMRunner extends StandardVMRunner {
 		if (monitor == null) {
 			monitor = new NullProgressMonitor();
 		}
-		IProgressMonitor subMonitor = new SubProgressMonitor(monitor, 1);
+		IProgressMonitor subMonitor = monitor.slice(1);
 		subMonitor.beginTask(LaunchingMessages.StandardVMRunner_Launching_VM____1, 2);
 		subMonitor.subTask(LaunchingMessages.StandardVMRunner_Constructing_command_line____2); //
 


### PR DESCRIPTION
by search & replace regexp
```
new SubProgressMonitor\(([^\,]+), ([^,\)]+)\)
```
->
```
$1.slice($2)
```
and quickfix imports
