### PR TITLE
Detect Windows JVMs on startup

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
@@ -207,5 +207,5 @@ RunnerBootpathPError=Xbootclasspath/p option have been removed as not supported 
 VMLogging_1=Restoring vm library location:
 VMLogging_2=Creating Library with Java Install path:
 VMLogging_3=Default Install retrieved:
-lookupInstalledJVMs=Look up for installed JVMs
+lookupInstalledJVMs=Detect installed JVMs
 configuringJVM=Configuring installed JVM {0}


### PR DESCRIPTION
## What it does
The JDK detection mechanism doesn't find much on Windows. Have it find the default installation directories of Adoptium and RedHat, both in the 64 and 32 bit installation directories. Further JDK distributors can easily be added without changing the code logic.

Also let duplicate VM names start with index 2, not 1. And finally improve the job name.

On my machine that change adds the upper 4 entries of this screenshot: 
![grafik](https://github.com/eclipse-jdt/eclipse.jdt.debug/assets/406876/1dc86711-5d98-41e0-a546-70013251b1fb)

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Install Adoptium or Redhat OpenJDK in default location and check preference page.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
