### PR TITLE
Remove redundant maven configs

### DIFF
--- a/org.eclipse.jdt.launching.macosx/pom.xml
+++ b/org.eclipse.jdt.launching.macosx/pom.xml
@@ -30,9 +30,7 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
-          <resolver>p2</resolver>
           <environments>
             <environment>
               <os>macosx</os>


### PR DESCRIPTION
* tycho-version is already defined in parent
* resover=p2 is not needed for ages

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
