### PR TITLE
Remove useless tycho target-platform-configuration

### DIFF
--- a/org.eclipse.jdt.launching.macosx/pom.xml
+++ b/org.eclipse.jdt.launching.macosx/pom.xml
@@ -24,23 +24,4 @@
   <properties>
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>macosx</os>
-              <ws>cocoa</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/org.eclipse.jdt.launching.ui.macosx/pom.xml
+++ b/org.eclipse.jdt.launching.ui.macosx/pom.xml
@@ -25,22 +25,4 @@
     <skipAPIAnalysis>true</skipAPIAnalysis>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments>
-            <environment>
-              <os>macosx</os>
-              <ws>cocoa</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
It's smart enough to do that based on Eclipse-PlatformFilter

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
