### PR TITLE
Do not sign inner jars

### DIFF
--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -23,13 +23,13 @@
   <properties>
     <testSuite>${project.artifactId}</testSuite>
     <testClass>org.eclipse.jdt.debug.tests.AutomatedSuite</testClass>
+  	<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
   </properties>
   <build>
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>

--- a/org.eclipse.jdt.debug.ui/pom.xml
+++ b/org.eclipse.jdt.debug.ui/pom.xml
@@ -20,4 +20,7 @@
   <artifactId>org.eclipse.jdt.debug.ui</artifactId>
   <version>3.13.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
+  <properties>
+  	<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
+  </properties>
 </project>


### PR DESCRIPTION
Much like in
https://github.com/eclipse-equinox/p2/blob/f682eb19414bfcdef31ea498f4b3bffb76166d5[…]bundles/org.eclipse.equinox.p2.tests.discovery/build.properties and https://github.com/eclipse-equinox/p2/blob/f682eb19414bfcdef31ea498f4b3bffb76166d58/bundles/org.eclipse.equinox.p2.tests/pom.xml#L23 signing inner jars is in general disabled in other places of the build as it's not enhancing the security (signature for the inner jar is in the outer one MANIFEST.MF)

Contributes to eclipse-platform/eclipse.platform.releng.aggregator#1781

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
