### PR TITLE
Add JavaSE-23 EE to launching

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
@@ -41,6 +41,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 
 	// XXX: Note that this string is not yet standardized by OSGi, see http://wiki.osgi.org/wiki/Execution_Environment
 
+	private static final String JavaSE_23 = "JavaSE-23"; //$NON-NLS-1$
 	private static final String JavaSE_22 = "JavaSE-22"; //$NON-NLS-1$
 	private static final String JavaSE_21 = "JavaSE-21"; //$NON-NLS-1$
 	private static final String JavaSE_20 = "JavaSE-20"; //$NON-NLS-1$
@@ -108,6 +109,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_20, new String[] { JavaSE_19 });
 		mappings.put(JavaSE_21, new String[] { JavaSE_20 });
 		mappings.put(JavaSE_22, new String[] { JavaSE_21 });
+		mappings.put(JavaSE_23, new String[] { JavaSE_22 });
 	}
 	@Override
 	public CompatibleEnvironment[] analyze(IVMInstall vm, IProgressMonitor monitor) throws CoreException {
@@ -133,7 +135,9 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 					types = getTypes(CDC_FOUNDATION_1_1);
 				}
 			} else {
-				if (javaVersion.startsWith("22")) { //$NON-NLS-1$
+				if (javaVersion.startsWith("23")) { //$NON-NLS-1$
+					types = getTypes(JavaSE_23);
+				} else if (javaVersion.startsWith("22")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_22);
 				} else if (javaVersion.startsWith("21")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_21);

--- a/org.eclipse.jdt.launching/plugin.properties
+++ b/org.eclipse.jdt.launching/plugin.properties
@@ -83,6 +83,7 @@ environment.description.23 = Java Platform, Standard Edition 19
 environment.description.24 = Java Platform, Standard Edition 20
 environment.description.25 = Java Platform, Standard Edition 21
 environment.description.26 = Java Platform, Standard Edition 22
+environment.description.27 = Java Platform, Standard Edition 23
 
 classpathVariableInitializer.deprecated = Use the JRE System Library instead
 

--- a/org.eclipse.jdt.launching/plugin.xml
+++ b/org.eclipse.jdt.launching/plugin.xml
@@ -384,6 +384,11 @@
             id="JavaSE-22"
             compliance="22">
       </environment>
+      <environment
+            description="%environment.description.27"
+            id="JavaSE-23"
+            compliance="23">
+      </environment>
       <analyzer
             class="org.eclipse.jdt.internal.launching.environments.ExecutionEnvironmentAnalyzer"
             id="org.eclipse.jdt.launching.eeAnalyzer"/>


### PR DESCRIPTION
## What it does
As jdt.core still doesn't have the Java 23 support JavaSE-23 doesn't appear in the various places with EE lists but allows Java 23 JVM to be seen as super set of Java 22.
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1225

## How to test
Running child eclipse with Java 23 jvm should work without the validation errors shown in https://github.com/eclipse-pde/eclipse.pde/issues/1225 .

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
