### PR TITLE
Revert "Remove use of OPTION_JdtDebugCompileMode with OPTION_IgnoreUnnamedModuleForSplitPackage"

### DIFF
--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -390,7 +390,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			Map<String, String> extraOptions = Collections.emptyMap();
 			// if target runtime is above java 1.8 then switch the compiler to debug mode to ignore java 9 module system
 			if (JavaCore.compareJavaVersions(((IJavaDebugTarget) frame.getDebugTarget()).getVersion(), JavaCore.VERSION_1_8) > 0) {
-				extraOptions = Collections.singletonMap(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, JavaCore.ENABLED);
+				extraOptions = Collections.singletonMap(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
 			}
 
 			unit = parseCompilationUnit(

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JavaLogicalStructure.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JavaLogicalStructure.java
@@ -135,7 +135,7 @@ public class JavaLogicalStructure implements ILogicalStructureType, ILogicalStru
 		 */
 		public IJavaValue evaluate(String snippet) throws DebugException {
 			Map<String, String> compileOptions =
-					Collections.singletonMap(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, JavaCore.ENABLED);
+					Collections.singletonMap(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
 			ICompiledExpression compiledExpression = fEvaluationEngine
 					.getCompiledExpression(snippet, fEvaluationType, compileOptions);
 			if (compiledExpression.hasErrors()) {


### PR DESCRIPTION
This reverts commit f52ee5758f0fe241abae4e718d4e3cfc2b0a0e6c as it caused regression.

See https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/260

See also https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2340

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/309