### PR TITLE
Set Java 23 EE compliance accordingly

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
@@ -196,7 +196,9 @@ public class EnvironmentsManager implements IExecutionEnvironmentsManager, IVMIn
 
 	private String getExecutionEnvironmentCompliance(IExecutionEnvironment executionEnvironment) {
 		String desc = executionEnvironment.getId();
-		if (desc.indexOf(JavaCore.VERSION_22) != -1) {
+		if (desc.indexOf(JavaCore.VERSION_23) != -1) {
+			return JavaCore.VERSION_23;
+		} else if (desc.indexOf(JavaCore.VERSION_22) != -1) {
 			return JavaCore.VERSION_22;
 		} else if (desc.indexOf(JavaCore.VERSION_21) != -1) {
 			return JavaCore.VERSION_21;


### PR DESCRIPTION
## What it does
Sets Java 23 EE compliance to Java 23 now that constants are in jdt.core via https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2345. 
Fixes https://github.com/eclipse-pde/eclipse.pde/issues/1227

## How to test
org.eclipse.pde.core.tests.internal.classpath.ClasspathResolutionTest should succeed with this patch.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
