### PR TITLE
Revert "Equinox deletes some JRE1.1 profile"

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironment.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironment.java
@@ -492,7 +492,7 @@ class ExecutionEnvironment implements IExecutionEnvironment {
 	private static final String JAVASE = "JavaSE"; //$NON-NLS-1$
 
 	private String calculateVMExecutionEnvs(Version javaVersion) {
-		StringBuilder result = new StringBuilder("OSGi/Minimum-1.0, OSGi/Minimum-1.1, OSGi/Minimum-1.2, JavaSE/compact1-1.8, JavaSE/compact2-1.8, JavaSE/compact3-1.8, J2SE-1.2, J2SE-1.3, J2SE-1.4, J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.8"); //$NON-NLS-1$
+		StringBuilder result = new StringBuilder("OSGi/Minimum-1.0, OSGi/Minimum-1.1, OSGi/Minimum-1.2, JavaSE/compact1-1.8, JavaSE/compact2-1.8, JavaSE/compact3-1.8, JRE-1.1, J2SE-1.2, J2SE-1.3, J2SE-1.4, J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.8"); //$NON-NLS-1$
 		Version v = new Version(9, 0, 0);
 		while (v.compareTo(javaVersion) <= 0) {
 			result.append(',').append(' ').append(JAVASE).append('-').append(v.getMajor());

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
@@ -65,6 +65,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 	private static final String J2SE_1_4 = "J2SE-1.4"; //$NON-NLS-1$
 	private static final String J2SE_1_3 = "J2SE-1.3"; //$NON-NLS-1$
 	private static final String J2SE_1_2 = "J2SE-1.2"; //$NON-NLS-1$
+	private static final String JRE_1_1 = "JRE-1.1"; //$NON-NLS-1$
 
 	private static final String CDC_FOUNDATION_1_1 = "CDC-1.1/Foundation-1.1"; //$NON-NLS-1$
 	private static final String CDC_FOUNDATION_1_0 = "CDC-1.0/Foundation-1.0"; //$NON-NLS-1$
@@ -87,7 +88,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(CDC_FOUNDATION_1_1, new String[] {CDC_FOUNDATION_1_0, OSGI_MINIMUM_1_2});
 		mappings.put(OSGI_MINIMUM_1_1, new String[] {OSGI_MINIMUM_1_0});
 		mappings.put(OSGI_MINIMUM_1_2, new String[] {OSGI_MINIMUM_1_1});
-		mappings.put(J2SE_1_2, new String[] { CDC_FOUNDATION_1_1 });
+		mappings.put(J2SE_1_2, new String[] {JRE_1_1});
 		mappings.put(J2SE_1_3, new String[] {J2SE_1_2, CDC_FOUNDATION_1_0, OSGI_MINIMUM_1_0});
 		mappings.put(J2SE_1_4, new String[] {J2SE_1_3, CDC_FOUNDATION_1_1, OSGI_MINIMUM_1_2});
 		mappings.put(J2SE_1_5, new String[] {J2SE_1_4});
@@ -183,7 +184,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 					if ((vm instanceof IVMInstall3) && isFoundation1_1((IVMInstall3) vm)) {
 						types = getTypes(CDC_FOUNDATION_1_1);
 					} else {
-						types = getTypes(CDC_FOUNDATION_1_0);
+						types = getTypes(JRE_1_1);
 					}
 				} else if (javaVersion.startsWith("1.0")) { //$NON-NLS-1$
 					if ((vm instanceof IVMInstall3) && isFoundation1_0((IVMInstall3) vm)) {

--- a/org.eclipse.jdt.launching/plugin.properties
+++ b/org.eclipse.jdt.launching/plugin.properties
@@ -60,6 +60,7 @@ classpathContainerSourceContainerType.description= A collection of binary archiv
 environment.description.0 = Minimum environment to run the OSGi framework 1.0
 environment.description.1 = Minimum environment to run the OSGi framework 1.1
 environment.description.10 = Minimum environment to run the OSGi framework 1.2
+environment.description.2 = Java Runtime Environment 1.1
 environment.description.3 = Java 2 Platform, Standard Edition 1.2
 environment.description.4 = Java 2 Platform, Standard Edition 1.3
 environment.description.5 = Java 2 Platform, Standard Edition 1.4

--- a/org.eclipse.jdt.launching/plugin.xml
+++ b/org.eclipse.jdt.launching/plugin.xml
@@ -279,6 +279,10 @@
             id="OSGi/Minimum-1.2"
             ruleParticipant="org.eclipse.jdt.internal.launching.environments.DefaultAccessRuleParticipant"/>            
       <environment
+            description="%environment.description.2"
+            id="JRE-1.1"
+            ruleParticipant="org.eclipse.jdt.internal.launching.environments.DefaultAccessRuleParticipant"/>
+      <environment
             description="%environment.description.3"
             id="J2SE-1.2"
             ruleParticipant="org.eclipse.jdt.internal.launching.environments.DefaultAccessRuleParticipant"/>

--- a/org.eclipse.jdt.launching/schema/executionEnvironments.exsd
+++ b/org.eclipse.jdt.launching/schema/executionEnvironments.exsd
@@ -199,6 +199,7 @@
 &lt;li&gt;OSGi/Minimum-1.0&lt;/li&gt;
 &lt;li&gt;OSGi/Minimum-1.1&lt;/li&gt;
 &lt;li&gt;OSGi/Minimum-1.2&lt;/li&gt;
+&lt;li&gt;JRE-1.1&lt;/li&gt;
 &lt;li&gt;J2SE-1.2&lt;/li&gt;
 &lt;li&gt;J2SE-1.3&lt;/li&gt;
 &lt;li&gt;J2SE-1.4&lt;/li&gt;


### PR DESCRIPTION
This reverts commit 0cd092a7c274ebd6a2c6b33297b8f202e3b55301 because corresponding equinox change was reverted.

See discussion on https://github.com/eclipse-equinox/equinox/issues/571 
See https://github.com/eclipse-pde/eclipse.pde/issues/1231 
See https://github.com/eclipse-equinox/equinox/pull/596
