### PR TITLE
[Build] Make non-modular JDK available in Jenkins pipeline for tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,13 @@ pipeline {
 		maven 'apache-maven-latest'
 		jdk 'openjdk-jdk21-latest'
 	}
+	environment {
+		NON_MODULAR_JAVA_HOME = tool(type:'jdk', name:'temurin-jdk8-latest')
+	}
 	stages {
 		stage('Build') {
 			steps {
-				wrap([$class: 'Xvnc', useXauthority: true]) {
+				xvnc(useXauthority: true) {
 					sh """
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Ptest-on-javase-21 -Pbree-libs -Papi-check -Pjavadoc\


### PR DESCRIPTION
Prerequisite for https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/294#issuecomment-2072952578

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
