### PR TITLE
Use proper shell for modal dialogs

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/NoLineNumberAttributesStatusHandler.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/NoLineNumberAttributesStatusHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.debug.core.IStatusHandler;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 
 import com.sun.jdi.ReferenceType;
 
@@ -32,7 +33,7 @@ public class NoLineNumberAttributesStatusHandler implements IStatusHandler {
 		ReferenceType type= (ReferenceType) source;
 		IPreferenceStore preferenceStore= JDIDebugUIPlugin.getDefault().getPreferenceStore();
 		if (preferenceStore.getBoolean(IJDIPreferencesConstants.PREF_ALERT_UNABLE_TO_INSTALL_BREAKPOINT)) {
-			final ErrorDialogWithToggle dialog= new ErrorDialogWithToggle(JDIDebugUIPlugin.getActiveWorkbenchShell(),
+			final ErrorDialogWithToggle dialog = new ErrorDialogWithToggle(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(),
 					DebugUIMessages.NoLineNumberAttributesStatusHandler_Java_Breakpoint_1,
 					NLS.bind(DebugUIMessages.NoLineNumberAttributesStatusHandler_2, new String[] {type.name()}),
 					status, IJDIPreferencesConstants.PREF_ALERT_UNABLE_TO_INSTALL_BREAKPOINT,

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/SuspendTimeoutStatusHandler.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/SuspendTimeoutStatusHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.debug.core.IJavaThread;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 
 public class SuspendTimeoutStatusHandler implements IStatusHandler {
 
@@ -30,7 +31,7 @@ public class SuspendTimeoutStatusHandler implements IStatusHandler {
 	@Override
 	public Object handleStatus(IStatus status, Object source) throws CoreException {
 		IJavaThread thread= (IJavaThread) source;
-		final ErrorDialog dialog= new ErrorDialog(JDIDebugUIPlugin.getActiveWorkbenchShell(), DebugUIMessages.SuspendTimeoutHandler_suspend, NLS.bind(DebugUIMessages.SuspendTimeoutHandler_timeout_occurred, new String[] {thread.getName()}), status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO); //
+		final ErrorDialog dialog= new ErrorDialog(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), DebugUIMessages.SuspendTimeoutHandler_suspend, NLS.bind(DebugUIMessages.SuspendTimeoutHandler_timeout_occurred, new String[] {thread.getName()}), status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO); //
 		Display display= JDIDebugUIPlugin.getStandardDisplay();
 		display.syncExec(new Runnable() {
 			@Override

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/VMConnectTimeoutStatusHandler.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/VMConnectTimeoutStatusHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.debug.core.IStatusHandler;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * Prompts the user to continue waiting for a connection
@@ -36,7 +37,7 @@ public class VMConnectTimeoutStatusHandler implements IStatusHandler {
 			public void run() {
 				String title= LauncherMessages.VMConnectTimeoutStatusHandler_Java_Application_1;
 				String message= LauncherMessages.jdkLauncher_error_timeout;
-				result[0]= (MessageDialog.openQuestion(JDIDebugUIPlugin.getActiveWorkbenchShell(), title, message));
+				result[0] = (MessageDialog.openQuestion(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), title, message));
 			}
 		});
 		return Boolean.valueOf(result[0]);


### PR DESCRIPTION
This prevents the dialogs to appear behind the possible opened progress dialog (or any other modal dialog).

See https://github.com/eclipse-platform/eclipse.platform/issues/1373
