### PR TITLE
Add "Detect JVMs" Button to Preferences

### DIFF
--- a/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.ui; singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.debug.ui/pom.xml
+++ b/org.eclipse.jdt.debug.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.ui</artifactId>
-  <version>3.13.400-SNAPSHOT</version>
+  <version>3.13.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
   	<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
@@ -86,6 +86,8 @@ public class JREMessages extends NLS {
 	public static String JREsPreferencePage_7;
 	public static String JREsPreferencePage_8;
 
+	public static String JREsPreferencePage_DetectJVMsNow;
+
 	public static String addVMDialog_duplicateName;
 	public static String addVMDialog_enterLocation;
 	public static String addVMDialog_enterName;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
@@ -80,6 +80,7 @@ JREsPreferencePage_6=Apply
 JREsPreferencePage_7=Discard
 JREsPreferencePage_8=Apply Later
 JREsPreferencePage_9=You selected a JRE that this version of Eclipse JDT does not yet support fully. Some of the features may not work as expected.
+JREsPreferencePage_DetectJVMsNow=Auto detect
 
 addVMDialog_duplicateName=The JRE name is already in use.
 addVMDialog_enterLocation=Enter the home directory of the JRE.

--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -47,12 +47,12 @@ public class DetectVMInstallationsJob extends Job {
 
 	private static final Object FAMILY = DetectVMInstallationsJob.class;
 
-	private DetectVMInstallationsJob() {
+	public DetectVMInstallationsJob() {
 		super(LaunchingMessages.lookupInstalledJVMs);
 	}
 
 	@Override
-	protected IStatus run(IProgressMonitor monitor) {
+	public IStatus run(IProgressMonitor monitor) {
 		StandardVMType standardType = (StandardVMType) JavaRuntime.getVMInstallType(StandardVMType.ID_STANDARD_VM_TYPE);
 		Collection<File> candidates = computeCandidateVMs(standardType);
 		if (monitor.isCanceled()) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
@@ -22,6 +22,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -809,7 +811,7 @@ public class StandardVMType extends AbstractVMInstallType {
 		try {
 			if (version.startsWith(JavaCore.VERSION_22)) {
 				// To modify to version 22 after the release
-				return new URL("https://docs.oracle.com/en/java/javase/22/docs/api/"); //$NON-NLS-1$
+				return new URI("https://docs.oracle.com/en/java/javase/22/docs/api/").toURL(); //$NON-NLS-1$
 			} else if (version.startsWith(JavaCore.VERSION_21)) {
 				return new URL("https://docs.oracle.com/en/java/javase/21/docs/api/"); //$NON-NLS-1$
 			} else if (version.startsWith(JavaCore.VERSION_20)) {
@@ -851,7 +853,7 @@ public class StandardVMType extends AbstractVMInstallType {
 				// archived: http://download.oracle.com/javase/1.3/docs/api/
 				return new URL("https://docs.oracle.com/javase/1.5.0/docs/api/"); //$NON-NLS-1$
 			}
-		} catch (MalformedURLException e) {
+		} catch (URISyntaxException | MalformedURLException e) {
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.22.0-SNAPSHOT</version>
+  <version>3.22.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
I just had a workspace where an appropriate JVM was not installed,
![image](https://github.com/eclipse-jdt/eclipse.jdt.debug/assets/51790620/c2838268-616e-4e6d-be05-17365acaed0a)
I thought it would be easier to just add a Button for that case that runs the detect job instead of waiting for a restart:
![image](https://github.com/eclipse-jdt/eclipse.jdt.debug/assets/51790620/155d556c-a918-44e7-9835-7eff7bebfa6d)
