### PR TITLE
try to get OpenFromClipboardTests.testMethod_11 stable

### DIFF
--- a/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.tests; singleton:=true
-Bundle-Version: 3.12.400.qualifier
+Bundle-Version: 3.12.500.qualifier
 Bundle-ClassPath: javadebugtests.jar
 Bundle-Activator: org.eclipse.jdt.debug.testplugin.JavaTestPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.tests</artifactId>
-  <version>3.12.400-SNAPSHOT</version>
+  <version>3.12.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/OpenFromClipboardTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/OpenFromClipboardTests.java
@@ -15,8 +15,8 @@ package org.eclipse.jdt.debug.tests.ui;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.core.internal.resources.CharsetDeltaJob;
 import org.eclipse.core.internal.resources.ValidateProjectEncoding;
@@ -97,8 +97,8 @@ public class OpenFromClipboardTests {
 	}
 
 	private static void waitForEncodingRelatedJobs() {
-		TestUtil.waitForJobs("OpenFromClipboardTests", 10, 5_000, ValidateProjectEncoding.class);
-		TestUtil.waitForJobs("OpenFromClipboardTests", 10, 5_000, CharsetDeltaJob.FAMILY_CHARSET_DELTA);
+		TestUtil.waitForJobs("OpenFromClipboardTests", ValidateProjectEncoding.class, 0, 5_000);
+		TestUtil.waitForJobs("OpenFromClipboardTests", CharsetDeltaJob.FAMILY_CHARSET_DELTA, 0, 5_000);
 	}
 
 	private static IJavaProject createProject(String name) throws CoreException {
@@ -136,7 +136,7 @@ public class OpenFromClipboardTests {
 
 	private List<?> getJavaElementMatches(final String textData) throws Exception {
 		JavaModelManager.getIndexManager().waitForIndex(false, null);
-		final List<Object> matches = new ArrayList<>();
+		final List<Object> matches = new CopyOnWriteArrayList<>();
 		Display.getDefault().syncCall(() -> OpenFromClipboardAction.getJavaElementMatches(textData, matches));
 		return matches;
 	}


### PR DESCRIPTION
* use concurrent data structure for inter-thread communication
* fix wait for charsetsjobs instead of exclude for waiting for them
* use monotonic nantotime
