### PR TITLE
Launching: Do not log error to std.err, ignore closed project

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
@@ -1060,7 +1060,9 @@ public final class JavaRuntime {
 			return isModularJava(vm);
 		}
 		catch (CoreException e) {
-			e.printStackTrace();
+			if (e.getStatus().getCode() != IJavaLaunchConfigurationConstants.ERR_PROJECT_CLOSED) {
+				LaunchingPlugin.log(e);
+			}
 		}
 		return false;
 


### PR DESCRIPTION
Having a closed project, opening the Launch Configuration menu did log exception to std.err
