### PR TITLE
remove unnecessary casts

### DIFF
--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/SpecificDebugElementEventWaiter.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/SpecificDebugElementEventWaiter.java
@@ -40,7 +40,7 @@ public class SpecificDebugElementEventWaiter extends DebugEventWaiter {
 	public boolean accept(DebugEvent event) {
 		Object o = event.getSource();
 		if (o instanceof IDebugElement) {
-			return super.accept(event) && ((IDebugElement)o).equals(fDebugElement);
+			return super.accept(event) && o.equals(fDebugElement);
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/breakpoints/JavaBreakpointConditionEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/breakpoints/JavaBreakpointConditionEditor.java
@@ -58,7 +58,6 @@ import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.ITextOperationTarget;
-import org.eclipse.jface.text.ITextViewerExtension6;
 import org.eclipse.jface.text.IUndoManager;
 import org.eclipse.jface.text.IUndoManagerExtension;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
@@ -821,7 +820,7 @@ public final class JavaBreakpointConditionEditor extends AbstractJavaBreakpointE
 	 * @since 3.1
 	 */
 	private IUndoContext getUndoContext() {
-		IUndoManager undoManager= ((ITextViewerExtension6)fViewer).getUndoManager();
+		IUndoManager undoManager= fViewer.getUndoManager();
 		if (undoManager instanceof IUndoManagerExtension) {
 			return ((IUndoManagerExtension)undoManager).getUndoContext();
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaWatchExpressionDelegate.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaWatchExpressionDelegate.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.ui;
 
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IDebugElement;
@@ -61,7 +60,7 @@ public class JavaWatchExpressionDelegate implements IWatchExpressionDelegate {
 			fListener.watchEvaluationFinished(null);
 		} else {
 			// consult the adapter in case of a wrappered debug model
-			final IJavaStackFrame javaStackFrame = ((IAdaptable) frame).getAdapter(IJavaStackFrame.class);
+			final IJavaStackFrame javaStackFrame = frame.getAdapter(IJavaStackFrame.class);
 			if (javaStackFrame != null) {
 				doEvaluation(javaStackFrame);
 			} else {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/display/DisplayView.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/display/DisplayView.java
@@ -577,7 +577,7 @@ public class DisplayView extends ViewPart implements ITextInputListener, IPerspe
 	@Override
 	public void perspectiveChanged(IWorkbenchPage page, IPerspectiveDescriptor perspective, IWorkbenchPartReference partRef, String changeId) {
 		if (partRef instanceof IViewReference && changeId.equals(IWorkbenchPage.CHANGE_VIEW_HIDE)) {
-			String id = ((IViewReference) partRef).getId();
+			String id = partRef.getId();
 			if (id.equals(getViewSite().getId())) {
 				// Display view closed. Persist contents.
 			    String contents= getContents();

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.21.400.qualifier
+Bundle-Version: 3.21.500.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/ConditionalJump.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/ConditionalJump.java
@@ -36,7 +36,7 @@ public class ConditionalJump extends Jump {
 		if (conditionValue instanceof IJavaPrimitiveValue) {
 			condition = (IJavaPrimitiveValue) conditionValue;
 		} else if (conditionValue instanceof IJavaObject) {
-			if (((IJavaObject) conditionValue).getJavaType().getName().equals("java.lang.Boolean")) { //$NON-NLS-1$
+			if (conditionValue.getJavaType().getName().equals("java.lang.Boolean")) { //$NON-NLS-1$
 				condition = (IJavaPrimitiveValue) ((IJavaObject) conditionValue).getField("value", false).getValue(); //$NON-NLS-1$
 			}
 		}

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketAttachingConnectorImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketAttachingConnectorImpl.java
@@ -99,8 +99,7 @@ public class SocketAttachingConnectorImpl extends ConnectorImpl implements
 		String attribute = ""; //$NON-NLS-1$
 		try {
 			attribute = "hostname"; //$NON-NLS-1$
-			fHostname = ((Connector.StringArgument) connectionArgs
-					.get(attribute)).value();
+			fHostname = connectionArgs.get(attribute).value();
 			attribute = "port"; //$NON-NLS-1$
 			fPort = ((Connector.IntegerArgument) connectionArgs.get(attribute))
 					.intValue();

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketLaunchingConnectorImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketLaunchingConnectorImpl.java
@@ -149,22 +149,19 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 		String attribute = ""; //$NON-NLS-1$
 		try {
 			attribute = "home"; //$NON-NLS-1$
-			fHome = ((Connector.StringArgument) connectionArgs.get(attribute))
-					.value();
+			fHome = connectionArgs.get(attribute).value();
 			attribute = "options"; //$NON-NLS-1$
-			fOptions = ((Connector.StringArgument) connectionArgs
-					.get(attribute)).value();
+			fOptions = connectionArgs.get(attribute).value();
 			attribute = "main"; //$NON-NLS-1$
-			fMain = ((Connector.StringArgument) connectionArgs.get(attribute))
+			fMain = connectionArgs.get(attribute)
 					.value();
 			attribute = "suspend"; //$NON-NLS-1$
 			fSuspend = ((Connector.BooleanArgument) connectionArgs
 					.get(attribute)).booleanValue();
 			attribute = "quote"; //$NON-NLS-1$
-			((Connector.StringArgument) connectionArgs.get(attribute)).value();
+			connectionArgs.get(attribute).value();
 			attribute = "vmexec"; //$NON-NLS-1$
-			fLauncher = ((Connector.StringArgument) connectionArgs
-					.get(attribute)).value();
+			fLauncher = connectionArgs.get(attribute).value();
 			attribute = "includevirtualthreads"; //$NON-NLS-1$
 			fIncludeVirtualThreads = ((Connector.BooleanArgument) connectionArgs
 					.get(attribute)).booleanValue();
@@ -229,8 +226,7 @@ public class SocketLaunchingConnectorImpl extends ConnectorImpl implements
 		} catch (InterruptedIOException e) {
 			proc.destroy();
 			String message = NLS.bind(ConnectMessages.SocketLaunchingConnectorImpl_VM_did_not_connect_within_given_time___0__ms_1,
-							new String[] { ((Connector.IntegerArgument) args
-									.get("timeout")).value() }); //$NON-NLS-1$
+							new String[] { args.get("timeout").value() }); //$NON-NLS-1$
 			throw new VMStartException(message, proc);
 		}
 

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketRawLaunchingConnectorImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/connect/SocketRawLaunchingConnectorImpl.java
@@ -105,13 +105,11 @@ public class SocketRawLaunchingConnectorImpl extends ConnectorImpl implements
 		String attribute = ""; //$NON-NLS-1$
 		try {
 			attribute = "command"; //$NON-NLS-1$
-			fCommand = DebugPlugin.parseArguments(((Connector.StringArgument) connectionArgs
-					.get(attribute)).value());
+			fCommand = DebugPlugin.parseArguments(connectionArgs.get(attribute).value());
 			attribute = "address"; //$NON-NLS-1$
-			fAddress = ((Connector.StringArgument) connectionArgs
-					.get(attribute)).value();
+			fAddress = connectionArgs.get(attribute).value();
 			attribute = "quote"; //$NON-NLS-1$
-			((Connector.StringArgument) connectionArgs.get(attribute)).value();
+			connectionArgs.get(attribute).value();
 		} catch (ClassCastException e) {
 			throw new IllegalConnectorArgumentsException(
 					ConnectMessages.SocketRawLaunchingConnectorImpl_Connection_argument_is_not_of_the_right_type_8,
@@ -141,7 +139,7 @@ public class SocketRawLaunchingConnectorImpl extends ConnectorImpl implements
 		SocketListeningConnectorImpl listenConnector = new SocketListeningConnectorImpl(
 				virtualMachineManager());
 		Map<String, Connector.Argument> args = listenConnector.defaultArguments();
-		((Connector.IntegerArgument) args.get("port")).setValue(fAddress); //$NON-NLS-1$
+		args.get("port").setValue(fAddress); //$NON-NLS-1$
 		((Connector.IntegerArgument) args.get("timeout")).setValue(ACCEPT_TIMEOUT); //$NON-NLS-1$
 		listenConnector.startListening(args);
 
@@ -155,8 +153,7 @@ public class SocketRawLaunchingConnectorImpl extends ConnectorImpl implements
 		} catch (InterruptedIOException e) {
 			proc.destroy();
 			String message = NLS.bind(ConnectMessages.SocketLaunchingConnectorImpl_VM_did_not_connect_within_given_time___0__ms_1,
-							new String[] { ((Connector.IntegerArgument) args
-									.get("timeout")).value() }); //$NON-NLS-1$
+							new String[] { args.get("timeout").value() }); //$NON-NLS-1$
 			throw new VMStartException(message, proc);
 		}
 

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JDIPlaceholderVariable.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/logicalstructures/JDIPlaceholderVariable.java
@@ -135,7 +135,7 @@ public class JDIPlaceholderVariable extends PlatformObject implements
 	 */
 	@Override
 	public String getReferenceTypeName() throws DebugException {
-		return ((IJavaValue) getValue()).getReferenceTypeName();
+		return getValue().getReferenceTypeName();
 	}
 
 	/*
@@ -235,7 +235,7 @@ public class JDIPlaceholderVariable extends PlatformObject implements
 	 */
 	@Override
 	public IDebugTarget getDebugTarget() {
-		return ((IJavaValue) getValue()).getDebugTarget();
+		return getValue().getDebugTarget();
 	}
 
 	/*

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchableTester.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaLaunchableTester.java
@@ -303,9 +303,9 @@ public class JavaLaunchableTester extends PropertyTester {
 			IBuffer buffer= null;
 			IOpenable openable= type.getOpenable();
 			if (openable instanceof ICompilationUnit) {
-				buffer= ((ICompilationUnit) openable).getBuffer();
+				buffer= openable.getBuffer();
 			} else if (openable instanceof IClassFile) {
-				buffer= ((IClassFile) openable).getBuffer();
+				buffer= openable.getBuffer();
 			}
 			if (buffer == null) {
 				return false;
@@ -370,9 +370,9 @@ public class JavaLaunchableTester extends PropertyTester {
 			IBuffer buffer= null;
 			IOpenable openable= type.getOpenable();
 			if (openable instanceof ICompilationUnit) {
-				buffer= ((ICompilationUnit) openable).getBuffer();
+				buffer= openable.getBuffer();
 			} else if (openable instanceof IClassFile) {
-				buffer= ((IClassFile) openable).getBuffer();
+				buffer= openable.getBuffer();
 			}
 			if (buffer == null) {
 				return false;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/PListParser.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/PListParser.java
@@ -32,7 +32,6 @@ import org.eclipse.core.runtime.Status;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.w3c.dom.Text;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -232,7 +231,7 @@ public class PListParser {
 			node = list.item(i);
 			short nodeType = node.getNodeType();
 			if (nodeType == Node.TEXT_NODE) {
-				return ((Text) node).getNodeValue();
+				return node.getNodeValue();
 			}
 		}
 		return null;


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new errors/warnings will show up in the build.
