### PR TITLE
Make ExecutionEnvironment serializable

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ExecutionEnvironmentTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ExecutionEnvironmentTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,11 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.core;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.variables.IStringVariableManager;
@@ -259,4 +264,18 @@ public class ExecutionEnvironmentTests extends AbstractDebugTest {
 		}
 		assertNotNull("Test should have thrown an exception", null);
 	}
+
+	public void testSerializability() throws Exception {
+		IExecutionEnvironment ee = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-21");
+		ByteArrayOutputStream bs = new ByteArrayOutputStream();
+		try (ObjectOutputStream out = new ObjectOutputStream(bs);) {
+			out.writeObject(ee);
+		}
+		byte[] bytes = bs.toByteArray();
+		try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));) {
+			IExecutionEnvironment readEE = (IExecutionEnvironment) in.readObject();
+			assertSame(ee, readEE);
+		}
+	}
+
 }

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironment.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2022 IBM Corporation and others.
+ *  Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,8 @@ package org.eclipse.jdt.internal.launching.environments;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,6 +61,18 @@ import org.osgi.framework.Version;
  * @since 3.2
  */
 class ExecutionEnvironment implements IExecutionEnvironment {
+
+	record SerializationSurrogate(String id) implements Serializable {
+		@SuppressWarnings("unused") // called during de-serialization
+		Object readResolve() throws ObjectStreamException {
+			return JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(id);
+		}
+	}
+
+	@SuppressWarnings("unused") // called during serialization
+	Object writeReplace() throws ObjectStreamException {
+		return new SerializationSurrogate(getId());
+	}
 
 	/**
 	 * Add a VM changed listener to clear cached values when a VM changes or is removed

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironment.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2012 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.launching.environments;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Properties;
 
@@ -38,7 +39,7 @@ import org.eclipse.jdt.launching.LibraryLocation;
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
  */
-public interface IExecutionEnvironment {
+public interface IExecutionEnvironment extends Serializable {
 
 	/**
 	 * Returns a unique identifier for this execution environment.


### PR DESCRIPTION
## What it does
This PR has to goal to make the class `ExecutionEnvironment`, the only implementation of IExecutionEnvironment, serializable.

That is necessary for https://github.com/eclipse-pde/eclipse.pde/pull/1318 in order to still be able to use the SWT's `dnd.Transfor` for Copy&Pasting execution environments from one Manifest to the other.




## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
