### PR TITLE
Remove now unneeded @SuppressWarnings to fix compilation error

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/JDIDebugModel.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/JDIDebugModel.java
@@ -64,7 +64,6 @@ import com.sun.jdi.VirtualMachine;
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.
  */
-@SuppressWarnings("deprecation")
 public class JDIDebugModel {
 
 	/**


### PR DESCRIPTION
That was used for imports only and not needed anymore after https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2680

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2178
