### PR TITLE
One place to create JDIStackFrame's for given JDIThread

### DIFF
--- a/org.eclipse.jdt.debug.tests/testresources/JarRefProject/.classpath
+++ b/org.eclipse.jdt.debug.tests/testresources/JarRefProject/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="lib" path="/JarProject/lib/sample.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.jdt.debug.tests/testresources/JarRefProject/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.debug.tests/testresources/JarRefProject/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 #Wed Aug 03 13:31:56 CDT 2011
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.2
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.4
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=warning
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=warning
-org.eclipse.jdt.core.compiler.source=1.3
+org.eclipse.jdt.core.compiler.source=1.8

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/sourcelookup/JarSourceLookupTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/sourcelookup/JarSourceLookupTests.java
@@ -85,7 +85,7 @@ public class JarSourceLookupTests extends AbstractDebugTest {
 		IFile jar = jarProject.getFile("lib/sample.jar");
 		assertTrue("lib/sample.jar is missing in project: " + jarProject.getName(), jar.exists());
 
-		fgJarProject = createJavaProjectClone(RefPjName, testrpath.append(RefPjName).toString(), JavaProjectHelper.JAVA_SE_1_7_EE_NAME, true);
+		fgJarProject = createJavaProjectClone(RefPjName, testrpath.append(RefPjName).toString(), JavaProjectHelper.JAVA_SE_1_8_EE_NAME, true);
 
 		IProject jarRefProject = fgJarProject.getProject();
 		IFile cp = jarRefProject.getFile(".classpath");

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
@@ -204,7 +204,7 @@ public class JDIStackFrame extends JDIDebugElement implements IJavaStackFrame {
 			// invalidate this frame
 			bind(null, -1);
 			// return a new frame
-			return new JDIStackFrame(fThread, frame, depth);
+			return fThread.newJDIStackFrame(frame, depth);
 		}
 
 	}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -635,8 +635,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 													// create, if any
 				int depth = oldSize;
 				for (int i = newFrames - 1; i >= 0; i--) {
-					fStackFrames.add(0, new JDIStackFrame(this,
-							frames.get(i), depth));
+					fStackFrames.add(0, newJDIStackFrame(frames.get(i), depth));
 					depth++;
 				}
 				int numToRebind = Math.min(newSize, oldSize); // number of
@@ -663,6 +662,19 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 			return Collections.EMPTY_LIST;
 		}
 		return fStackFrames;
+	}
+
+	/**
+	 * Creates new {@link JDIStackFrame} linked to current thread
+	 *
+	 * @param frame
+	 *            non null, underlying frame
+	 * @param depth
+	 *            on the stack (0 is bottom)
+	 * @return never null
+	 */
+	protected JDIStackFrame newJDIStackFrame(StackFrame frame, int depth) {
+		return new JDIStackFrame(this, frame, depth);
 	}
 
 	/**


### PR DESCRIPTION
Currently JDIStackFrame instances for given JDIThread are created in two different places (JDIStackFrame and JDIThread).

Added JDIThread.newJDIStackFrame() method to make it clearer who is responsible for JDIStackFrame creation and to allow JDIThread implementations to create their custom JDIStackFrame objects.