### PR TITLE
Don't use javaw to start JVM for tests, it doesn't work on Linux

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -731,7 +731,7 @@ public abstract class AbstractJDITest extends TestCase {
 
 			Vector<String> commandLine = new Vector<>();
 
-			commandLine.add(binDirectory + "javaw");
+			commandLine.add(binDirectory + "java");
 			if (fBootPath.length() > 0) {
 				commandLine.add("-bootpath");
 				commandLine.add(fBootPath);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/466
