### PR TITLE
Adapt to change in JavaCore's new API about supported Java versions

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsPreferencePage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsPreferencePage.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.debug.ui.jres;
 
 
 import java.io.File;
-import java.util.List;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IStatus;
@@ -198,8 +197,7 @@ public class JREsPreferencePage extends PreferencePage implements IWorkbenchPref
 			fCompliance.setVisible(true);
 		}
 		else {
-			List<String> allVersions = JavaCore.getAllJavaSourceVersionsSupportedByCompiler();
-			String latest = allVersions.get(allVersions.size() - 1);
+			String latest = JavaCore.getAllJavaSourceVersionsSupportedByCompiler().last();
 			String vmver = null;
 			if (vmInstall instanceof AbstractVMInstall) {
 				AbstractVMInstall vm = (AbstractVMInstall) vmInstall;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/StandardVMPage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/StandardVMPage.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.debug.ui.jres;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
@@ -247,8 +246,7 @@ public class StandardVMPage extends AbstractVMInstallPage {
 		}
 		detectJavadocLocation();
 		if (s.isOK()) {
-			List<String> allVersions = JavaCore.getAllJavaSourceVersionsSupportedByCompiler();
-			String latest = allVersions.get(allVersions.size() - 1);
+			String latest = JavaCore.getAllJavaSourceVersionsSupportedByCompiler().last();
 			IVMInstallType vmType = fVM.getVMInstallType();
 			if (vmType instanceof StandardVMType) {
 				String vmver = ((StandardVMType) vmType).readReleaseVersion(getInstallLocation());


### PR DESCRIPTION
The new API is enhanced in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
