### PR TITLE
Return a SortedSet in EEManager's getSupportedExecutionEnvironments()

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsComboBlock.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsComboBlock.java
@@ -464,6 +464,7 @@ public class JREsComboBlock {
 	protected void fillWithWorkspaceProfiles() {
 		fEnvironments.clear();
 		fEnvironments.addAll(JavaRuntime.getExecutionEnvironmentsManager().getSupportedExecutionEnvironments());
+		Collections.reverse(fEnvironments);
 		String[] names = new String[fEnvironments.size()];
 		Iterator<Object> iter = fEnvironments.iterator();
 		int i = 0;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironmentsManager.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironmentsManager.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.launching.environments;
 
-import java.util.List;
+import java.util.SortedSet;
 
 import org.eclipse.jdt.core.JavaCore;
 
@@ -36,7 +36,7 @@ public interface IExecutionEnvironmentsManager {
 	public IExecutionEnvironment[] getExecutionEnvironments();
 
 	/**
-	 * Returns all execution environments supported by Java projects, <b>reverse</b> sorted by their id.
+	 * Returns all execution environments supported by Java projects, sorted by their id.
 	 *
 	 * @see IExecutionEnvironment#getId()
 	 * @see JavaCore#isJavaSourceVersionSupportedByCompiler(String)
@@ -44,7 +44,7 @@ public interface IExecutionEnvironmentsManager {
 	 * @return all registered execution environments sorted by their id
 	 * @since 3.23
 	 */
-	public List<IExecutionEnvironment> getSupportedExecutionEnvironments();
+	public SortedSet<IExecutionEnvironment> getSupportedExecutionEnvironments();
 
 	/**
 	 * Returns the execution environment associated with the given


### PR DESCRIPTION
## What it does

Similar to https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770, return a `SortedSet` in `IExecutionEnvironmentsManager.getSupportedExecutionEnvironments()`.

And don't reverse the EE order to be consistent with existing methods. As soon as Java-21 is used, one can just use the reversed() method inherited from `SequencedSet` to get the supported EE's in descending order.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
