### PR TITLE
Fix for Conditional Breakpoint not working in File class.

### DIFF
--- a/org.eclipse.jdt.debug.tests/testprograms/FileConditionSnippet2.java
+++ b/org.eclipse.jdt.debug.tests/testprograms/FileConditionSnippet2.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+import java.io.File;
+
+public class FileConditionSnippet2 {
+	public static void main(String[] ecs) {
+		int i = 0;
+		File parent = new File("parent");
+		File file = new File(parent,"test");	
+		System.out.println("COMPLETED");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -184,7 +184,10 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	public static final String BOUND_JRE_PROJECT_NAME = "BoundJRE";
 	public static final String CLONE_SUFFIX = "Clone";
 
-	final String[] LAUNCH_CONFIG_NAMES_1_4 = {"LargeSourceFile", "LotsOfFields", "Breakpoints", "InstanceVariablesTests", "LocalVariablesTests", "LocalVariableTests2", "StaticVariablesTests",
+	final String[] LAUNCH_CONFIG_NAMES_1_4 = { "LargeSourceFile", "LotsOfFields",
+			"Breakpoints",
+			"InstanceVariablesTests",
+			"LocalVariablesTests", "LocalVariableTests2", "StaticVariablesTests",
 			"DropTests", "ThrowsNPE", "ThrowsException", "org.eclipse.debug.tests.targets.Watchpoint",
 			"org.eclipse.debug.tests.targets.BreakpointsLocationBug344984", "org.eclipse.debug.tests.targets.CallLoop", "A",
 			"HitCountLooper", "CompileError", "MultiThreadedLoop", "HitCountException", "MultiThreadedException", "MultiThreadedList", "MethodLoop", "StepFilterOne",
@@ -201,7 +204,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 			"StepResult2", "StepResult3", "StepUncaught", "TriggerPoint_01", "BulkThreadCreationTest", "MethodExitAndException",
 			"Bug534319earlyStart", "Bug534319lateStart", "Bug534319singleThread", "Bug534319startBetwen", "MethodCall", "Bug538303", "Bug540243",
 			"OutSync", "OutSync2", "ConsoleOutputUmlaut", "ErrorRecurrence", "ModelPresentationTests", "Bug565982",
-			"SuspendVMConditionalBreakpointsTestSnippet" };
+			"SuspendVMConditionalBreakpointsTestSnippet", "FileConditionSnippet2" };
 
 	/**
 	 * the default timeout
@@ -1553,7 +1556,6 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		int lineNumber = breakpoint.getLineNumber();
 		int stackLine = thread.getTopStackFrame().getLineNumber();
 		assertEquals("line numbers of breakpoint and stack frame do not match", lineNumber, stackLine); //$NON-NLS-1$
-
 		return thread;
 	}
 

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.debug.tests.breakpoints.BreakpointLocationVerificationTes
 import org.eclipse.jdt.debug.tests.breakpoints.BreakpointWorkingSetTests;
 import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsInJava8Tests;
 import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsTests;
+import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsWithFileClass;
 import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsWithGenerics;
 import org.eclipse.jdt.debug.tests.breakpoints.DeferredBreakpointTests;
 import org.eclipse.jdt.debug.tests.breakpoints.ExceptionBreakpointTests;
@@ -394,6 +395,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(TestToggleBreakpointsTarget.class));
 		addTest(new TestSuite(TriggerPointBreakpointsTests.class));
 		addTest(new TestSuite(JavaThreadEventHandlerTests.class));
+		addTest(new TestSuite(ConditionalBreakpointsWithFileClass.class));
 
 		if (JavaProjectHelper.isJava8Compatible()) {
 			addTest(new TestSuite(TestToggleBreakpointsTarget8.class));

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation -- initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.breakpoints;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+
+public class ConditionalBreakpointsWithFileClass extends AbstractDebugTest {
+
+
+	public ConditionalBreakpointsWithFileClass(String name) {
+		super(name);
+	}
+
+	@Override
+	protected IJavaProject getProjectContext() {
+		return get14Project();
+	}
+
+	public void testFileConditionalBreakpointforFalse() throws Exception {
+		String typeName = "FileConditionSnippet2";
+		IJavaLineBreakpoint bp3 = createLineBreakpoint(20, typeName);
+		IJavaLineBreakpoint bp2 = createConditionalLineBreakpoint(364, "java.io.File", "false", true);
+		IJavaThread mainThread = null;
+		try {
+			Thread.sleep(10);
+			mainThread = launchToBreakpoint(typeName);
+			int hitLine = 0;
+			assertTrue("Thread should be suspended", mainThread.isSuspended());
+			hitLine = mainThread.getStackFrames()[0].getLineNumber();
+			assertEquals("Didn't suspend at the expected line", 20, hitLine);
+
+			bp2.delete();
+			bp3.delete();
+		} finally {
+			terminateAndRemove(mainThread);
+			removeAllBreakpoints();
+		}
+	}
+
+	public void testFileConditionalBreakpointforTrue() throws Exception {
+		String typeName = "FileConditionSnippet2";
+		IJavaLineBreakpoint bp3 = createLineBreakpoint(20, typeName);
+		IJavaThread mainThread = null;
+
+		try {
+			Thread.sleep(10);
+			mainThread = launchToBreakpoint(typeName);
+			mainThread.getTopStackFrame().stepInto();
+			IJavaLineBreakpoint bp2 = createConditionalLineBreakpoint(364, "java.io.File", "true", true);
+			int hitLine = 0;
+			mainThread.resume();
+			Thread.sleep(1000);
+			assertTrue("Thread should be suspended", mainThread.isSuspended());
+			hitLine = mainThread.getStackFrames()[0].getLineNumber();
+			assertEquals("Didn't suspend at the expected line", 364, hitLine);
+
+			bp2.delete();
+			bp3.delete();
+		} finally {
+			terminateAndRemove(mainThread);
+			removeAllBreakpoints();
+		}
+	}
+
+}

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -92,30 +92,24 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	/**
 	 * Regex to find occurrences of 'this' in a code snippet
 	 */
-	private static Pattern fgThisPattern = Pattern
-			.compile("(.*[^a-zA-Z0-9]+|^)(this)([^a-zA-Z0-9]+|$).*"); //$NON-NLS-1$
+	private static Pattern fgThisPattern = Pattern.compile("(.*[^a-zA-Z0-9]+|^)(this)([^a-zA-Z0-9]+|$).*"); //$NON-NLS-1$
 
 	/**
-	 * Filters variable change events during an evaluation to avoid refreshing
-	 * the variables view until done.
+	 * Filters variable change events during an evaluation to avoid refreshing the variables view until done.
 	 */
 	class EventFilter implements IDebugEventFilter {
 
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.debug.core.IDebugEventFilter#filterDebugEvents(org.eclipse
-		 * .debug.core.DebugEvent[])
+		 * @see org.eclipse.debug.core.IDebugEventFilter#filterDebugEvents(org.eclipse .debug.core.DebugEvent[])
 		 */
 		@Override
 		public DebugEvent[] filterDebugEvents(DebugEvent[] events) {
 			if (events.length == 1) {
 				DebugEvent event = events[0];
-				if (event.getSource() instanceof IJavaVariable
-						&& event.getKind() == DebugEvent.CHANGE) {
-					if (((IJavaVariable) event.getSource()).getDebugTarget()
-							.equals(getDebugTarget())) {
+				if (event.getSource() instanceof IJavaVariable && event.getKind() == DebugEvent.CHANGE) {
+					if (((IJavaVariable) event.getSource()).getDebugTarget().equals(getDebugTarget())) {
 						return null;
 					}
 				}
@@ -125,8 +119,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 	}
 
-	public ASTEvaluationEngine(IJavaProject project,
-			IJavaDebugTarget debugTarget) {
+	public ASTEvaluationEngine(IJavaProject project, IJavaDebugTarget debugTarget) {
 		setJavaProject(project);
 		setDebugTarget(debugTarget);
 	}
@@ -142,39 +135,27 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IEvaluationEngine#evaluate(java.lang.String,
-	 * org.eclipse.jdt.debug.core.IJavaStackFrame,
+	 * @see org.eclipse.jdt.debug.eval.IEvaluationEngine#evaluate(java.lang.String, org.eclipse.jdt.debug.core.IJavaStackFrame,
 	 * org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
 	 */
 	@Override
-	public void evaluate(String snippet, IJavaStackFrame frame,
-			IEvaluationListener listener, int evaluationDetail,
-			boolean hitBreakpoints) throws DebugException {
+	public void evaluate(String snippet, IJavaStackFrame frame, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) throws DebugException {
 		traceCaller(snippet, frame.getThread());
 		ICompiledExpression expression = getCompiledExpression(snippet, frame);
-		evaluateExpression(expression, frame, listener, evaluationDetail,
-				hitBreakpoints);
+		evaluateExpression(expression, frame, listener, evaluationDetail, hitBreakpoints);
 	}
 
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IEvaluationEngine#evaluate(java.lang.String,
-	 * org.eclipse.jdt.debug.core.IJavaObject,
-	 * org.eclipse.jdt.debug.core.IJavaThread,
-	 * org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
+	 * @see org.eclipse.jdt.debug.eval.IEvaluationEngine#evaluate(java.lang.String, org.eclipse.jdt.debug.core.IJavaObject,
+	 * org.eclipse.jdt.debug.core.IJavaThread, org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
 	 */
 	@Override
-	public void evaluate(String snippet, IJavaObject thisContext,
-			IJavaThread thread, IEvaluationListener listener,
-			int evaluationDetail, boolean hitBreakpoints) throws DebugException {
+	public void evaluate(String snippet, IJavaObject thisContext, IJavaThread thread, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) throws DebugException {
 		traceCaller(snippet, thread);
-		ICompiledExpression expression = getCompiledExpression(snippet,
-				thisContext);
-		evaluateExpression(expression, thisContext, thread, listener,
-				evaluationDetail, hitBreakpoints);
+		ICompiledExpression expression = getCompiledExpression(snippet, thisContext);
+		evaluateExpression(expression, thisContext, thread, listener, evaluationDetail, hitBreakpoints);
 	}
 
 	/**
@@ -207,94 +188,61 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IAstEvaluationEngine#evaluateExpression(org
-	 * .eclipse.jdt.debug.eval.ICompiledExpression,
-	 * org.eclipse.jdt.debug.core.IJavaStackFrame,
-	 * org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
+	 * @see org.eclipse.jdt.debug.eval.IAstEvaluationEngine#evaluateExpression(org .eclipse.jdt.debug.eval.ICompiledExpression,
+	 * org.eclipse.jdt.debug.core.IJavaStackFrame, org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
 	 */
 	@Override
-	public void evaluateExpression(ICompiledExpression expression,
-			IJavaStackFrame frame, IEvaluationListener listener,
-			int evaluationDetail, boolean hitBreakpoints) throws DebugException {
+	public void evaluateExpression(ICompiledExpression expression, IJavaStackFrame frame, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) throws DebugException {
 		traceCaller(expression.getSnippet(), frame.getThread());
 		RuntimeContext context = new RuntimeContext(getJavaProject(), frame);
-		doEvaluation(expression, context, (IJavaThread) frame.getThread(),
-				listener, evaluationDetail, hitBreakpoints);
+		doEvaluation(expression, context, (IJavaThread) frame.getThread(), listener, evaluationDetail, hitBreakpoints);
 	}
 
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IAstEvaluationEngine#evaluateExpression(org
-	 * .eclipse.jdt.debug.eval.ICompiledExpression,
-	 * org.eclipse.jdt.debug.core.IJavaObject,
-	 * org.eclipse.jdt.debug.core.IJavaThread,
-	 * org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
+	 * @see org.eclipse.jdt.debug.eval.IAstEvaluationEngine#evaluateExpression(org .eclipse.jdt.debug.eval.ICompiledExpression,
+	 * org.eclipse.jdt.debug.core.IJavaObject, org.eclipse.jdt.debug.core.IJavaThread, org.eclipse.jdt.debug.eval.IEvaluationListener, int, boolean)
 	 */
 	@Override
-	public void evaluateExpression(ICompiledExpression expression,
-			IJavaObject thisContext, IJavaThread thread,
-			IEvaluationListener listener, int evaluationDetail,
-			boolean hitBreakpoints) throws DebugException {
+	public void evaluateExpression(ICompiledExpression expression, IJavaObject thisContext, IJavaThread thread, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) throws DebugException {
 		traceCaller(expression.getSnippet(), thread);
 		IRuntimeContext context = null;
 		if (thisContext instanceof IJavaArray) {
-			context = new ArrayRuntimeContext((IJavaArray) thisContext, thread,
-					getJavaProject());
+			context = new ArrayRuntimeContext((IJavaArray) thisContext, thread, getJavaProject());
 		} else {
-			context = new JavaObjectRuntimeContext(thisContext,
-					getJavaProject(), thread);
+			context = new JavaObjectRuntimeContext(thisContext, getJavaProject(), thread);
 		}
-		doEvaluation(expression, context, thread, listener, evaluationDetail,
-				hitBreakpoints);
+		doEvaluation(expression, context, thread, listener, evaluationDetail, hitBreakpoints);
 	}
 
 	/**
-	 * Evaluates the given expression in the given thread and the given runtime
-	 * context.
+	 * Evaluates the given expression in the given thread and the given runtime context.
 	 */
-	private void doEvaluation(ICompiledExpression expression,
-			IRuntimeContext context, IJavaThread thread,
-			IEvaluationListener listener, int evaluationDetail,
-			boolean hitBreakpoints) throws DebugException {
+	private void doEvaluation(ICompiledExpression expression, IRuntimeContext context, IJavaThread thread, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) throws DebugException {
 		if (expression instanceof InstructionSequence) {
 			// don't queue explicit evaluation if the thread is all ready
 			// performing an evaluation.
 			if (thread.isSuspended() && ((JDIThread) thread).isInvokingMethod()
-					|| thread.isPerformingEvaluation()
-					&& evaluationDetail == DebugEvent.EVALUATION) {
-				EvaluationResult result = new EvaluationResult(this,
-						expression.getSnippet(), thread);
+					|| thread.isPerformingEvaluation() && evaluationDetail == DebugEvent.EVALUATION) {
+				EvaluationResult result = new EvaluationResult(this, expression.getSnippet(), thread);
 				result.addError(EvaluationEngineMessages.ASTEvaluationEngine_Cannot_perform_nested_evaluations);
 				listener.evaluationComplete(result);
 				return;
 			}
-			thread.queueRunnable(new EvalRunnable(
-					(InstructionSequence) expression, thread, context,
-					listener, evaluationDetail, hitBreakpoints));
+			thread.queueRunnable(new EvalRunnable((InstructionSequence) expression, thread, context, listener, evaluationDetail, hitBreakpoints));
 		} else {
-			throw new DebugException(
-					new Status(
-							IStatus.ERROR,
-							JDIDebugPlugin.getUniqueIdentifier(),
-							IStatus.OK,
-							EvaluationEngineMessages.ASTEvaluationEngine_AST_evaluation_engine_cannot_evaluate_expression,
-							null));
+			throw new DebugException(new Status(IStatus.ERROR, JDIDebugPlugin.getUniqueIdentifier(), IStatus.OK, EvaluationEngineMessages.ASTEvaluationEngine_AST_evaluation_engine_cannot_evaluate_expression, null));
 		}
 	}
 
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression
-	 * (java.lang.String, org.eclipse.jdt.debug.core.IJavaStackFrame)
+	 * @see org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression (java.lang.String, org.eclipse.jdt.debug.core.IJavaStackFrame)
 	 */
 	@Override
-	public ICompiledExpression getCompiledExpression(String snippet,
-			IJavaStackFrame frame) {
+	public ICompiledExpression getCompiledExpression(String snippet, IJavaStackFrame frame) {
 		IJavaProject javaProject = getJavaProject();
 		RuntimeContext context = new RuntimeContext(javaProject, frame);
 
@@ -339,7 +287,8 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 					IJavaVariable javaVariable = (IJavaVariable) variable;
 					final boolean lambdaField = LambdaUtils.isLambdaField(variable);
 					String name = variable.getName();
-					String variableName = (lambdaField && name.startsWith(ANONYMOUS_VAR_PREFIX)) ? name.substring(ANONYMOUS_VAR_PREFIX.length()) : name;
+					String variableName = (lambdaField && name.startsWith(ANONYMOUS_VAR_PREFIX)) ? name.substring(ANONYMOUS_VAR_PREFIX.length())
+							: name;
 					if (variableName != null && (!variableName.contains("$") || lambdaField)) { //$NON-NLS-1$
 						if (!isLocalType(javaVariable.getSignature()) && !names.contains(variableName)) {
 							locals[numLocals] = javaVariable;
@@ -370,8 +319,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			// String[] localVariables = Arrays.clonesub(localVariablesWithNull, names.size());
 			String[] localVariables = new String[names.size()];
 			System.arraycopy(localVariablesWithNull, 0, localVariables, 0, localVariables.length);
-			mapper = new EvaluationSourceGenerator(localTypesNames,
-					localVariables, snippet, getJavaProject());
+			mapper = new EvaluationSourceGenerator(localTypesNames, localVariables, snippet, getJavaProject());
 			// Compile in context of declaring type to get proper visibility of
 			// locals and members.
 			// Compiling in context of receiving type potentially provides
@@ -393,10 +341,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 				extraOptions = Collections.singletonMap(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
 			}
 
-			unit = parseCompilationUnit(
-					mapper.getSource(receivingType, frame.getLineNumber(), javaProject,
-							frame.isStatic()).toCharArray(),
-					mapper.getCompilationUnitName(), javaProject, extraOptions);
+			unit = parseCompilationUnit(mapper.getSource(receivingType, frame.getLineNumber(), javaProject, frame.isStatic()).toCharArray(), mapper.getCompilationUnitName(), javaProject, extraOptions);
 		} catch (CoreException e) {
 			InstructionSequence expression = new InstructionSequence(snippet);
 			expression.addError(e.getStatus().getMessage());
@@ -421,21 +366,19 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 	private void scanAndFixSignature(String genericSignature, String erasureSignature, StringBuilder fixedSignature) {
 		/*
-		 * This actually fix variables which are type of Generic Types which cannot be resolved to a type in the current context.
-		 * For example variable type like P_OUT in java.util.stream.ReferencePipeline.filter(Predicate<? super P_OUT>)
+		 * This actually fix variables which are type of Generic Types which cannot be resolved to a type in the current context. For example variable
+		 * type like P_OUT in java.util.stream.ReferencePipeline.filter(Predicate<? super P_OUT>)
 		 *
 		 * and also generic signature such as Ljava/util/function/Predicate<+Ljava/util/List<Ljava/lang/Integer;>;>; Ljava/util/Comparator<-TT;>;
 		 * which will fail to properly resolved to the type.
 		 */
-		if (genericSignature.startsWith(String.valueOf(Signature.C_TYPE_VARIABLE)) ||
-				genericSignature.startsWith(String.valueOf(Signature.C_CAPTURE)) ||
-				genericSignature.startsWith(String.valueOf(Signature.C_SUPER)))
-		{
+		if (genericSignature.startsWith(String.valueOf(Signature.C_TYPE_VARIABLE)) || genericSignature.startsWith(String.valueOf(Signature.C_CAPTURE))
+				|| genericSignature.startsWith(String.valueOf(Signature.C_SUPER))) {
 			fixedSignature.append(toDotQualified(erasureSignature));
 			return;
 		}
 
-		if(genericSignature.startsWith(String.valueOf(Signature.C_EXTENDS))) {
+		if (genericSignature.startsWith(String.valueOf(Signature.C_EXTENDS))) {
 			fixedSignature.append(toDotQualified(Signature.toString(getUpperBoundTypeSignature(genericSignature))));
 			return;
 		}
@@ -445,9 +388,8 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 		String[] typeArguments = Signature.getTypeArguments(genericSignature);
 		if (typeArguments.length > 0) {
-			if (typeArguments.length == 1 &&
-					(typeArguments[0].equals(String.valueOf(Signature.C_STAR)) ||
-							typeArguments[0].startsWith(String.valueOf(new char[] { Signature.C_EXTENDS, Signature.C_TYPE_VARIABLE })))) {
+			if (typeArguments.length == 1 && (typeArguments[0].equals(String.valueOf(Signature.C_STAR))
+					|| typeArguments[0].startsWith(String.valueOf(new char[] { Signature.C_EXTENDS, Signature.C_TYPE_VARIABLE })))) {
 				// this is when we have recursive generics or we have a upper bound type variable
 				// so remove the generics to avoid compilation issues.
 				return;
@@ -480,20 +422,17 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 		return CharOperation.subarray(typeParamaterSignature, 1, typeParamaterSignature.length);
 	}
 
-	private CompilationUnit parseCompilationUnit(char[] source,
-			String unitName, IJavaProject project) {
+	private CompilationUnit parseCompilationUnit(char[] source, String unitName, IJavaProject project) {
 		return parseCompilationUnit(source, unitName, project, Collections.EMPTY_MAP);
 	}
 
-	private CompilationUnit parseCompilationUnit(char[] source,
-			String unitName, IJavaProject project, Map<String, String> extraCompileOptions) {
+	private CompilationUnit parseCompilationUnit(char[] source, String unitName, IJavaProject project, Map<String, String> extraCompileOptions) {
 		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(source);
 		parser.setUnitName(unitName);
 		parser.setProject(project);
 		parser.setResolveBindings(true);
-		Map<String, String> options = EvaluationSourceGenerator
-				.getCompilerOptions(project);
+		Map<String, String> options = EvaluationSourceGenerator.getCompilerOptions(project);
 		options = new LinkedHashMap<>(options);
 		for (Entry<String, String> extraCompileOption : extraCompileOptions.entrySet()) {
 			options.put(extraCompileOption.getKey(), extraCompileOption.getValue());
@@ -519,11 +458,9 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	// ******
 
 	/**
-	 * Returns a compiled expression for an evaluation in the context of an
-	 * array as a receiver.
+	 * Returns a compiled expression for an evaluation in the context of an array as a receiver.
 	 */
-	private ICompiledExpression getCompiledExpression(String snippet,
-			IJavaArrayType arrayType) {
+	private ICompiledExpression getCompiledExpression(String snippet, IJavaArrayType arrayType) {
 		EvaluationSourceGenerator mapper = null;
 		CompilationUnit unit = null;
 		try {
@@ -534,8 +471,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			int dimension = 1;
 			IJavaType componentType = arrayType.getComponentType();
 			while (componentType instanceof IJavaArrayType) {
-				componentType = ((IJavaArrayType) componentType)
-						.getComponentType();
+				componentType = ((IJavaArrayType) componentType).getComponentType();
 				dimension++;
 			}
 
@@ -556,8 +492,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 			String[] localTypesNames = new String[] { typeName };
 			String[] localVariables = new String[] { ArrayRuntimeContext.ARRAY_THIS_VARIABLE };
-			mapper = new EvaluationSourceGenerator(localTypesNames,
-					localVariables, newSnippet, getJavaProject());
+			mapper = new EvaluationSourceGenerator(localTypesNames, localVariables, newSnippet, getJavaProject());
 
 			int index = typeName.indexOf('$');
 			// if the argument is an inner type, compile in context of outer
@@ -568,15 +503,9 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			IJavaType[] javaTypes = getDebugTarget().getJavaTypes(recTypeName);
 			if (javaTypes.length > 0) {
 				IJavaReferenceType recType = (IJavaReferenceType) javaTypes[0];
-				unit = parseCompilationUnit(
-						mapper.getSource(recType, -1, getJavaProject(), false)
-								.toCharArray(),
-						mapper.getCompilationUnitName(), javaProject);
+				unit = parseCompilationUnit(mapper.getSource(recType, -1, getJavaProject(), false).toCharArray(), mapper.getCompilationUnitName(), javaProject);
 			} else {
-				IStatus status = new Status(IStatus.ERROR,
-						JDIDebugPlugin.getUniqueIdentifier(),
-						JDIDebugPlugin.ERROR,
-						EvaluationEngineMessages.ASTEvaluationEngine_1, null);
+				IStatus status = new Status(IStatus.ERROR, JDIDebugPlugin.getUniqueIdentifier(), JDIDebugPlugin.ERROR, EvaluationEngineMessages.ASTEvaluationEngine_1, null);
 				throw new CoreException(status);
 			}
 		} catch (CoreException e) {
@@ -591,20 +520,15 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression
-	 * (java.lang.String, org.eclipse.jdt.debug.core.IJavaObject)
+	 * @see org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression (java.lang.String, org.eclipse.jdt.debug.core.IJavaObject)
 	 */
 	@Override
-	public ICompiledExpression getCompiledExpression(String snippet,
-			IJavaObject thisContext) {
+	public ICompiledExpression getCompiledExpression(String snippet, IJavaObject thisContext) {
 		try {
 			if (thisContext instanceof IJavaArray) {
-				return getCompiledExpression(snippet,
-						(IJavaArrayType) thisContext.getJavaType());
+				return getCompiledExpression(snippet, (IJavaArrayType) thisContext.getJavaType());
 			}
-			return getCompiledExpression(snippet,
-					(IJavaReferenceType) thisContext.getJavaType());
+			return getCompiledExpression(snippet, (IJavaReferenceType) thisContext.getJavaType());
 		} catch (DebugException e) {
 			InstructionSequence expression = new InstructionSequence(snippet);
 			expression.addError(e.getStatus().getMessage());
@@ -616,19 +540,15 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see
-	 * org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression
-	 * (java.lang.String, org.eclipse.jdt.debug.core.IJavaType)
+	 * @see org.eclipse.jdt.debug.eval.IAstEvaluationEngine#getCompiledExpression (java.lang.String, org.eclipse.jdt.debug.core.IJavaType)
 	 */
 	@Override
-	public ICompiledExpression getCompiledExpression(String snippet,
-			IJavaReferenceType type) {
+	public ICompiledExpression getCompiledExpression(String snippet, IJavaReferenceType type) {
 		return getCompiledExpression(snippet, type, Collections.EMPTY_MAP);
 	}
 
 	@Override
-	public ICompiledExpression getCompiledExpression(String snippet,
-			IJavaReferenceType type, Map<String, String> compileOptions) {
+	public ICompiledExpression getCompiledExpression(String snippet, IJavaReferenceType type, Map<String, String> compileOptions) {
 		if (type instanceof IJavaArrayType) {
 			return getCompiledExpression(snippet, (IJavaArrayType) type);
 		}
@@ -637,13 +557,10 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 		EvaluationSourceGenerator mapper = null;
 		CompilationUnit unit = null;
 
-		mapper = new EvaluationSourceGenerator(new String[0], new String[0],
-				snippet, getJavaProject());
+		mapper = new EvaluationSourceGenerator(new String[0], new String[0], snippet, getJavaProject());
 
 		try {
-			unit = parseCompilationUnit(
-					mapper.getSource(type, -1, javaProject, false).toCharArray(),
-					mapper.getCompilationUnitName(), javaProject, compileOptions);
+			unit = parseCompilationUnit(mapper.getSource(type, -1, javaProject, false).toCharArray(), mapper.getCompilationUnitName(), javaProject, compileOptions);
 		} catch (CoreException e) {
 			InstructionSequence expression = new InstructionSequence(snippet);
 			expression.addError(e.getStatus().getMessage());
@@ -653,8 +570,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	}
 
 	/**
-	 * Creates a compiled expression for the given snippet using the given
-	 * mapper and compilation unit (AST).
+	 * Creates a compiled expression for the given snippet using the given mapper and compilation unit (AST).
 	 *
 	 * @param snippet
 	 *            the code snippet to be compiled
@@ -663,16 +579,14 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 	 * @param unit
 	 *            the compilation unit (AST) generated for the snippet
 	 */
-	private ICompiledExpression createExpressionFromAST(String snippet,
-			EvaluationSourceGenerator mapper, CompilationUnit unit) {
+	private ICompiledExpression createExpressionFromAST(String snippet, EvaluationSourceGenerator mapper, CompilationUnit unit) {
 		IProblem[] problems = unit.getProblems();
 		if (problems.length != 0) {
 			boolean snippetError = false;
 			boolean runMethodError = false;
 			InstructionSequence errorSequence = new InstructionSequence(snippet);
 			int codeSnippetStart = mapper.getSnippetStart();
-			int codeSnippetEnd = codeSnippetStart
-					+ mapper.getSnippet().length();
+			int codeSnippetEnd = codeSnippetStart + mapper.getSnippet().length();
 			int runMethodStart = mapper.getRunMethodStart();
 			int runMethodEnd = runMethodStart + mapper.getRunMethodLength();
 			for (IProblem problem : problems) {
@@ -682,21 +596,17 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 					errorSequence.addError(problem.getMessage());
 					snippetError = true;
 				}
-				if (problemId == IProblem.VoidMethodReturnsValue
-						|| problemId == IProblem.NotVisibleMethod
-						|| problemId == IProblem.NotVisibleConstructor
-						|| problemId == IProblem.NotVisibleField
-						|| problemId == IProblem.NotVisibleType
-						|| problemId == IProblem.UnexpectedStaticModifierForMethod) {
+				if (problemId == IProblem.VoidMethodReturnsValue || problemId == IProblem.NotVisibleMethod
+						|| problemId == IProblem.NotVisibleConstructor || problemId == IProblem.NotVisibleField
+						|| problemId == IProblem.NotVisibleType || problemId == IProblem.UnexpectedStaticModifierForMethod
+						|| problemId == IProblem.AmbiguousType) {
 					continue;
 				}
 				if (problem.isError()) {
-					if (codeSnippetStart <= errorOffset
-							&& errorOffset <= codeSnippetEnd) {
+					if (codeSnippetStart <= errorOffset && errorOffset <= codeSnippetEnd) {
 						errorSequence.addError(problem.getMessage());
 						snippetError = true;
-					} else if (runMethodStart <= errorOffset
-							&& errorOffset <= runMethodEnd) {
+					} else if (runMethodStart <= errorOffset && errorOffset <= runMethodEnd) {
 						runMethodError = true;
 						DebugPlugin.log(new Status(IStatus.WARNING, DebugPlugin.getUniqueIdentifier(), "Compile error during code evaluation: " //$NON-NLS-1$
 								+ problem.getMessage()));
@@ -705,15 +615,13 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			}
 			if (snippetError || runMethodError) {
 				if (runMethodError) {
-					errorSequence
-							.addError(EvaluationEngineMessages.ASTEvaluationEngine_Evaluations_must_contain_either_an_expression_or_a_block_of_well_formed_statements_1);
+					errorSequence.addError(EvaluationEngineMessages.ASTEvaluationEngine_Evaluations_must_contain_either_an_expression_or_a_block_of_well_formed_statements_1);
 				}
 				return errorSequence;
 			}
 		}
 
-		ASTInstructionCompiler visitor = new ASTInstructionCompiler(
-				mapper.getSnippetStart(), snippet, getJavaProject());
+		ASTInstructionCompiler visitor = new ASTInstructionCompiler(mapper.getSnippetStart(), snippet, getJavaProject());
 		unit.accept(visitor);
 
 		return visitor.getInstructions();
@@ -764,9 +672,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 
 		private final boolean fDisableGcOnResult;
 
-		public EvalRunnable(InstructionSequence expression, IJavaThread thread,
-				IRuntimeContext context, IEvaluationListener listener,
-				int evaluationDetail, boolean hitBreakpoints) {
+		public EvalRunnable(InstructionSequence expression, IJavaThread thread, IRuntimeContext context, IEvaluationListener listener, int evaluationDetail, boolean hitBreakpoints) {
 			fExpression = expression;
 			fThread = thread;
 			fContext = context;
@@ -805,8 +711,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 				buf.append(fHitBreakpoints);
 				JDIDebugOptions.trace(buf.toString());
 			}
-			EvaluationResult result = new EvaluationResult(
-					ASTEvaluationEngine.this, fExpression.getSnippet(), fThread);
+			EvaluationResult result = new EvaluationResult(ASTEvaluationEngine.this, fExpression.getSnippet(), fThread);
 			if (fExpression.hasErrors()) {
 				String[] errors = fExpression.getErrorMessages();
 				for (String error : errors) {
@@ -827,8 +732,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 				}
 				return;
 			}
-			final Interpreter interpreter = new Interpreter(fExpression,
-					fContext);
+			final Interpreter interpreter = new Interpreter(fExpression, fContext);
 
 			class EvaluationRunnable implements IEvaluationRunnable, ITerminate {
 
@@ -843,22 +747,14 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 						interpreter.execute(fDisableGcOnResult);
 					} catch (CoreException exception) {
 						fException = exception;
-						if (fEvaluationDetail == DebugEvent.EVALUATION
-								&& exception.getStatus().getException() instanceof InvocationException) {
+						if (fEvaluationDetail == DebugEvent.EVALUATION && exception.getStatus().getException() instanceof InvocationException) {
 							// print the stack trace for the exception if an
 							// *explicit* evaluation
-							InvocationException invocationException = (InvocationException) exception
-									.getStatus().getException();
-							ObjectReference exObject = invocationException
-									.exception();
-							IJavaObject modelObject = (IJavaObject) JDIValue
-									.createValue(
-											(JDIDebugTarget) getDebugTarget(),
-											exObject);
+							InvocationException invocationException = (InvocationException) exception.getStatus().getException();
+							ObjectReference exObject = invocationException.exception();
+							IJavaObject modelObject = (IJavaObject) JDIValue.createValue((JDIDebugTarget) getDebugTarget(), exObject);
 							try {
-								modelObject
-										.sendMessage(
-												"printStackTrace", "()V", null, jt, false); //$NON-NLS-1$ //$NON-NLS-2$
+								modelObject.sendMessage("printStackTrace", "()V", null, jt, false); //$NON-NLS-1$ //$NON-NLS-2$
 							} catch (DebugException e) {
 								// unable to print stack trace
 							}
@@ -893,8 +789,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 			CoreException exception = null;
 			long start = System.currentTimeMillis();
 			try {
-				fThread.runEvaluation(er, null, fEvaluationDetail,
-						fHitBreakpoints);
+				fThread.runEvaluation(er, null, fEvaluationDetail, fHitBreakpoints);
 			} catch (DebugException e) {
 				exception = e;
 			}
@@ -917,8 +812,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 				if (exception instanceof DebugException) {
 					result.setException((DebugException) exception);
 				} else {
-					result.setException(new DebugException(exception
-							.getStatus()));
+					result.setException(new DebugException(exception.getStatus()));
 				}
 			} else {
 				if (value != null) {

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -568,7 +568,6 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 		}
 		return createExpressionFromAST(snippet, mapper, unit);
 	}
-
 	/**
 	 * Creates a compiled expression for the given snippet using the given mapper and compilation unit (AST).
 	 *

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -108,8 +108,8 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 		public DebugEvent[] filterDebugEvents(DebugEvent[] events) {
 			if (events.length == 1) {
 				DebugEvent event = events[0];
-				if (event.getSource() instanceof IJavaVariable && event.getKind() == DebugEvent.CHANGE) {
-					if (((IJavaVariable) event.getSource()).getDebugTarget().equals(getDebugTarget())) {
+				if (event.getSource() instanceof IJavaVariable jvar && event.getKind() == DebugEvent.CHANGE) {
+					if (jvar.getDebugTarget().equals(getDebugTarget())) {
 						return null;
 					}
 				}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
@@ -62,10 +62,8 @@ public class ConditionalBreakpointHandler implements IJavaBreakpointListener {
 	private boolean fHasErrors = false;
 
 	/**
-	 * Listens for evaluation completion for condition evaluation. If an
-	 * evaluation evaluates <code>true</code> or has an error, this breakpoint
-	 * will suspend the thread in which the breakpoint was hit. If the
-	 * evaluation returns <code>false</code>, the thread is resumed.
+	 * Listens for evaluation completion for condition evaluation. If an evaluation evaluates <code>true</code> or has an error, this breakpoint will
+	 * suspend the thread in which the breakpoint was hit. If the evaluation returns <code>false</code>, the thread is resumed.
 	 */
 	class EvaluationListener implements IEvaluationListener {
 

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.debug.core.breakpoints;
 import java.text.MessageFormat;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -220,10 +221,17 @@ public class ConditionalBreakpointHandler implements IJavaBreakpointListener {
 						.getTopStackFrame();
 				IJavaProject project = lineBreakpoint.getJavaProject(frame);
 				if (project == null) {
-					IMarker marker = breakpoint.getMarker(); // my changes
+					IMarker marker = breakpoint.getMarker();
 					if (marker != null) {
 						IResource res = marker.getResource();
-						project = JavaCore.create(res.getProject());
+						IProject curProject = res.getProject();
+						if (curProject != null) {
+							project = JavaCore.create(curProject);
+						} else {
+							fireConditionHasErrors(lineBreakpoint, new Message[] {
+									new Message(JDIDebugBreakpointMessages.JavaLineBreakpoint_Unable_to_compile_conditional_breakpoint___missing_Java_project_context__1, -1) });
+							return SUSPEND;
+						}
 					} else {
 						fireConditionHasErrors(lineBreakpoint, new Message[] {
 								new Message(JDIDebugBreakpointMessages.JavaLineBreakpoint_Unable_to_compile_conditional_breakpoint___missing_Java_project_context__1, -1) });

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ConditionalBreakpointHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,8 @@ package org.eclipse.jdt.internal.debug.core.breakpoints;
 
 import java.text.MessageFormat;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -23,6 +25,7 @@ import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.Message;
 import org.eclipse.jdt.debug.core.IJavaBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaBreakpointListener;
@@ -217,12 +220,15 @@ public class ConditionalBreakpointHandler implements IJavaBreakpointListener {
 						.getTopStackFrame();
 				IJavaProject project = lineBreakpoint.getJavaProject(frame);
 				if (project == null) {
-					fireConditionHasErrors(
-							lineBreakpoint,
-							new Message[] { new Message(
-									JDIDebugBreakpointMessages.JavaLineBreakpoint_Unable_to_compile_conditional_breakpoint___missing_Java_project_context__1,
-									-1) });
-					return SUSPEND;
+					IMarker marker = breakpoint.getMarker(); // my changes
+					if (marker != null) {
+						IResource res = marker.getResource();
+						project = JavaCore.create(res.getProject());
+					} else {
+						fireConditionHasErrors(lineBreakpoint, new Message[] {
+								new Message(JDIDebugBreakpointMessages.JavaLineBreakpoint_Unable_to_compile_conditional_breakpoint___missing_Java_project_context__1, -1) });
+						return SUSPEND;
+					}
 				}
 				IJavaDebugTarget target = (IJavaDebugTarget) thread
 						.getDebugTarget();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Handles all the exception caused while evaluating conditional breakpoint java.io.File class 
Fix for -> https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/273

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Drop a valid conditional breakpoint inside java.io.File class and run in debug mode

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
