### PR TITLE
Don't close a ZipEntryStorage archive file when obtaining its name

### DIFF
--- a/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -50,7 +50,7 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.resources,
- org.eclipse.debug.core;bundle-version="[3.12.0,4.0.0)"
+ org.eclipse.debug.core;bundle-version="[3.22.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.jdt.debug.ui

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/SourceElementQualifierProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/SourceElementQualifierProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,12 +15,10 @@ package org.eclipse.jdt.internal.debug.ui.launcher;
 
 
 import java.io.File;
-import java.io.IOException;
-import java.util.zip.ZipFile;
+import java.nio.file.Path;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
 import org.eclipse.debug.core.sourcelookup.containers.ZipEntryStorage;
 import org.eclipse.jdt.core.IJavaElement;
@@ -49,25 +47,17 @@ public class SourceElementQualifierProvider extends LabelProvider implements ILa
 		if (element instanceof IJavaElement) {
 			IJavaElement parent = ((IJavaElement)element).getParent();
 			return fJavaLabels.getText(parent);
-		} else if (element instanceof ZipEntryStorage) {
-			ZipEntryStorage storage = (ZipEntryStorage)element;
-			try (ZipFile archive = storage.getArchive()) {
-				String zipFileName = archive.getName();
-				IPath path = new Path(zipFileName);
-				IRuntimeClasspathEntry entry = JavaRuntime.newArchiveRuntimeClasspathEntry(path);
-				IResource res = entry.getResource();
-				if (res == null) {
-					// external
-					return zipFileName;
-				}
-				// internal
-				return res.getName();
-			} catch (IOException e) {
-				e.printStackTrace();
+		} else if (element instanceof ZipEntryStorage storage) {
+			Path zipFile = storage.getArchivePath();
+			IPath path = IPath.fromPath(zipFile);
+			IRuntimeClasspathEntry entry = JavaRuntime.newArchiveRuntimeClasspathEntry(path);
+			IResource res = entry.getResource();
+			if (res == null) {
+				// external
+				return zipFile.toString();
 			}
-			// ZipFile archive = storage.getArchive();
-			// String zipFileName = archive.getName();
-
+			// internal
+			return res.getName();
 		} else if (element instanceof LocalFileStorage) {
 			LocalFileStorage storage = (LocalFileStorage)element;
 			File extFile = storage.getFile();


### PR DESCRIPTION
## What it does
Don't close a `ZipEntryStorage` archive file when obtaining its name to show a label.

The setup where this happens not not very simple and I therefore didn't replicated this in a clean debug environment yet, but from looking at all callers of `ZipEntryStorage.getArchive()`, this seems to be the only one closing it. 
So this is just an anticipated fix that hopefully fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2251

Of course it could also be some code that is holding a reference to the archive from before it was passed to a `ZipEntryStorage`.

This basically reverts 876dd122b731d57c8fe0da71298783891bc6c1f4 done for [Bug 558863](https://bugs.eclipse.org/bugs/show_bug.cgi?id=558863)

## How to test

The setup where this happens not not very simple and I was not yet able to replicate and test this.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
