### PR TITLE
jdi tests: more logging, reduce timeout

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractReader.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractReader.java
@@ -19,7 +19,7 @@ package org.eclipse.debug.jdi.tests;
 abstract public class AbstractReader {
 	protected String fName;
 	protected Thread fReaderThread;
-	protected boolean fIsStopping = false;
+	protected volatile boolean fIsStopping = false;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
jdi tests do not start on I Builds and we don't know why.
