### PR TITLE
jdi tests: log ClassPrepareEvent referenceType

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ClassPrepareEventWaiter.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/ClassPrepareEventWaiter.java
@@ -35,6 +35,7 @@ public class ClassPrepareEventWaiter extends EventWaiter {
 	 */
 	@Override
 	public boolean classPrepare(ClassPrepareEvent event) {
+		System.out.println("classPrepare:" + event + " " + event.referenceType().name());
 		if (event.referenceType().name().equals(fClassName)) {
 			notifyEvent(event);
 			return fShouldGo;

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventReader.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventReader.java
@@ -63,7 +63,6 @@ public class EventReader extends AbstractReader {
 	 * Returns whether the VM should be resumed.
 	 */
 	private boolean dispath(Event event, EventListener listener) {
-		System.out.println(event);
 		if (event instanceof AccessWatchpointEvent) {
 			return listener.accessWatchpoint((AccessWatchpointEvent) event);
 		}

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.21.500.qualifier
+Bundle-Version: 3.21.600.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/event/ClassPrepareEventImpl.java
+++ b/org.eclipse.jdt.debug/jdi/org/eclipse/jdi/internal/event/ClassPrepareEventImpl.java
@@ -77,4 +77,10 @@ public class ClassPrepareEventImpl extends EventImpl implements
 	public String classSignature() {
 		return referenceType().signature();
 	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " referenceType=" + referenceType().name(); //$NON-NLS-1$
+	}
+
 }


### PR DESCRIPTION
ClassPrepareEvent for org.eclipse.debug.jdi.tests.program.MainClass missing after 10000ms
