### PR TITLE
Add auto-detection for JVMs installed by mise

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -133,6 +133,7 @@ public class DetectVMInstallationsJob extends Job {
 			rootDirectories.add(new File("/usr/lib/jvm")); //$NON-NLS-1$
 		}
 		rootDirectories.add(new File(System.getProperty("user.home"), ".sdkman/candidates/java")); //$NON-NLS-1$ //$NON-NLS-2$
+		rootDirectories.add(new File(System.getProperty("user.home"), ".local/share/mise/installs/java")); //$NON-NLS-1$ //$NON-NLS-2$
 
 		Set<File> directories = rootDirectories.stream().filter(File::isDirectory)
 			.map(dir -> dir.listFiles(File::isDirectory))


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
mise-en-place (https://mise.jdx.dev/) is a polyglot tool version manager which easily install various JDKs in the user's home directory in a fixed place


## How to test

1. Install mise
2. mise install java@temurin-22
3. Open the preference page, and check if the new JVM is detected

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
