### PR TITLE
[test] jdi: fix AutomatedSuite dir classpath

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -124,7 +124,8 @@ public abstract class AbstractJDITest extends TestCase {
 		try {
 			String cp = MainClass.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
 			System.out.println("MainClass path=" + cp);
-			if (new File(cp).isDirectory() && !cp.endsWith(File.separatorChar + "bin" + File.separatorChar)) {
+			if (new File(cp).isDirectory() && !cp.endsWith(File.separatorChar + "bin" + File.separatorChar)
+					&& new File(cp + "bin" + File.separatorChar).isDirectory()) {
 				cp += "bin" + File.separatorChar;
 			}
 			fClassPath = new File(cp).getAbsolutePath();


### PR DESCRIPTION
Do not add "bin" to classpath for "Eclipse-BundleShape: dir" in MANIFEST.MF
