### PR TITLE
Cleanup VirtualThreadTest

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDI Tests
 Bundle-SymbolicName: org.eclipse.jdt.debug.jdi.tests; singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse
 Require-Bundle: org.junit,

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.jdi.tests</artifactId>
-  <version>1.1.100-SNAPSHOT</version>
+  <version>1.1.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>


### PR DESCRIPTION
- enable-preview not needed anymore
- don't hide exceptions
- use nio to create directories
- added more info about compiler used to compile program

See https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/503
