### PR TITLE
Fix warnings during JDI tests run

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -752,7 +752,7 @@ public abstract class AbstractJDITest extends TestCase {
 			commandLine.add("-classpath");
 			commandLine.add(fClassPath);
 			addDebugOptions(commandLine);
-			commandLine.add("-Djava.compiler=NONE");
+			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
 			injectVMArgs(commandLine);
 			commandLine.add(getMainClassName());
@@ -795,7 +795,7 @@ public abstract class AbstractJDITest extends TestCase {
 			commandLine.add("-classpath");
 			commandLine.add(fClassPath);
 			addDebugOptions(commandLine);
-			commandLine.add("-Djava.compiler=NONE");
+			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
 			injectVMArgs(commandLine);
 			commandLine.add(getMainClassName());
@@ -829,7 +829,7 @@ public abstract class AbstractJDITest extends TestCase {
 			commandLine.add("-classpath");
 			commandLine.add(fClassPath);
 			addDebugOptions(commandLine);
-			commandLine.add("-Djava.compiler=NONE");
+			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
 			injectVMArgs(commandLine);
 			commandLine.add(getMainClassName());
@@ -838,6 +838,14 @@ public abstract class AbstractJDITest extends TestCase {
 
 		} catch (IOException e) {
 			throw new Error("Could not launch the VM because " + e.getMessage());
+		}
+	}
+
+	private void addNoJITCompilerOption(Vector<String> commandLine) {
+		if (Runtime.version().feature() >= 21) {
+			commandLine.add("-Xint");
+		} else {
+			commandLine.add("-Djava.compiler=NONE");
 		}
 	}
 

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -850,18 +850,7 @@ public abstract class AbstractJDITest extends TestCase {
 	}
 
 	private void addDebugOptions(Vector<String> commandLine) {
-		int vmVersion = 0;
-		try {
-			String versionString = System.getProperty("java.specification.version");
-			if (versionString != null) {
-				String[] nums = versionString.split("\\.");
-				if (nums.length > 0) {
-					vmVersion = Integer.parseInt(nums[0]);
-				}
-			}
-		} catch (Exception e) {
-			// Ignore
-		}
+		int vmVersion = Runtime.version().feature();
 		if (vmVersion < 22) {
 			commandLine.add("-Xdebug");
 		}


### PR DESCRIPTION
"The java.compiler system property is obsolete and no longer supported, use -Xint" as can be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20240923-1800/testresults/ep434I-unit-cen64-gtk3-java21_linux.gtk.x86_64_21/org.eclipse.debug.jdi.tests.AutomatedSuite.txt .
This is an effort to fix failing tests on Java 21+ :
* https://download.eclipse.org/eclipse/downloads/drops4/I20240923-1800/testresults/html/org.eclipse.jdt.debug.jdi.tests_ep434I-unit-cen64-gtk3-java21_linux.gtk.x86_64_21.html
* https://download.eclipse.org/eclipse/downloads/drops4/I20240923-1800/testresults/html/org.eclipse.jdt.debug.jdi.tests_ep434I-unit-cen64-gtk3-java23_linux.gtk.x86_64_23.html
