### PR TITLE
Remove workaround in jdt.debug.tests

### DIFF
--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -34,14 +34,6 @@
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
           <appArgLine>-consoleLog</appArgLine>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Was needed for https://bugs.eclipse.org/462862 which is fixed long ago.

