### PR TITLE
Fix for VM not connected in JDI tests

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -16,6 +16,7 @@ package org.eclipse.debug.jdi.tests;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
@@ -1205,7 +1206,16 @@ public abstract class AbstractJDITest extends TestCase {
 		// We want subsequent connections to use different ports, unless a
 		// VM exec sting is given.
 		if (fVmCmd == null) {
-			fBackEndPort += 2;
+			ServerSocket socket;
+			try {
+				socket = new ServerSocket(0);
+				int availablePort = socket.getLocalPort();
+				socket.close(); //Available but always initialized
+				fBackEndPort = availablePort;
+			} catch (IOException e) {
+				fBackEndPort +=2;
+			
+			}
 		}
 	}
 	/**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Choose more optimised way for choosing port numbers for VM connections
VM Fix for - #508 
## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
