### PR TITLE
Bugfix for #518 (Setting a breakpoint inside lambda with object).

### DIFF
--- a/org.eclipse.jdt.debug.tests/java8/ClassWithLambdas.java
+++ b/org.eclipse.jdt.debug.tests/java8/ClassWithLambdas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024 Christian Schima.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.jdt.debug.tests/java8/ClassWithLambdas.java
+++ b/org.eclipse.jdt.debug.tests/java8/ClassWithLambdas.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christian Schima - initial API and implementation
+ *******************************************************************************/
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Test class with lambdas.
+ */
+public class ClassWithLambdas {
+	
+	private static class Factory {
+		public static <T> Factory create(Supplier<T> supplier, Consumer<T> consumer) {
+			return new Factory();
+		}
+	}
+
+	public ClassWithLambdas(String parent) {
+		Factory.create(() -> Optional.of(""), sample -> new Consumer<Optional<String>>() {
+
+			Optional<String> lastSample = Optional.empty();
+
+			@Override
+			public void accept(Optional<String> currentSample) {
+				lastSample.ifPresent(System.out::println);
+				currentSample.ifPresent(System.out::println);
+				lastSample = currentSample;
+			}
+		});
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/TestToggleBreakpointsTarget8.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/TestToggleBreakpointsTarget8.java
@@ -25,12 +25,8 @@ import org.eclipse.jdt.debug.tests.TestUtil;
  */
 public class TestToggleBreakpointsTarget8 extends AbstractToggleBreakpointsTarget {
 
-
-
-
 	public TestToggleBreakpointsTarget8(String name) {
 		super(name);
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -124,4 +120,26 @@ public class TestToggleBreakpointsTarget8 extends AbstractToggleBreakpointsTarge
 		}
 	}
 
+	/**
+	 * Tests that a line breakpoints in an lambda expression works.
+	 */
+	public void testLineBreakpointInsideLambda() throws Exception {
+		Listener listener = new Listener();
+		IBreakpointManager manager = getBreakpointManager();
+		manager.addBreakpointListener(listener);
+		try {
+			Path path = new Path("java8/ClassWithLambdas.java");
+			final int lineNr = 35; // 0 based offset in document line numbers
+			toggleBreakpoint(path, lineNr);
+			TestUtil.waitForJobs(getName(), 100, DEFAULT_TIMEOUT);
+			IBreakpoint added = listener.getAdded();
+			assertTrue("Should be a line breakpoint", added instanceof IJavaLineBreakpoint);
+			IJavaLineBreakpoint breakpoint = (IJavaLineBreakpoint) added;
+			assertEquals("Wrong line number", lineNr + 1, breakpoint.getLineNumber());
+			assertEquals("Wrong type name", "ClassWithLambdas", breakpoint.getTypeName());
+		} finally {
+			manager.removeBreakpointListener(listener);
+			removeAllBreakpoints();
+		}
+	}
 }

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
@@ -1067,14 +1067,8 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 						}
 					}
 
-				// Lambda body can be a block (which is handled above) or an (arbitrary) expression. So maybe the
-				// following cases are insufficient and should be replaced by handling the general
-				// org.eclipse.jdt.core.dom.Expression.
-				} else if (body instanceof LambdaExpression) {
-					body.accept(this);
-				} else if (body instanceof MethodInvocation) {
-					body.accept(this);
-				} else if (body instanceof ClassInstanceCreation) {
+					// Lambda body can be a block (which is handled above) or an (arbitrary) expression.
+				} else if (body instanceof Expression) {
 					body.accept(this);
 				}
 			}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/ValidBreakpointLocationLocator.java
@@ -1066,9 +1066,15 @@ public class ValidBreakpointLocationLocator extends ASTVisitor {
 
 						}
 					}
+
+				// Lambda body can be a block (which is handled above) or an (arbitrary) expression. So maybe the
+				// following cases are insufficient and should be replaced by handling the general
+				// org.eclipse.jdt.core.dom.Expression.
 				} else if (body instanceof LambdaExpression) {
 					body.accept(this);
 				} else if (body instanceof MethodInvocation) {
+					body.accept(this);
+				} else if (body instanceof ClassInstanceCreation) {
 					body.accept(this);
 				}
 			}


### PR DESCRIPTION
## What it does
Fixes #518 

## How to test
Try to set a breakpoint inside a lambda expression with its body beginning with an anonymous class declaration.
See #518 as example. The new breakpoint should appear as usual and jumping to it from inside the "breakpoint view" must work.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
