### PR TITLE
Properly add "on the fly" compiled classes to the started JVM classpath

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,9 @@ Bundle-Version: 1.1.200.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse
 Require-Bundle: org.junit,
- org.eclipse.jdt.debug
+ org.eclipse.jdt.debug,
+ org.eclipse.equinox.common,
+ org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/org.eclipse.jdt.debug.jdi.tests/build.properties
+++ b/org.eclipse.jdt.debug.jdi.tests/build.properties
@@ -16,4 +16,6 @@ output.. = bin/
 bin.includes = about.html,\
                test.xml,\
                META-INF/,\
-               .
+               .,\
+               java19/
+

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -751,7 +751,7 @@ public abstract class AbstractJDITest extends TestCase {
 			}
 
 			commandLine.add("-classpath");
-			commandLine.add(fClassPath);
+			commandLine.add(enhanceClasspath(fClassPath));
 			addDebugOptions(commandLine);
 			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
@@ -763,6 +763,15 @@ public abstract class AbstractJDITest extends TestCase {
 		} catch (IOException e) {
 			throw new Error("Could not launch the VM because " + e.getMessage());
 		}
+	}
+
+	/**
+	 * @param classPath
+	 *            current classpath used for JVM
+	 * @return possibly updated classpath with more entries required by a test
+	 */
+	protected String enhanceClasspath(String classPath) {
+		return fClassPath;
 	}
 
 	/**
@@ -794,7 +803,7 @@ public abstract class AbstractJDITest extends TestCase {
 				commandLine.add(fBootPath);
 			}
 			commandLine.add("-classpath");
-			commandLine.add(fClassPath);
+			commandLine.add(enhanceClasspath(fClassPath));
 			addDebugOptions(commandLine);
 			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
@@ -828,7 +837,7 @@ public abstract class AbstractJDITest extends TestCase {
 			}
 
 			commandLine.add("-classpath");
-			commandLine.add(fClassPath);
+			commandLine.add(enhanceClasspath(fClassPath));
 			addDebugOptions(commandLine);
 			addNoJITCompilerOption(commandLine);
 			commandLine.add("-Xrunjdwp:transport=dt_socket,address=" + fBackEndPort + ",suspend=y,server=y");
@@ -1214,7 +1223,7 @@ public abstract class AbstractJDITest extends TestCase {
 				fBackEndPort = availablePort;
 			} catch (IOException e) {
 				fBackEndPort +=2;
-			
+
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/503
