### PR TITLE
[test] don't log VMDisconnectedException while stopping

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventReader.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/EventReader.java
@@ -146,7 +146,9 @@ public class EventReader extends AbstractReader {
 					return;
 				}
 			} catch (VMDisconnectedException e) {
-				e.printStackTrace();
+				if (!fIsStopping) {
+					e.printStackTrace();
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
https://download.eclipse.org/eclipse/downloads/drops4/I20241008-1810/testresults/consolelogs/ep434I-unit-win32-java17_win32.win32.x86_64_17_consolelog.txt

```
     [java] com.sun.jdi.VMDisconnectedException: Got com.sun.jdi.connect.spi.ClosedConnectionException from Virtual Machine
     [java] 	at org.eclipse.jdi.internal.connect.PacketReceiveManager.getCommand(PacketReceiveManager.java:140)
     [java] 	at org.eclipse.jdi.internal.MirrorImpl.getCommandVM(MirrorImpl.java:336)
     [java] 	at org.eclipse.jdi.internal.event.EventQueueImpl.remove(EventQueueImpl.java:70)
     [java] 	at org.eclipse.jdi.internal.event.EventQueueImpl.remove(EventQueueImpl.java:49)
     [java] 	at org.eclipse.debug.jdi.tests.EventReader.readerLoop(EventReader.java:117)
     [java] 	at org.eclipse.debug.jdi.tests.AbstractReader$1.run(AbstractReader.java:43)
     [java] 	at java.base/java.lang.Thread.run(Thread.java:833)
```