### PR TITLE
[Oomph-Setup] Add jdt.debug configuration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Please bear in mind that this project is almost entirely developed by volunteers
 If you do not provide the implementation yourself (or pay someone to do it for you), the bug might never get fixed.
 If it is a serious bug, other people than you might care enough to provide a fix.
 
+[![Create Eclipse Development Environment for JDT Debug](https://download.eclipse.org/oomph/www/setups/svg/JDT_Debug.svg)](
+https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-jdt/eclipse.jdt.debug/master/org.eclipse.jdt.debug.setup/JdtDebugConfiguration.setup&show=true
+"Click to open Eclipse-Installer Auto Launch or drag into your running installer")
+
 ## License
 
 [Eclipse Public License (EPL) v2.0](https://www.eclipse.org/legal/epl-2.0/)

--- a/org.eclipse.jdt.debug.setup/.project
+++ b/org.eclipse.jdt.debug.setup/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.jdt.debug.setup</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.debug.setup/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.debug.setup/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.debug.setup/JdtDebugConfiguration.setup
+++ b/org.eclipse.jdt.debug.setup/JdtDebugConfiguration.setup
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="JDT Debug">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="badgeLabel">
+      <value>JDT Debug</value>
+    </detail>
+  </annotation>
+  <installation
+      name="jdt.debug.installation"
+      label="JDT Debug Installation">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="installation.id.default"
+        value="jdt-debug"/>
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.applications']/@products[name='eclipse.platform.sdk']/@versions[name='latest']"/>
+    <description>The JDT Debug installation provides the latest tools needed to work with the project's source code.</description>
+  </installation>
+  <workspace
+      name="jdt.debug.workspace"
+      label="JDT Debug Workspace">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="workspace.id.default"
+        value="jdt-debug-ws"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+        <detail
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions">
+          <value>record</value>
+        </detail>
+      </annotation>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.oomph.setup.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions"
+            value="true"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.ui.ide">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
+            value="JDT Debug"/>
+      </setupTask>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="eclipse.git.authentication.style"
+        defaultValue="anonymous"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='debug']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='debug']/@projects[name='tests']/@streams[name='master']"/>
+    <description>The JDT Debug workspace provides all the source code of the project.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;code>JDT Debug&lt;/code> configuration provisions a dedicated development environment for the complete set of projects that comprise JDT Debug,
+    i.e. the projects that are contained in the &lt;a href=&quot;https://github.com/eclipse-jdt/jdt.debug&quot;>jdt.debug&lt;/a> repository.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest successful integration build of the &lt;code>Eclipse Platform SDK&lt;/code>,
+    the PDE target platform, like the installation, is also based on the latest integration build,
+    and the API baseline is based on the most recent release.
+    &lt;p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
## What it does
Add jdt.debug configuration setup.
Additionally add a styled and drag&drop-able Oomph Configuration button to the main README.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2430

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
