### PR TITLE
Virtual threads debug view update + JdiThread new API + unit tests

### DIFF
--- a/org.eclipse.jdt.debug.tests/java23/Main21.java
+++ b/org.eclipse.jdt.debug.tests/java23/Main21.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation -- initial API and implementation
+ *******************************************************************************/
+public class Main21 {
+	public static void main(String[] args) throws InterruptedException {
+		try {
+			Thread.startVirtualThread(() -> {
+				int p = 21;
+				System.out.println("From Virtual Thread");
+			}).join();
+		} catch (Exception e) {
+
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -633,6 +633,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				jp.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
 				cfgs.add(createLaunchConfiguration(jp, "Main1"));
 				cfgs.add(createLaunchConfiguration(jp, "Main2"));
+				cfgs.add(createLaunchConfiguration(jp, "Main21"));
 				loaded23 = true;
 				waitForBuild();
 				assertNoErrorMarkersExist(jp.getProject());

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -150,6 +150,7 @@ import org.eclipse.jdt.debug.tests.ui.DetailPaneManagerTests;
 import org.eclipse.jdt.debug.tests.ui.JavaSnippetEditorTest;
 import org.eclipse.jdt.debug.tests.ui.OpenFromClipboardTests;
 import org.eclipse.jdt.debug.tests.ui.ViewManagementTests;
+import org.eclipse.jdt.debug.tests.ui.VirtualThreadsDebugViewTests;
 import org.eclipse.jdt.debug.tests.ui.presentation.ModelPresentationTests;
 import org.eclipse.jdt.debug.tests.ui.presentation.ModelPresentationTests18;
 import org.eclipse.jdt.debug.tests.variables.DetailFormatterTests;
@@ -416,6 +417,9 @@ public class AutomatedSuite extends DebugSuite {
 
 		if (JavaProjectHelper.isJava16_Compatible()) {
 			addTest(new TestSuite(RecordBreakpointTests.class));
+		}
+		if (Runtime.version().feature() == 23 && JavaProjectHelper.isJava23_Compatible()) {
+			addTest(new TestSuite(VirtualThreadsDebugViewTests.class));
 		}
 	}
 }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/VirtualThreadsDebugViewTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/VirtualThreadsDebugViewTests.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation -- initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.ui;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IThread;
+import org.eclipse.debug.internal.ui.views.console.ProcessConsole;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.IDebugModelPresentation;
+import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.debug.ui.IDebugView;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.core.IJavaBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.tests.TestUtil;
+import org.eclipse.jdt.debug.ui.IJavaDebugUIConstants;
+import org.eclipse.jdt.internal.debug.core.model.JDIThread;
+import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
+import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.test.OrderedTestSuite;
+
+import junit.framework.Test;
+
+/**
+ * Tests for debug view.
+ */
+public class VirtualThreadsDebugViewTests extends AbstractDebugUiTests {
+
+
+	public static Test suite() {
+		return new OrderedTestSuite(VirtualThreadsDebugViewTests.class);
+	}
+
+	private boolean showMonitorsOriginal;
+
+	public VirtualThreadsDebugViewTests(String name) {
+		super(name);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		IPreferenceStore jdiUIPreferences = JDIDebugUIPlugin.getDefault().getPreferenceStore();
+		showMonitorsOriginal = jdiUIPreferences.getBoolean(IJavaDebugUIConstants.PREF_SHOW_MONITOR_THREAD_INFO);
+		jdiUIPreferences.setValue(IJavaDebugUIConstants.PREF_SHOW_MONITOR_THREAD_INFO, true);
+		resetPerspective(DebugViewPerspectiveFactory.ID);
+		processUiEvents(100);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		IPreferenceStore jdiUIPreferences = JDIDebugUIPlugin.getDefault().getPreferenceStore();
+		jdiUIPreferences.setValue(IJavaDebugUIConstants.PREF_SHOW_MONITOR_THREAD_INFO, showMonitorsOriginal);
+		sync(() -> getActivePage().closeAllEditors(false));
+		processUiEvents(100);
+		super.tearDown();
+	}
+
+	@Override
+	protected IJavaProject getProjectContext() {
+		return super.get23Project();
+	}
+
+	public void testVirtualThreadDebugView() throws Exception {
+		sync(() -> TestUtil.waitForJobs(getName(), 1000, 10000, ProcessConsole.class));
+		final String typeName = "Main21";
+		final int bpLine = 19;
+
+		IJavaBreakpoint bp = createLineBreakpoint(bpLine, "", typeName + ".java", typeName);
+		bp.setSuspendPolicy(IJavaBreakpoint.SUSPEND_THREAD);
+		IFile file = (IFile) bp.getMarker().getResource();
+		assertEquals(typeName + ".java", file.getName());
+
+		IJavaThread mainThread = null;
+		try {
+			mainThread = launchToBreakpoint(typeName);
+			assertNotNull("Launch unsuccessful", mainThread);
+			openEditorInDebug(file);
+			Display.getDefault().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					IDebugView debugViewer = (IDebugView) getActivePage().findView(IDebugUIConstants.ID_DEBUG_VIEW);
+					ISelection currentSelection = debugViewer.getViewer().getSelection();
+					assertNotNull("Debug View is not available", debugViewer);
+					if (currentSelection instanceof IStructuredSelection) {
+						Object sel = ((IStructuredSelection) currentSelection).getFirstElement();
+						if (sel instanceof IStackFrame stackFrame) {
+							IThread thread = stackFrame.getThread();
+							JDIThread vThread = (JDIThread) stackFrame.getThread();
+							assertTrue("Not a Virtual thread", vThread.isVirtualThread());
+							StructuredSelection select = new StructuredSelection(thread);
+							debugViewer.getViewer().setSelection(select, true);
+							IDebugModelPresentation md = DebugUITools.newDebugModelPresentation();
+							String groupName = md.getText(thread);
+							assertTrue("Not a Virtual thread grouping", groupName.contains("Virtual"));
+						}
+					}
+				}
+			});
+			mainThread.resume();
+		} catch (Exception e) {
+			DebugPlugin.log(e);
+		} finally {
+			terminateAndRemove(mainThread);
+			removeAllBreakpoints();
+		}
+	}
+
+	private void openEditorInDebug(IFile file) throws Exception {
+		// Let now all pending jobs proceed, ignore console jobs
+		sync(() -> TestUtil.waitForJobs(getName(), 1000, 10000, ProcessConsole.class));
+		@SuppressWarnings("unused")
+		CompilationUnitEditor part = (CompilationUnitEditor) sync(() -> openEditor(file));
+		processUiEvents(100);
+	}
+
+	@Override
+	protected boolean enableUIEventLoopProcessingInWaiter() {
+		return true;
+	}
+
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -243,6 +243,23 @@ public class DebugUIMessages extends NLS {
 	public static String thread_daemon_system_suspended_fieldmodification;
 	public static String thread_daemon_system_suspended_runtoline;
 	public static String thread_daemon_system_suspended_classprepare;
+
+	public static String thread_virtual_terminated;
+	public static String thread_virtual_evaluating;
+	public static String thread_virtual_running;
+	public static String thread_virtual_stepping;
+	public static String thread_virtual_suspended;
+	public static String thread_virtual_suspended_problem;
+	public static String thread_virtual_suspended_fieldaccess;
+	public static String thread_virtual_suspended_linebreakpoint;
+	public static String thread_virtual_suspended_methodentry;
+	public static String thread_virtual_suspended_exception;
+	public static String thread_virtual_suspended_exception_uncaught;
+	public static String thread_virtual_suspended_methodexit;
+	public static String thread_virtual_suspended_fieldmodification;
+	public static String thread_virtual_suspended_runtoline;
+	public static String thread_virtual_suspended_classprepare;
+
 	public static String SuspendTimeoutHandler_suspend;
 	public static String SuspendTimeoutHandler_timeout_occurred;
 	public static String JDIDebugUIPlugin_Searching_1;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -184,6 +184,21 @@ thread_daemon_system_suspended_fieldmodification=Daemon System Thread [{0}] (Sus
 thread_daemon_system_suspended_runtoline=Daemon System Thread [{0}] (Suspended (run to line {1} in {2}))
 thread_daemon_system_suspended_classprepare=Daemon System Thread [{0}] (Class load: {1})
 
+thread_virtual_terminated=Virtual Thread [{0}] (Terminated)
+thread_virtual_evaluating=Virtual Thread [{0}] (Evaluating)
+thread_virtual_running=Virtual Thread [{0}] (Running)
+thread_virtual_stepping=Virtual Thread [{0}] (Stepping)
+thread_virtual_suspended=Virtual Thread [{0}] (Suspended)
+thread_virtual_suspended_problem=Virtual Thread [{0}] (Suspended ({1}))
+thread_virtual_suspended_fieldaccess=Virtual Thread [{0}] (Suspended (access of field {1} in {2}))
+thread_virtual_suspended_linebreakpoint=Virtual Thread [{0}] (Suspended (breakpoint at line {1} in {2}))
+thread_virtual_suspended_methodentry=Virtual Thread [{0}] (Suspended (entry into method {1} in {2}))
+thread_virtual_suspended_exception=Virtual Thread [{0}] (Suspended (exception {1}))
+thread_virtual_suspended_exception_uncaught=Virtual Thread [{0}] (Suspended (uncaught exception {1}))
+thread_virtual_suspended_methodexit=Virtual Thread [{0}] (Suspended (exit of method {1} in {2}))
+thread_virtual_suspended_fieldmodification=Virtual Thread [{0}] (Suspended (modification of field {1} in {2}))
+thread_virtual_suspended_runtoline=Virtual Thread [{0}] (Suspended (run to line {1} in {2}))
+thread_virtual_suspended_classprepare=Virtual Thread [{0}] (Class load: {1})
 ###############################################################################
 
 JDIModelPresentation_target_suspended=\ (Suspended)

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/BreakpointListenerManager.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/BreakpointListenerManager.java
@@ -60,8 +60,7 @@ public class BreakpointListenerManager {
 	/**
 	 * Proxy to a breakpoint listener
 	 */
-	private class JavaBreakpointListenerProxy implements
-			IJavaBreakpointListener {
+	private class JavaBreakpointListenerProxy implements IJavaBreakpointListener {
 
 		private final IConfigurationElement fConfigElement;
 		private IJavaBreakpointListener fDelegate;
@@ -78,8 +77,7 @@ public class BreakpointListenerManager {
 		private synchronized IJavaBreakpointListener getDelegate() {
 			if (fDelegate == null) {
 				try {
-					fDelegate = (IJavaBreakpointListener) fConfigElement
-							.createExecutableExtension(ATTR_CLASS);
+					fDelegate = (IJavaBreakpointListener) fConfigElement.createExecutableExtension(ATTR_CLASS);
 				} catch (CoreException e) {
 					JDIDebugPlugin.log(e);
 				}
@@ -91,14 +89,11 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.jdt.debug.core.IJavaBreakpointListener#addingBreakpoint
-		 * (org.eclipse.jdt.debug.core.IJavaDebugTarget,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#addingBreakpoint (org.eclipse.jdt.debug.core.IJavaDebugTarget,
 		 * org.eclipse.jdt.debug.core.IJavaBreakpoint)
 		 */
 		@Override
-		public void addingBreakpoint(IJavaDebugTarget target,
-				IJavaBreakpoint breakpoint) {
+		public void addingBreakpoint(IJavaDebugTarget target, IJavaBreakpoint breakpoint) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				delegate.addingBreakpoint(target, breakpoint);
@@ -121,14 +116,11 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#
-		 * breakpointHasCompilationErrors
-		 * (org.eclipse.jdt.debug.core.IJavaLineBreakpoint,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener# breakpointHasCompilationErrors (org.eclipse.jdt.debug.core.IJavaLineBreakpoint,
 		 * org.eclipse.jdt.core.dom.Message[])
 		 */
 		@Override
-		public void breakpointHasCompilationErrors(
-				IJavaLineBreakpoint breakpoint, Message[] errors) {
+		public void breakpointHasCompilationErrors(IJavaLineBreakpoint breakpoint, Message[] errors) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				delegate.breakpointHasCompilationErrors(breakpoint, errors);
@@ -138,14 +130,11 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#
-		 * breakpointHasRuntimeException
-		 * (org.eclipse.jdt.debug.core.IJavaLineBreakpoint,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener# breakpointHasRuntimeException (org.eclipse.jdt.debug.core.IJavaLineBreakpoint,
 		 * org.eclipse.debug.core.DebugException)
 		 */
 		@Override
-		public void breakpointHasRuntimeException(
-				IJavaLineBreakpoint breakpoint, DebugException exception) {
+		public void breakpointHasRuntimeException(IJavaLineBreakpoint breakpoint, DebugException exception) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				delegate.breakpointHasRuntimeException(breakpoint, exception);
@@ -155,9 +144,7 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointHit(
-		 * org.eclipse.jdt.debug.core.IJavaThread,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointHit( org.eclipse.jdt.debug.core.IJavaThread,
 		 * org.eclipse.jdt.debug.core.IJavaBreakpoint)
 		 */
 		@Override
@@ -172,31 +159,26 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointInstalled
-		 * (org.eclipse.jdt.debug.core.IJavaDebugTarget,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointInstalled (org.eclipse.jdt.debug.core.IJavaDebugTarget,
 		 * org.eclipse.jdt.debug.core.IJavaBreakpoint)
 		 */
 		@Override
-		public void breakpointInstalled(IJavaDebugTarget target,
-				IJavaBreakpoint breakpoint) {
+		public void breakpointInstalled(IJavaDebugTarget target, IJavaBreakpoint breakpoint) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				delegate.breakpointInstalled(target, breakpoint);
 			}
+
 		}
 
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointRemoved
-		 * (org.eclipse.jdt.debug.core.IJavaDebugTarget,
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#breakpointRemoved (org.eclipse.jdt.debug.core.IJavaDebugTarget,
 		 * org.eclipse.jdt.debug.core.IJavaBreakpoint)
 		 */
 		@Override
-		public void breakpointRemoved(IJavaDebugTarget target,
-				IJavaBreakpoint breakpoint) {
+		public void breakpointRemoved(IJavaDebugTarget target, IJavaBreakpoint breakpoint) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				delegate.breakpointRemoved(target, breakpoint);
@@ -206,22 +188,17 @@ public class BreakpointListenerManager {
 		/*
 		 * (non-Javadoc)
 		 *
-		 * @see
-		 * org.eclipse.jdt.debug.core.IJavaBreakpointListener#installingBreakpoint
-		 * (org.eclipse.jdt.debug.core.IJavaDebugTarget,
-		 * org.eclipse.jdt.debug.core.IJavaBreakpoint,
-		 * org.eclipse.jdt.debug.core.IJavaType)
+		 * @see org.eclipse.jdt.debug.core.IJavaBreakpointListener#installingBreakpoint (org.eclipse.jdt.debug.core.IJavaDebugTarget,
+		 * org.eclipse.jdt.debug.core.IJavaBreakpoint, org.eclipse.jdt.debug.core.IJavaType)
 		 */
 		@Override
-		public int installingBreakpoint(IJavaDebugTarget target,
-				IJavaBreakpoint breakpoint, IJavaType type) {
+		public int installingBreakpoint(IJavaDebugTarget target, IJavaBreakpoint breakpoint, IJavaType type) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
 				return delegate.installingBreakpoint(target, breakpoint, type);
 			}
 			return IJavaBreakpointListener.DONT_CARE;
 		}
-
 	}
 
 	/**
@@ -231,23 +208,15 @@ public class BreakpointListenerManager {
 		if (fgJavaBreakpointListenersMap == null) {
 			fgJavaBreakpointListenersMap = new HashMap<>();
 			List<JavaBreakpointListenerProxy> global = new ArrayList<>();
-			IExtensionPoint extensionPoint = Platform
-					.getExtensionRegistry()
-					.getExtensionPoint(
-							JDIDebugPlugin.getUniqueIdentifier(),
-							JDIDebugPlugin.EXTENSION_POINT_JAVA_BREAKPOINT_LISTENERS);
-			IConfigurationElement[] actionDelegateElements = extensionPoint
-					.getConfigurationElements();
+			IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(JDIDebugPlugin.getUniqueIdentifier(), JDIDebugPlugin.EXTENSION_POINT_JAVA_BREAKPOINT_LISTENERS);
+			IConfigurationElement[] actionDelegateElements = extensionPoint.getConfigurationElements();
 			for (IConfigurationElement actionDelegateElement : actionDelegateElements) {
 				try {
 					String id = actionDelegateElement.getAttribute(ATTR_ID);
-					if (id == null)
-						throw new CoreException(
-								new Status(IStatus.ERROR, JDIDebugPlugin
-										.getUniqueIdentifier(),
-										"Java breakpoint listener requires an  identifier attribute.")); //$NON-NLS-1$
-					JavaBreakpointListenerProxy listener = new JavaBreakpointListenerProxy(
-							actionDelegateElement);
+					if (id == null) {
+						throw new CoreException(new Status(IStatus.ERROR, JDIDebugPlugin.getUniqueIdentifier(), "Java breakpoint listener requires an  identifier attribute.")); //$NON-NLS-1$
+					}
+					JavaBreakpointListenerProxy listener = new JavaBreakpointListenerProxy(actionDelegateElement);
 					fgJavaBreakpointListenersMap.put(id, listener);
 					if (listener.isGlobal()) {
 						global.add(listener);
@@ -256,14 +225,12 @@ public class BreakpointListenerManager {
 					JDIDebugPlugin.log(e);
 				}
 			}
-			fgGlobalListeners = global
-					.toArray(new IJavaBreakpointListener[global.size()]);
+			fgGlobalListeners = global.toArray(new IJavaBreakpointListener[global.size()]);
 		}
 	}
 
 	/**
-	 * Returns the listener registered with the given identifier or
-	 * <code>null</code> if none.
+	 * Returns the listener registered with the given identifier or <code>null</code> if none.
 	 *
 	 * @param id
 	 *            extension identifier
@@ -275,8 +242,7 @@ public class BreakpointListenerManager {
 	}
 
 	/**
-	 * Returns breakpoint listener extensions registered to listen for changes
-	 * to all breakpoints.
+	 * Returns breakpoint listener extensions registered to listen for changes to all breakpoints.
 	 *
 	 * @return global listeners
 	 */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Enhancement for #296 
Provides better view for Virtual threads in debug view
before - 
<img width="496" alt="image" src="https://github.com/user-attachments/assets/f7be0377-abba-44ce-b8c8-e4f6fe03e9d5">

After - 
<img width="519" alt="image" src="https://github.com/user-attachments/assets/55d761c4-d11f-48a0-bba4-d669403c6cdd">

![image](https://github.com/user-attachments/assets/a2767221-5ace-4a71-8834-c15e1c358b8d)





## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the test or create an ibuild with it and try (Wont be able to see in child eclipse - existing issue)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
