### PR TITLE
Duplicate mise's logic for finding Java installations

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -136,7 +136,7 @@ public class DetectVMInstallationsJob extends Job {
 			rootDirectories.add(new File("/usr/lib/jvm")); //$NON-NLS-1$
 		}
 		rootDirectories.add(new File(System.getProperty("user.home"), ".sdkman/candidates/java")); //$NON-NLS-1$ //$NON-NLS-2$
-		rootDirectories.add(new File(System.getProperty("user.home"), ".local/share/mise/installs/java")); //$NON-NLS-1$ //$NON-NLS-2$
+		rootDirectories.add(new File(miseDataDir(), "installs/java")); //$NON-NLS-1$
 
 		Set<File> directories = rootDirectories.stream().filter(File::isDirectory)
 			.map(dir -> dir.listFiles(File::isDirectory))
@@ -178,6 +178,26 @@ public class DetectVMInstallationsJob extends Job {
 			.distinct()
 			.flatMap(progFilesDir -> subDirs.stream().map(subDir -> new File(progFilesDir, subDir)))
 			.collect(Collectors.toList()));
+	}
+
+	private static File miseDataDir() {
+		String miseDataDir = System.getenv("MISE_DATA_DIR"); //$NON-NLS-1$
+		return miseDataDir != null ? new File(miseDataDir) : new File(xdgDataHome(), "mise"); //$NON-NLS-1$
+	}
+
+	private static File xdgDataHome() {
+		String xdgDataHome = System.getenv("XDG_DATA_HOME"); //$NON-NLS-1$
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			if (xdgDataHome == null) {
+				xdgDataHome = System.getenv("LOCALAPPDATA"); //$NON-NLS-1$
+			}
+			if (xdgDataHome == null) {
+				return new File(System.getProperty("user.home"), "AppData/Local"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		} else if (xdgDataHome == null) {
+			return new File(System.getProperty("user.home"), ".local/share"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return new File(xdgDataHome);
 	}
 
 	private static Set<File> knownVMs() {


### PR DESCRIPTION
## What it does

This amends #493 by duplicating mise's logic on where to put installed Java versions (see https://github.com/jdx/mise/blob/c412b3295aa768980774126315da18a9db4a8349/src/env.rs#L48-L65), so we find them in the same location.

## How to test

1. Configure one of the supported variables (`XDG_DATA_HOME`, `MISE_DATA_DIR`) in your environment
2. Install any JDK with mise (for example `mise install java@microsoft-17`)
3. Open the preference page, and check if the new JVM is detected

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
