### PR TITLE
[24] Add Execution Environment for JavaSE-24

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.23.150.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
@@ -6,6 +6,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,6 +45,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 
 	// XXX: Note that this string is not yet standardized by OSGi, see http://wiki.osgi.org/wiki/Execution_Environment
 
+	private static final String JavaSE_24 = "JavaSE-24"; //$NON-NLS-1$
 	private static final String JavaSE_23 = "JavaSE-23"; //$NON-NLS-1$
 	private static final String JavaSE_22 = "JavaSE-22"; //$NON-NLS-1$
 	private static final String JavaSE_21 = "JavaSE-21"; //$NON-NLS-1$
@@ -97,7 +102,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_1_8, new String[] { JavaSE_1_7 });
 		mappings.put(JavaSE_9, new String[] { JavaSE_1_8 });
 		mappings.put(JavaSE_10, new String[] { JavaSE_9 });
-		mappings.put(JavaSE_10_Plus, new String[] { JavaSE_23 });
+		mappings.put(JavaSE_10_Plus, new String[] { JavaSE_24 });
 		mappings.put(JavaSE_11, new String[] { JavaSE_10 });
 		mappings.put(JavaSE_12, new String[] { JavaSE_11 });
 		mappings.put(JavaSE_13, new String[] { JavaSE_12 });
@@ -111,6 +116,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_21, new String[] { JavaSE_20 });
 		mappings.put(JavaSE_22, new String[] { JavaSE_21 });
 		mappings.put(JavaSE_23, new String[] { JavaSE_22 });
+		mappings.put(JavaSE_24, new String[] { JavaSE_23 });
 	}
 	@Override
 	public CompatibleEnvironment[] analyze(IVMInstall vm, IProgressMonitor monitor) throws CoreException {
@@ -136,7 +142,9 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 					types = getTypes(CDC_FOUNDATION_1_1);
 				}
 			} else {
-				if (javaVersion.startsWith("23")) { //$NON-NLS-1$
+				if (javaVersion.startsWith("24")) { //$NON-NLS-1$
+					types = getTypes(JavaSE_24);
+				} else if (javaVersion.startsWith("23")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_23);
 				} else if (javaVersion.startsWith("22")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_22);

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.23.100-SNAPSHOT</version>
+  <version>3.23.150-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
+ Start the BETA_JAVA24 branch
+ recognize JavaSE-24
+ bump version by +50

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/551
