### PR TITLE
Instance main methods tests fix

### DIFF
--- a/org.eclipse.jdt.debug.tests/java24/Main1.java
+++ b/org.eclipse.jdt.debug.tests/java24/Main1.java
@@ -1,0 +1,5 @@
+public class Main1 {
+	public static void main() {
+		System.out.println("test");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/java24/Main2.java
+++ b/org.eclipse.jdt.debug.tests/java24/Main2.java
@@ -1,0 +1,7 @@
+public class Main2 {
+	
+	void main() {
+		System.out.println("test");
+	}
+	
+}

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
@@ -6,6 +6,10 @@
  *  which accompanies this distribution, and is available at
  *  https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  *  SPDX-License-Identifier: EPL-2.0
  *
  *  Contributors:
@@ -66,6 +70,7 @@ public class JavaProjectHelper {
 	public static final String JAVA_SE_16_EE_NAME = "JavaSE-16";
 	public static final String JAVA_SE_21_EE_NAME = "JavaSE-21";
 	public static final String JAVA_SE_23_EE_NAME = "JavaSE-23";
+	public static final String JAVA_SE_24_EE_NAME = "JavaSE-24";
 
 	/**
 	 * path to the test src for 'testprograms'
@@ -100,6 +105,10 @@ public class JavaProjectHelper {
 	 * path to the 23 test source
 	 */
 	public static final IPath TEST_23_SRC_DIR = new Path("java23");
+	/**
+	 * path to the 24 test source
+	 */
+	public static final IPath TEST_24_SRC_DIR = new Path("java24");
 
 	/**
 	 * path to the compiler error java file

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -6,6 +6,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -181,6 +185,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	public static final String ONESIX_PROJECT_NAME = "One_Six";
 	public static final String TWENTYONE_PROJECT_NAME = "Two_One";
 	public static final String TWENTYTHREE_PROJECT_NAME = "Two_Three";
+	public static final String TWENTYFOUR_PROJECT_NAME = "Two_Four";
 	public static final String BOUND_JRE_PROJECT_NAME = "BoundJRE";
 	public static final String CLONE_SUFFIX = "Clone";
 
@@ -240,6 +245,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	private static boolean loaded16_ = false;
 	private static boolean loaded21 = false;
 	private static boolean loaded23 = false;
+	private static boolean loaded24 = false;
 	private static boolean loadedEE = false;
 	private static boolean loadedJRE = false;
 	private static boolean loadedMulti = false;
@@ -654,6 +660,40 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	}
 
 	/**
+	 * Creates the Java 24 compliant project
+	 */
+	synchronized void assert24Project() {
+		IJavaProject jp = null;
+		ArrayList<ILaunchConfiguration> cfgs = new ArrayList<>(1);
+		try {
+			if (!loaded24) {
+				jp = createProject(TWENTYFOUR_PROJECT_NAME, JavaProjectHelper.TEST_24_SRC_DIR.toString(), JavaProjectHelper.JAVA_SE_24_EE_NAME, false);
+				jp.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+				jp.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_24);
+				jp.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_24);
+				cfgs.add(createLaunchConfiguration(jp, "Main1"));
+				cfgs.add(createLaunchConfiguration(jp, "Main2"));
+				cfgs.add(createLaunchConfiguration(jp, "Main21"));
+				loaded24 = true;
+				waitForBuild();
+				assertNoErrorMarkersExist(jp.getProject());
+			}
+		} catch (Exception e) {
+			try {
+				if (jp != null) {
+					jp.getProject().delete(true, true, null);
+					for (int i = 0; i < cfgs.size(); i++) {
+						cfgs.get(i).delete();
+					}
+				}
+			} catch (CoreException ce) {
+				// ignore
+			}
+			handleProjectCreationException(e, TWENTYFOUR_PROJECT_NAME, jp);
+		}
+	}
+
+	/**
 	 * Creates the 'BoundJRE' project used for the JRE testing
 	 */
 	synchronized void assertBoundJreProject() {
@@ -957,6 +997,16 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	protected IJavaProject get23Project() {
 		assert23Project();
 		return getJavaProject(TWENTYTHREE_PROJECT_NAME);
+	}
+
+	/**
+	 * Returns the 'Two_Four' project, used for Java 24 tests.
+	 *
+	 * @return the test project
+	 */
+	protected IJavaProject get24Project() {
+		assert24Project();
+		return getJavaProject(TWENTYFOUR_PROJECT_NAME);
 	}
 
 	/**

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/InstanceMainMethodsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/launching/InstanceMainMethodsTests.java
@@ -6,6 +6,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,7 +30,7 @@ public class InstanceMainMethodsTests extends AbstractDebugTest {
 
 	@Override
 	protected IJavaProject getProjectContext() {
-		return super.get23Project();
+		return super.get24Project();
 	}
 
 	public void testStaticMainWithoutArgs() throws Exception {

--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.23.150.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
@@ -6,6 +6,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,6 +45,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 
 	// XXX: Note that this string is not yet standardized by OSGi, see http://wiki.osgi.org/wiki/Execution_Environment
 
+	private static final String JavaSE_24 = "JavaSE-24"; //$NON-NLS-1$
 	private static final String JavaSE_23 = "JavaSE-23"; //$NON-NLS-1$
 	private static final String JavaSE_22 = "JavaSE-22"; //$NON-NLS-1$
 	private static final String JavaSE_21 = "JavaSE-21"; //$NON-NLS-1$
@@ -97,7 +102,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_1_8, new String[] { JavaSE_1_7 });
 		mappings.put(JavaSE_9, new String[] { JavaSE_1_8 });
 		mappings.put(JavaSE_10, new String[] { JavaSE_9 });
-		mappings.put(JavaSE_10_Plus, new String[] { JavaSE_23 });
+		mappings.put(JavaSE_10_Plus, new String[] { JavaSE_24 });
 		mappings.put(JavaSE_11, new String[] { JavaSE_10 });
 		mappings.put(JavaSE_12, new String[] { JavaSE_11 });
 		mappings.put(JavaSE_13, new String[] { JavaSE_12 });
@@ -111,6 +116,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_21, new String[] { JavaSE_20 });
 		mappings.put(JavaSE_22, new String[] { JavaSE_21 });
 		mappings.put(JavaSE_23, new String[] { JavaSE_22 });
+		mappings.put(JavaSE_24, new String[] { JavaSE_23 });
 	}
 	@Override
 	public CompatibleEnvironment[] analyze(IVMInstall vm, IProgressMonitor monitor) throws CoreException {
@@ -136,7 +142,9 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 					types = getTypes(CDC_FOUNDATION_1_1);
 				}
 			} else {
-				if (javaVersion.startsWith("23")) { //$NON-NLS-1$
+				if (javaVersion.startsWith("24")) { //$NON-NLS-1$
+					types = getTypes(JavaSE_24);
+				} else if (javaVersion.startsWith("23")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_23);
 				} else if (javaVersion.startsWith("22")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_22);

--- a/org.eclipse.jdt.launching/plugin.properties
+++ b/org.eclipse.jdt.launching/plugin.properties
@@ -5,6 +5,10 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # https://www.eclipse.org/legal/epl-2.0/
+#
+# This is an implementation of an early-draft specification developed under the Java
+# Community Process (JCP) and is made available for testing and evaluation purposes
+# only. The code is not compatible with any specification of the JCP.
 # 
 # SPDX-License-Identifier: EPL-2.0
 #
@@ -85,6 +89,7 @@ environment.description.24 = Java Platform, Standard Edition 20
 environment.description.25 = Java Platform, Standard Edition 21
 environment.description.26 = Java Platform, Standard Edition 22
 environment.description.27 = Java Platform, Standard Edition 23
+environment.description.28 = Java Platform, Standard Edition 24
 
 classpathVariableInitializer.deprecated = Use the JRE System Library instead
 

--- a/org.eclipse.jdt.launching/plugin.xml
+++ b/org.eclipse.jdt.launching/plugin.xml
@@ -7,6 +7,10 @@
      are made available under the terms of the Eclipse Public License 2.0
      which accompanies this distribution, and is available at
      https://www.eclipse.org/legal/epl-2.0/
+
+	This is an implementation of an early-draft specification developed under the Java
+	Community Process (JCP) and is made available for testing and evaluation purposes
+	only. The code is not compatible with any specification of the JCP.
      
  	 SPDX-License-Identifier: EPL-2.0
 
@@ -392,6 +396,11 @@
             description="%environment.description.27"
             id="JavaSE-23"
             compliance="23">
+      </environment>
+      <environment
+            description="%environment.description.28"
+            id="JavaSE-24"
+            compliance="24">
       </environment>
       <analyzer
             class="org.eclipse.jdt.internal.launching.environments.ExecutionEnvironmentAnalyzer"

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.23.100-SNAPSHOT</version>
+  <version>3.23.150-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
Fixes failures in org.eclipse.jdt.debug.tests.launching.InstanceMainMethodsTests when run on Java 24: can not use --enable-preview with compliance 23.

Includes addition of "JavaSE-24" as an execution environment.