### PR TITLE
Code Cleanup: Java 16 instanceof pattern matching

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.23.200.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/ClasspathShortener.java
@@ -235,8 +235,7 @@ public class ClasspathShortener implements IProcessTempFileCreator {
 	}
 
 	public static String getJavaVersion(IVMInstall vmInstall) {
-		if (vmInstall instanceof IVMInstall2) {
-			IVMInstall2 install = (IVMInstall2) vmInstall;
+		if (vmInstall instanceof IVMInstall2 install) {
 			return install.getJavaVersion();
 		}
 		return null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/CommandLineShortener.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/CommandLineShortener.java
@@ -40,8 +40,7 @@ import org.eclipse.jdt.launching.IVMInstall2;
  */
 public class CommandLineShortener implements IProcessTempFileCreator {
 	public static String getJavaVersion(IVMInstall vmInstall) {
-		if (vmInstall instanceof IVMInstall2) {
-			IVMInstall2 install = (IVMInstall2) vmInstall;
+		if (vmInstall instanceof IVMInstall2 install) {
 			return install.getJavaVersion();
 		}
 		return null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DefaultProjectClasspathEntry.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DefaultProjectClasspathEntry.java
@@ -163,8 +163,7 @@ public class DefaultProjectClasspathEntry extends AbstractRuntimeClasspathEntry 
 		IRuntimeClasspathEntry[] runtimeEntries = new IRuntimeClasspathEntry[classpathEntries.size()];
 		for (int i = 0; i < runtimeEntries.length; i++) {
 			Object e = classpathEntries.get(i);
-			if (e instanceof IClasspathEntry) {
-				IClasspathEntry cpe = (IClasspathEntry)e;
+			if (e instanceof IClasspathEntry cpe) {
 				runtimeEntries[i] = new RuntimeClasspathEntry(cpe);
 			} else {
 				runtimeEntries[i] = (IRuntimeClasspathEntry)e;
@@ -290,8 +289,7 @@ public class DefaultProjectClasspathEntry extends AbstractRuntimeClasspathEntry 
 							ClasspathContainerInitializer initializer = JavaCore.getClasspathContainerInitializer(r.getPath().segment(0));
 							for (int i = 0; i < expandedPath.size(); i++) {
 								Object o = expandedPath.get(i);
-								if (o instanceof IRuntimeClasspathEntry) {
-									IRuntimeClasspathEntry re = (IRuntimeClasspathEntry)o;
+								if (o instanceof IRuntimeClasspathEntry re) {
 									if (re.getType() == IRuntimeClasspathEntry.CONTAINER) {
 										if (container instanceof IRuntimeContainerComparator) {
 											duplicate = ((IRuntimeContainerComparator)container).isDuplicate(re.getPath());
@@ -405,8 +403,7 @@ public class DefaultProjectClasspathEntry extends AbstractRuntimeClasspathEntry 
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof DefaultProjectClasspathEntry) {
-			DefaultProjectClasspathEntry entry = (DefaultProjectClasspathEntry) obj;
+		if (obj instanceof DefaultProjectClasspathEntry entry) {
 			return entry.getJavaProject().equals(getJavaProject()) &&
 				entry.isExportedEntriesOnly() == isExportedEntriesOnly();
 		}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JREContainer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JREContainer.java
@@ -97,8 +97,7 @@ public class JREContainer implements IClasspathContainer {
 		 */
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof RuleKey) {
-				RuleKey key = (RuleKey) obj;
+			if (obj instanceof RuleKey key) {
 				return fEnvironmentId.equals(key.fEnvironmentId) && fInstall.equals(key.fInstall);
 			}
 			return false;
@@ -236,8 +235,7 @@ public class JREContainer implements IClasspathContainer {
 			 * @param obj an object which should be castable to IVMInstall
 			 */
 			private void removeRuleEntry(Object obj) {
-				if(obj instanceof IVMInstall) {
-					IVMInstall install = (IVMInstall) obj;
+				if (obj instanceof IVMInstall install) {
 					fgClasspathEntriesWithRules.keySet().removeIf(key -> key.fInstall.equals(install));
 				}
 			}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaAppletLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaAppletLaunchConfigurationDelegate.java
@@ -208,11 +208,9 @@ public class JavaAppletLaunchConfigurationDelegate extends JavaLaunchDelegate im
 				case DebugEvent.TERMINATE :
 					if (eventSource != null) {
 						ILaunch launch = null;
-						if (eventSource instanceof IProcess) {
-							IProcess process = (IProcess) eventSource;
+						if (eventSource instanceof IProcess process) {
 							launch = process.getLaunch();
-						} else if (eventSource instanceof IDebugTarget) {
-							IDebugTarget debugTarget = (IDebugTarget) eventSource;
+						} else if (eventSource instanceof IDebugTarget debugTarget) {
 							launch = debugTarget.getLaunch();
 						}
 						if (launch != null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaSourceLookupDirector.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JavaSourceLookupDirector.java
@@ -54,9 +54,7 @@ public class JavaSourceLookupDirector extends AbstractSourceLookupDirector {
 
 	@Override
 	public boolean equalSourceElements(Object o1, Object o2) {
-		if (o1 instanceof AbstractClassFile && o2 instanceof AbstractClassFile) {
-			AbstractClassFile c1 = (AbstractClassFile) o1;
-			AbstractClassFile c2 = (AbstractClassFile) o2;
+		if (o1 instanceof AbstractClassFile c1 && o2 instanceof AbstractClassFile c2) {
 			String pathIdentifier1 = c1.getPathIdentifier();
 			String pathIdentifier2 = c2.getPathIdentifier();
 			return Objects.equals(pathIdentifier1, pathIdentifier2);

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/PackageFragmentRootSourceContainerTypeDelegate.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/PackageFragmentRootSourceContainerTypeDelegate.java
@@ -45,8 +45,8 @@ public class PackageFragmentRootSourceContainerTypeDelegate extends AbstractSour
 					abort(LaunchingMessages.PackageFragmentRootSourceContainerTypeDelegate_6, null);
 				}
 				IJavaElement root = JavaCore.create(string);
-				if (root instanceof IPackageFragmentRoot) {
-					return new PackageFragmentRootSourceContainer((IPackageFragmentRoot)root);
+				if (root instanceof IPackageFragmentRoot packetFragment) {
+					return new PackageFragmentRootSourceContainer(packetFragment);
 				}
 				abort(LaunchingMessages.PackageFragmentRootSourceContainerTypeDelegate_7, null);
 			} else {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntry.java
@@ -574,8 +574,7 @@ public class RuntimeClasspathEntry implements IRuntimeClasspathEntry {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IRuntimeClasspathEntry) {
-			IRuntimeClasspathEntry r = (IRuntimeClasspathEntry)obj;
+		if (obj instanceof IRuntimeClasspathEntry r) {
 			if (getType() == r.getType() && getClasspathProperty() == r.getClasspathProperty()) {
 				if (getType() == IRuntimeClasspathEntry.CONTAINER) {
 					String id = getPath().segment(0);

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntryResolver.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/RuntimeClasspathEntryResolver.java
@@ -117,8 +117,7 @@ public class RuntimeClasspathEntryResolver implements IRuntimeClasspathEntryReso
 	public boolean isVMInstallReference(IClasspathEntry entry) {
 		try {
 			IRuntimeClasspathEntryResolver resolver = getResolver();
-			if (resolver instanceof IRuntimeClasspathEntryResolver2) {
-				IRuntimeClasspathEntryResolver2 resolver2 = (IRuntimeClasspathEntryResolver2) resolver;
+			if (resolver instanceof IRuntimeClasspathEntryResolver2 resolver2) {
 				return resolver2.isVMInstallReference(entry);
 			}
 			return resolver.resolveVMInstall(entry) != null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMDebugger.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMDebugger.java
@@ -409,14 +409,14 @@ public class StandardVMDebugger extends StandardVMRunner {
 						}
 
 						Exception ex = runnable.getException();
-						if (ex instanceof IllegalConnectorArgumentsException) {
-							throw (IllegalConnectorArgumentsException)ex;
+						if (ex instanceof IllegalConnectorArgumentsException illegalException) {
+							throw illegalException;
 						}
-						if (ex instanceof InterruptedIOException) {
-							throw (InterruptedIOException)ex;
+						if (ex instanceof InterruptedIOException interruptedException) {
+							throw interruptedException;
 						}
-						if (ex instanceof IOException) {
-							throw (IOException)ex;
+						if (ex instanceof IOException ioException) {
+							throw ioException;
 						}
 
 						VirtualMachine vm= runnable.getVirtualMachine();

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMRunner.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMRunner.java
@@ -594,8 +594,7 @@ public class StandardVMRunner extends AbstractVMRunner {
 	 */
 	protected String[] prependJREPath(String[] env) {
 		if (Platform.OS_MACOSX.equals(Platform.getOS())) {
-			if (fVMInstance instanceof IVMInstall2) {
-				IVMInstall2 vm = (IVMInstall2) fVMInstance;
+			if (fVMInstance instanceof IVMInstall2 vm) {
 				String javaVersion = vm.getJavaVersion();
 				if (javaVersion != null) {
 					if (env == null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/VMDefinitionsContainer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/VMDefinitionsContainer.java
@@ -580,8 +580,7 @@ public class VMDefinitionsContainer {
 							NodeList entries = subElement.getElementsByTagName("entry"); //$NON-NLS-1$
 							for (int j = 0; j < entries.getLength(); j++) {
 								Node entryNode = entries.item(j);
-								if (entryNode instanceof Element) {
-									Element entryElement = (Element) entryNode;
+								if (entryNode instanceof Element entryElement) {
 									String key = entryElement.getAttribute("key"); //$NON-NLS-1$
 									String value = entryElement.getAttribute("value"); //$NON-NLS-1$
 									if (key != null && value != null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/VariableClasspathEntry.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/VariableClasspathEntry.java
@@ -126,8 +126,7 @@ public class VariableClasspathEntry extends AbstractRuntimeClasspathEntry {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof VariableClasspathEntry) {
-			VariableClasspathEntry other= (VariableClasspathEntry)obj;
+		if (obj instanceof VariableClasspathEntry other) {
 			if (variableString != null) {
 				return variableString.equals(other.variableString);
 			}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/AccessRuleParticipant.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/AccessRuleParticipant.java
@@ -98,13 +98,11 @@ class AccessRuleParticipant implements IAccessRuleParticipant {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof AccessRuleParticipant) {
-			AccessRuleParticipant participant = (AccessRuleParticipant) obj;
+		if (obj instanceof AccessRuleParticipant participant) {
 			return participant.getDelegateClassName().equals(getDelegateClassName());
 		}
 		return false;
 	}
-
 	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/JDIHelpers.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/JDIHelpers.java
@@ -45,8 +45,7 @@ public final class JDIHelpers implements IJDIHelpers {
 	@Override
 	public File getClassesLocation(Object element) throws DebugException {
 		IJavaReferenceType declaringType = null;
-		if (element instanceof IJavaStackFrame) {
-			IJavaStackFrame stackFrame = (IJavaStackFrame) element;
+		if (element instanceof IJavaStackFrame stackFrame) {
 			declaringType = stackFrame.getReferenceType();
 		} else if (element instanceof IJavaObject) {
 			IJavaType javaType = ((IJavaObject) element).getJavaType();
@@ -55,8 +54,7 @@ public final class JDIHelpers implements IJDIHelpers {
 			}
 		} else if (element instanceof IJavaReferenceType) {
 			declaringType = (IJavaReferenceType) element;
-		} else if (element instanceof IJavaVariable) {
-			IJavaVariable javaVariable = (IJavaVariable) element;
+		} else if (element instanceof IJavaVariable javaVariable) {
 			IJavaType javaType = ((IJavaValue) javaVariable.getValue()).getJavaType();
 			if (javaType instanceof IJavaReferenceType) {
 				declaringType = (IJavaReferenceType) javaType;
@@ -92,8 +90,7 @@ public final class JDIHelpers implements IJDIHelpers {
 	@Override
 	public String getSourcePath(Object element) throws DebugException {
 		IJavaReferenceType declaringType = null;
-		if (element instanceof IJavaStackFrame) {
-			IJavaStackFrame stackFrame = (IJavaStackFrame) element;
+		if (element instanceof IJavaStackFrame stackFrame) {
 			// under JSR 45 source path from the stack frame is more precise than anything derived from the type
 			String sourcePath = stackFrame.getSourcePath(STRATA_ID);
 			if (sourcePath != null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractJavaLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractJavaLaunchConfigurationDelegate.java
@@ -932,8 +932,7 @@ public abstract class AbstractJavaLaunchConfigurationDelegate extends LaunchConf
 		for (int i = 0; i < events.length; i++) {
 			DebugEvent event = events[i];
 			if (event.getKind() == DebugEvent.CREATE
-					&& event.getSource() instanceof IJavaDebugTarget) {
-				IJavaDebugTarget target = (IJavaDebugTarget) event.getSource();
+					&& event.getSource() instanceof IJavaDebugTarget target) {
 				ILaunch launch = target.getLaunch();
 				if (launch != null) {
 					ILaunchConfiguration configuration = launch
@@ -1261,9 +1260,8 @@ public abstract class AbstractJavaLaunchConfigurationDelegate extends LaunchConf
 	private static String toAbsolutePath(IResource resource, IWorkspaceRoot root) throws CoreException {
 		IJavaElement element = JavaCore.create(resource);
 		if (element != null && element.exists()) {
-			if (element instanceof IJavaProject) {
+			if (element instanceof IJavaProject project) {
 				Set<String> paths = new HashSet<>();
-				IJavaProject project = (IJavaProject) element;
 				paths.add(absPath(root, project.getOutputLocation()));
 				for (IClasspathEntry entry : project.getResolvedClasspath(true)) {
 					if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE && entry.getOutputLocation() != null) {
@@ -1271,8 +1269,7 @@ public abstract class AbstractJavaLaunchConfigurationDelegate extends LaunchConf
 					}
 				}
 				return String.join(File.pathSeparator, paths);
-			} else if (element instanceof IPackageFragmentRoot) {
-				IPackageFragmentRoot packageRoot = (IPackageFragmentRoot) element;
+			} else if (element instanceof IPackageFragmentRoot packageRoot) {
 				IClasspathEntry entry = packageRoot.getJavaProject().getClasspathEntryFor(resource.getFullPath());
 				return absPath(root, entry.getOutputLocation());
 			}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractVMRunner.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/AbstractVMRunner.java
@@ -219,8 +219,7 @@ public abstract class AbstractVMRunner implements IVMRunner {
 	 * @since 3.10
 	 */
 	protected boolean isModular(VMRunnerConfiguration config, IVMInstall vmInstall) {
-		if (config.getModuleDescription() != null && config.getModuleDescription().length() > 0 && vmInstall instanceof AbstractVMInstall) {
-			AbstractVMInstall install = (AbstractVMInstall) vmInstall;
+		if (config.getModuleDescription() != null && config.getModuleDescription().length() > 0 && vmInstall instanceof AbstractVMInstall install) {
 			String vmver = install.getJavaVersion();
 			// versionToJdkLevel only handles 3 char versions = 1.5, 1.6, 1.9, etc
 			if (vmver.length() > 3) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/LibraryLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/LibraryLocation.java
@@ -190,8 +190,7 @@ public final class LibraryLocation {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof LibraryLocation) {
-			LibraryLocation lib = (LibraryLocation)obj;
+		if (obj instanceof LibraryLocation lib) {
 			return getSystemLibraryPath().equals(lib.getSystemLibraryPath())
 				&& equals(getSystemLibrarySourcePath(), lib.getSystemLibrarySourcePath())
 				&& equals(getExternalAnnotationsPath(), lib.getExternalAnnotationsPath())

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ArchiveSourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ArchiveSourceLocation.java
@@ -299,8 +299,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 */
 	@Override
 	public boolean equals(Object object) {
-		return object instanceof ArchiveSourceLocation &&
-			 getName().equals(((ArchiveSourceLocation)object).getName());
+		return object instanceof ArchiveSourceLocation archivceSource && getName().equals(archivceSource.getName());
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaSourceLocator.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaSourceLocator.java
@@ -217,8 +217,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @since 2.1
 	 */
 	public Object[] getSourceElements(IStackFrame stackFrame) {
-		if (stackFrame instanceof IJavaStackFrame) {
-			IJavaStackFrame frame = (IJavaStackFrame)stackFrame;
+		if (stackFrame instanceof IJavaStackFrame frame) {
 			String name = null;
 			try {
 				name = getFullyQualfiedName(frame);
@@ -255,8 +254,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 */
 	@Override
 	public Object getSourceElement(IStackFrame stackFrame) {
-		if (stackFrame instanceof IJavaStackFrame) {
-			IJavaStackFrame frame = (IJavaStackFrame)stackFrame;
+		if (stackFrame instanceof IJavaStackFrame frame) {
 			String name = null;
 			try {
 				name = getFullyQualfiedName(frame);

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/containers/JavaProjectSourceContainer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/containers/JavaProjectSourceContainer.java
@@ -118,8 +118,8 @@ public class JavaProjectSourceContainer extends CompositeSourceContainer {
 					case IClasspathEntry.CPE_SOURCE:
 						IPath path = entry.getPath();
 						IResource resource = root.findMember(path);
-						if (resource instanceof IContainer) {
-							containers.add(new FolderSourceContainer((IContainer)resource, false));
+						if (resource instanceof IContainer iContainer) {
+							containers.add(new FolderSourceContainer(iContainer, false));
 						}
 						break;
 				}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/containers/PackageFragmentRootSourceContainer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/containers/PackageFragmentRootSourceContainer.java
@@ -118,8 +118,8 @@ public class PackageFragmentRootSourceContainer extends AbstractSourceContainer 
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		return obj instanceof PackageFragmentRootSourceContainer &&
-		 ((PackageFragmentRootSourceContainer)obj).getPackageFragmentRoot().equals(getPackageFragmentRoot());
+		return obj instanceof PackageFragmentRootSourceContainer packageFragment
+				&& packageFragment.getPackageFragmentRoot().equals(getPackageFragmentRoot());
 	}
 
 	/**

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.23.100-SNAPSHOT</version>
+  <version>3.23.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
Performs code cleanup in pattern matching using instanceof operator according to Java 16 guidelines, making the code more concise for classes in jdt.launching package.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
