### PR TITLE
Ignore HCR Failures for current session #347

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
@@ -142,6 +142,7 @@ public class DebugUIMessages extends NLS {
 	public static String JDIDebugUIPlugin_The_target_VM_does_not_support_hot_code_replace_1;
 	public static String JDIDebugUIPlugin_3;
     public static String JDIDebugUIPlugin_4;
+	public static String JDIDebugUIPlugin_5;
 
 	public static String JDIModelPresentation__No_explicit_return_value__30;
 	public static String JDIModelPresentation__conditional__2;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -88,6 +88,7 @@ JDIDebugUIPlugin_Stepping_may_be_hazardous_1=The virtual machine was unable to r
 JDIDebugUIPlugin_The_target_VM_does_not_support_hot_code_replace_1=The target VM does not support hot code replace
 JDIDebugUIPlugin_3=Do not show error &when hot code replace is not supported
 JDIDebugUIPlugin_0=Warning
+JDIDebugUIPlugin_5=Ignore errors in current session
 
 JDIModelPresentation__No_explicit_return_value__30=(No explicit return value)
 JDIModelPresentation__conditional__2=[conditional]

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ErrorDialogWithToggle.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ErrorDialogWithToggle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,8 @@ package org.eclipse.jdt.internal.debug.ui;
 
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -39,29 +41,45 @@ public class ErrorDialogWithToggle extends ErrorDialog {
 	 * The preference key which is set by the toggle button.
 	 * This key must be a boolean preference in the preference store.
 	 */
-	private String fPreferenceKey= null;
+	private String fPreferenceKey;
 	/**
 	 * The message displayed to the user, with the toggle button
 	 */
-	private String fToggleMessage= null;
-	private Button fToggleButton= null;
+	private String fToggleMessage1;
+	private Button fToggleButton;
+	/**
+	 * Optional message displayed to the user only applicable for HCR Failure, with the toggle button
+	 */
+	private String fToggleMessage2;
+
+	private Button fToggleButton2;
 	/**
 	 * The preference store which will be affected by the toggle button
 	 */
 	IPreferenceStore fStore= null;
 
+	public ErrorDialogWithToggle(Shell parentShell, String dialogTitle, String message, IStatus status, String preferenceKey, String toggleMessage1, String toggleMessage2, IPreferenceStore store) {
+		super(parentShell, dialogTitle, message, status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO);
+		fStore = store;
+		fPreferenceKey = preferenceKey;
+		fToggleMessage1 = toggleMessage1;
+		fToggleMessage2 = toggleMessage2;
+	}
 	public ErrorDialogWithToggle(Shell parentShell, String dialogTitle, String message, IStatus status, String preferenceKey, String toggleMessage, IPreferenceStore store) {
 		super(parentShell, dialogTitle, message, status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO);
 		fStore= store;
 		fPreferenceKey= preferenceKey;
-		fToggleMessage= toggleMessage;
+		fToggleMessage1= toggleMessage;
 	}
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		Composite dialogComposite= (Composite) super.createDialogArea(parent);
 		dialogComposite.setFont(parent.getFont());
-		setToggleButton(createCheckButton(dialogComposite, fToggleMessage));
+		setToggleButton(createCheckButton(dialogComposite, fToggleMessage1));
+		if (fToggleMessage2 != null) {
+			fToggleButton2 = createCheckButton(dialogComposite, fToggleMessage2);
+		}
 		getToggleButton().setSelection(!fStore.getBoolean(fPreferenceKey));
 		applyDialogFont(dialogComposite);
 		return dialogComposite;
@@ -76,7 +94,7 @@ public class ErrorDialogWithToggle extends ErrorDialog {
 		button.setText(label);
 
 		GridData data = new GridData(SWT.NONE);
-		data.horizontalSpan= 2;
+		data.horizontalSpan = 2;
 		data.horizontalAlignment= GridData.CENTER;
 		button.setLayoutData(data);
 		button.setFont(parent.getFont());
@@ -84,16 +102,20 @@ public class ErrorDialogWithToggle extends ErrorDialog {
 		return button;
 	}
 
-	@Override
-	protected void buttonPressed(int id) {
+	protected void buttonPressed(int id, IDebugTarget target) {
 		if (id == IDialogConstants.OK_ID) {  // was the OK button pressed?
-			storePreference();
+			storePreference(target);
 		}
 		super.buttonPressed(id);
 	}
 
-	private void storePreference() {
+	private void storePreference(IDebugTarget target) {
 		fStore.setValue(fPreferenceKey, !getToggleButton().getSelection());
+		if (fToggleButton2 != null) {
+			if (target instanceof JDIDebugTarget jdiTarget) {
+				jdiTarget.setHcrDebugErrorPref(fToggleButton2.getSelection());
+			}
+		}
 	}
 
 	protected Button getToggleButton() {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,11 +47,10 @@ public class HotCodeReplaceErrorDialog extends ErrorDialogWithToggle {
 	/**
 	 * Creates a new dialog which can terminate, disconnect or restart the given debug target.
 	 *
-	 * @param target the debug target
-	 * @see ErrorDialogWithToggle#ErrorDialogWithToggle(Shell, String, String, IStatus, String, String, IPreferenceStore)
+	 * @see ErrorDialogWithToggle#ErrorDialogWithToggle(Shell, String, String, IStatus, String, String,String, IPreferenceStore)
 	 */
-	public HotCodeReplaceErrorDialog(Shell parentShell, String dialogTitle, String message, IStatus status, String preferenceKey, String toggleMessage, IPreferenceStore store, IDebugTarget target) {
-		super(parentShell, dialogTitle, message, status, preferenceKey, toggleMessage, store);
+	public HotCodeReplaceErrorDialog(Shell parentShell, String dialogTitle, String message, IStatus status, String preferenceKey, String toggleMessage, String toggleMessage2, IPreferenceStore store, IDebugTarget target) {
+		super(parentShell, dialogTitle, message, status, preferenceKey, toggleMessage, toggleMessage2, store);
 		this.target = target;
 	}
 
@@ -143,7 +142,7 @@ public class HotCodeReplaceErrorDialog extends ErrorDialogWithToggle {
 			}
 			okPressed();
 		} else {
-			super.buttonPressed(id);
+			super.buttonPressed(id, target);
 		}
 	}
 }

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -337,6 +337,31 @@ public class JDIDebugTarget extends JDIDebugElement implements
 	 * Labels given by the user is stored in this map, where the key is the unique ID of the object.
 	 */
 	private final Map<Long, String> objectLabels = new HashMap<>();
+
+	/**
+	 * HCR failure alert pref for current debug session.
+	 */
+	private volatile boolean hcrDebugErrors = false;
+
+	/**
+	 * Returns the hcrDebugErrors boolean to decide whether HCR error pop-up should be shown or not for a debugging session dispatcher per debug
+	 * target.
+	 *
+	 * @return boolean
+	 */
+	public boolean isHcrFailurePopUpEnabled() {
+		return hcrDebugErrors;
+	}
+
+	/**
+	 * Sets the user preference for ignoring error pop-up for a debugging session
+	 *
+	 * @param preference
+	 *            Sets true or false for showing pop-up
+	 */
+	public void setHcrDebugErrorPref(boolean preference) {
+		hcrDebugErrors = preference;
+	}
 
 	/**
 	 * Creates a new JDI debug target for the given virtual machine.
@@ -3246,4 +3271,5 @@ public class JDIDebugTarget extends JDIDebugElement implements
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
Enhancement : #347 

Adds a checkbox to the HCR error alert box that allows users to ignore HCR failures only for the current debug session, rather than applying it to all future debug sessions.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/347
<img width="519" alt="image" src="https://github.com/user-attachments/assets/466c5256-7193-4f69-8c76-d53b24a21dbe">


<img width="549" alt="image" src="https://github.com/user-attachments/assets/fe95f5d3-f319-4826-b37c-6d709fbce25c">

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
