### PR TITLE
Null check for testHyperLink NPE error #559

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/LineTrackerTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/LineTrackerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -181,6 +181,14 @@ public class LineTrackerTests extends AbstractDebugTest implements IConsoleLineT
 	    try {
 			ConsoleLineTracker.setDelegate(this);
 			fTarget = launchAndTerminate("ThrowsNPE");
+			long startTime = System.nanoTime();
+			long timeOut = 6000 * 1_000_000;
+			while (ConsoleLineTracker.getDocument() == null) {
+				if (System.nanoTime() - startTime > timeOut) {
+					break;
+				}
+				Thread.sleep(200);
+			}
 			getHyperlink(0, ConsoleLineTracker.getDocument());
 	    } finally {
 	        ConsoleLineTracker.setDelegate(null);


### PR DESCRIPTION
This commit adds a null check prior invoking getHyperLink method as there is a possibility for throwing NPE

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/559

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
