### PR TITLE
Move the code that acquires the modal shell into UI thread

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/NoLineNumberAttributesStatusHandler.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/NoLineNumberAttributesStatusHandler.java
@@ -33,16 +33,16 @@ public class NoLineNumberAttributesStatusHandler implements IStatusHandler {
 		ReferenceType type= (ReferenceType) source;
 		IPreferenceStore preferenceStore= JDIDebugUIPlugin.getDefault().getPreferenceStore();
 		if (preferenceStore.getBoolean(IJDIPreferencesConstants.PREF_ALERT_UNABLE_TO_INSTALL_BREAKPOINT)) {
-			final ErrorDialogWithToggle dialog = new ErrorDialogWithToggle(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(),
-					DebugUIMessages.NoLineNumberAttributesStatusHandler_Java_Breakpoint_1,
-					NLS.bind(DebugUIMessages.NoLineNumberAttributesStatusHandler_2, new String[] {type.name()}),
-					status, IJDIPreferencesConstants.PREF_ALERT_UNABLE_TO_INSTALL_BREAKPOINT,
-					DebugUIMessages.NoLineNumberAttributesStatusHandler_3,
-					preferenceStore);
 			Display display= JDIDebugUIPlugin.getStandardDisplay();
 			display.syncExec(new Runnable() {
 				@Override
 				public void run() {
+					final ErrorDialogWithToggle dialog = new ErrorDialogWithToggle(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(),
+							DebugUIMessages.NoLineNumberAttributesStatusHandler_Java_Breakpoint_1,
+							NLS.bind(DebugUIMessages.NoLineNumberAttributesStatusHandler_2, new String[] {type.name()}),
+							status, IJDIPreferencesConstants.PREF_ALERT_UNABLE_TO_INSTALL_BREAKPOINT,
+							DebugUIMessages.NoLineNumberAttributesStatusHandler_3,
+							preferenceStore);
 					dialog.open();
 				}
 			});

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/SuspendTimeoutStatusHandler.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/SuspendTimeoutStatusHandler.java
@@ -31,11 +31,12 @@ public class SuspendTimeoutStatusHandler implements IStatusHandler {
 	@Override
 	public Object handleStatus(IStatus status, Object source) throws CoreException {
 		IJavaThread thread= (IJavaThread) source;
-		final ErrorDialog dialog= new ErrorDialog(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), DebugUIMessages.SuspendTimeoutHandler_suspend, NLS.bind(DebugUIMessages.SuspendTimeoutHandler_timeout_occurred, new String[] {thread.getName()}), status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO); //
+		String threadName = thread.getName();
 		Display display= JDIDebugUIPlugin.getStandardDisplay();
 		display.syncExec(new Runnable() {
 			@Override
 			public void run() {
+				final ErrorDialog dialog= new ErrorDialog(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), DebugUIMessages.SuspendTimeoutHandler_suspend, NLS.bind(DebugUIMessages.SuspendTimeoutHandler_timeout_occurred, new String[] {threadName}), status, IStatus.WARNING | IStatus.ERROR | IStatus.INFO); //
 				dialog.open();
 			}
 		});


### PR DESCRIPTION
The change in 353005075c1ab3df53959b3deee9299cfbb7d934 replaced JDIDebugUIPlugin.getActiveWorkbenchShell() with
PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), however later one behavior is undefined in API but implementation requires the caller to be in UI thread - which was not the case of the former API.

=> Move the code that acquires the modal shell into UI thread.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/563
