### PR TITLE
fix "unable to instantiate class JavaBreakpointAdvancedPage" #570

### DIFF
--- a/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.ui; singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.debug.ui/pom.xml
+++ b/org.eclipse.jdt.debug.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.ui</artifactId>
-  <version>3.13.600-SNAPSHOT</version>
+  <version>3.13.700-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
   	<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/propertypages/JavaBreakpointAdvancedPage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/propertypages/JavaBreakpointAdvancedPage.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PropertyPage;
 
-public abstract class JavaBreakpointAdvancedPage extends PropertyPage {
+public class JavaBreakpointAdvancedPage extends PropertyPage {
 
 	ThreadFilterEditor fThreadFilterEditor;
 	InstanceFilterEditor fInstanceFilterEditor;
@@ -81,9 +81,13 @@ public abstract class JavaBreakpointAdvancedPage extends PropertyPage {
 
 	/**
 	 * Allow subclasses to create type-specific editors.
+	 *
+	 * @param parent
+	 *            parent Composite
 	 */
-	abstract void createTypeSpecificEditors(Composite parent);
-
+	protected void createTypeSpecificEditors(Composite parent) {
+		// Do nothing.
+	}
 	protected void createThreadFilterEditor(Composite parent) {
 		fThreadFilterEditor = new ThreadFilterEditor(parent, this);
 	}


### PR DESCRIPTION
When trying to open breakpoint Preferences page "Filtering"

JavaBreakpointAdvancedPage is referenced by:
org.eclipse.jdt.debug.ui\plugin.xml

partial revert of
1e0e94b4dba875598495f1d73633023245699db7

https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/570
