### PR TITLE
OpenFromClipboardTests: wait for job families instead of excluding #442

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/TestUtil.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/TestUtil.java
@@ -133,10 +133,14 @@ public class TestUtil {
 	 * @return true if the method timed out, false if all the jobs terminated before the timeout
 	 */
 	public static boolean waitForJobs(String owner, long minTimeMs, long maxTimeMs, Object... excludedFamilies) {
+		return waitForJobs(owner, null, minTimeMs, maxTimeMs, excludedFamilies);
+	}
+
+	public static boolean waitForJobs(String owner, Object jobFamily, long minTimeMs, long maxTimeMs, Object... excludedFamilies) {
 		if (maxTimeMs < minTimeMs) {
 			throw new IllegalArgumentException("Max time is smaller as min time!");
 		}
-		wakeUpSleepingJobs(null);
+		wakeUpSleepingJobs(jobFamily);
 		final long start = System.currentTimeMillis();
 		while (System.currentTimeMillis() - start < minTimeMs) {
 			runEventLoop();
@@ -153,7 +157,7 @@ public class TestUtil {
 			} catch (InterruptedException e) {
 				// Uninterruptable
 			}
-			List<Job> jobs = getRunningOrWaitingJobs(null, excludedFamilies);
+			List<Job> jobs = getRunningOrWaitingJobs(jobFamily, excludedFamilies);
 			if (jobs.isEmpty()) {
 				// only uninteresting jobs running
 				break;
@@ -169,7 +173,7 @@ public class TestUtil {
 				dumpRunningOrWaitingJobs(owner, jobs);
 				return true;
 			}
-			wakeUpSleepingJobs(null);
+			wakeUpSleepingJobs(jobFamily);
 		}
 		runningJobs.clear();
 		return false;

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/OpenFromClipboardTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/OpenFromClipboardTests.java
@@ -97,8 +97,8 @@ public class OpenFromClipboardTests {
 	}
 
 	private static void waitForEncodingRelatedJobs() {
-		TestUtil.waitForJobs("OpenFromClipboardTests", 10, 5_000, ValidateProjectEncoding.class);
-		TestUtil.waitForJobs("OpenFromClipboardTests", 10, 5_000, CharsetDeltaJob.FAMILY_CHARSET_DELTA);
+		TestUtil.waitForJobs("OpenFromClipboardTests", ValidateProjectEncoding.class, 0, 5_000);
+		TestUtil.waitForJobs("OpenFromClipboardTests", CharsetDeltaJob.FAMILY_CHARSET_DELTA, 0, 5_000);
 	}
 
 	private static IJavaProject createProject(String name) throws CoreException {


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/442
