### PR TITLE
Jenkinsfile: longer history, less artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '15', artifactDaysToKeepStr: '99'))
+		buildDiscarder(logRotator(numToKeepStr: (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ 'BETA.*') ? '100':'5', artifactNumToKeepStr: (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ 'BETA.*') ? '15':'2'))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'15'))
+		buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '15', artifactDaysToKeep: '99'))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '15', artifactDaysToKeep: '99'))
+		buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '15', artifactDaysToKeepStr: '99'))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}


### PR DESCRIPTION
Keep more builds to get better statistics for master and BETA branches.
But less builds for others (especially PRs).

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2653
