### PR TITLE
[performance] avoid File.getCanonicalPath()

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ImportBreakpointsTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ImportBreakpointsTest.java
@@ -228,7 +228,7 @@ public class ImportBreakpointsTest extends AbstractBreakpointWorkingSetTest {
 			File file = JavaTestPlugin.getDefault().getFileInPlugin(new Path("testresources/brkpt_missing.bkpt"));
 			assertNotNull(file);
 			assertEquals(true, file.exists());
-			ImportBreakpointsOperation op = new ImportBreakpointsOperation(file.getCanonicalPath(), true, true);
+			ImportBreakpointsOperation op = new ImportBreakpointsOperation(file.toPath().normalize().toAbsolutePath().toString(), true, true);
 			op.run(new NullProgressMonitor());
 			assertEquals("should be no breakpoints imported", 0, getBreakpointManager().getBreakpoints().length);
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/InstalledJREsBlock.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/InstalledJREsBlock.java
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.internal.debug.ui.jres;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1052,11 +1051,8 @@ public class InstalledJREsBlock implements IAddVMDialogRequestor, ISelectionProv
 				return;
 			}
 			File file = new File(directory, names[i]);
-			try {
-				monitor.subTask(NLS.bind(JREMessages.InstalledJREsBlock_14, new String[]{Integer.toString(found.size()),
-						file.getCanonicalPath().replaceAll("&", "&&")}));   // @see bug 29855 //$NON-NLS-1$ //$NON-NLS-2$
-			} catch (IOException e) {
-			}
+			monitor.subTask(NLS.bind(JREMessages.InstalledJREsBlock_14, new String[] { Integer.toString(found.size()),
+					file.toPath().normalize().toAbsolutePath().toString().replaceAll("&", "&&") })); // @see bug 29855 //$NON-NLS-1$ //$NON-NLS-2$
 			IVMInstallType[] vmTypes = JavaRuntime.getVMInstallTypes();
 			if (file.isDirectory()) {
 				if (!ignore.contains(file)) {


### PR DESCRIPTION
File.getCanonicalPath() is a IO Operation that is costly especially on windows OS.
Instead use a NON-IO .toPath().normalize().toAbsolutePath().toString()

https://bugs.eclipse.org/bugs/show_bug.cgi?id=571614

