### PR TITLE
Make a couple of methods private around JDIModelPresentation

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
@@ -186,7 +186,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 	 *            the target in which a thread is required
 	 * @return thread or <code>null</code>
 	 */
-	public static IJavaThread getEvaluationThread(IJavaDebugTarget target) {
+	private static IJavaThread getEvaluationThread(IJavaDebugTarget target) {
 		IJavaStackFrame frame = EvaluationContextManager.getEvaluationContext((IWorkbenchWindow)null);
 		IJavaThread thread = null;
 		if (frame != null) {
@@ -2017,14 +2017,14 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 	/**
 	 * Plug in the single argument to the resource String for the key to get a formatted resource String
 	 */
-	public static String getFormattedString(String key, String arg) {
+	private static String getFormattedString(String key, String arg) {
 		return getFormattedString(key, new String[] {arg});
 	}
 
 	/**
 	 * Plug in the arguments to the resource String for the key to get a formatted resource String
 	 */
-	public static String getFormattedString(String string, String[] args) {
+	private static String getFormattedString(String string, String[] args) {
 		return NLS.bind(string, args);
 	}
 
@@ -2064,7 +2064,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 		}
 	}
 
-	protected static org.eclipse.jdt.internal.debug.ui.ImageDescriptorRegistry getDebugImageRegistry() {
+	private static org.eclipse.jdt.internal.debug.ui.ImageDescriptorRegistry getDebugImageRegistry() {
 		if (fgDebugImageRegistry == null) {
 			fgDebugImageRegistry = JDIDebugUIPlugin.getImageDescriptorRegistry();
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
@@ -55,7 +55,8 @@ import org.eclipse.swt.graphics.FontData;
  */
 public class JavaVariableLabelProvider extends VariableLabelProvider implements IPreferenceChangeListener {
 
-	public static JDIModelPresentation fLabelProvider = new JDIModelPresentation();
+	private final static JDIModelPresentation fLabelProvider = new JDIModelPresentation();
+
 	/**
 	 * Map of view id to qualified name setting
 	 */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
 Couple of methods is public, however it is not used outside of that class in JDIModelPresentation

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
