### PR TITLE
Remove redundant "NON-NLS" comments

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaApplicationLaunchShortcut.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaApplicationLaunchShortcut.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.util.Util;
 
 /**
  * Launch shortcut for local Java applications.
@@ -209,6 +210,6 @@ public class JavaApplicationLaunchShortcut extends JavaLaunchShortcut {
 				return moduleDescription.getElementName();
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return Util.ZERO_LENGTH_STRING;
 	}
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaArgumentsTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaArgumentsTab.java
@@ -200,7 +200,7 @@ public class JavaArgumentsTab extends JavaLaunchTab {
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		try {
-			fPrgmArgumentsText.setText(configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, "")); //$NON-NLS-1$
+			fPrgmArgumentsText.setText(configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, EMPTY_STRING));
 			fVMArgumentsBlock.initializeFrom(configuration);
 			fWorkingDirectoryBlock.initializeFrom(configuration);
 		} catch (CoreException e) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
@@ -94,6 +94,7 @@ import org.eclipse.jdt.ui.JavaElementLabelProvider;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.resource.CompositeImageDescriptor;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.osgi.util.NLS;
@@ -1521,7 +1522,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 				label = getClassPrepareBreakpointText(prepareBreakpoint);
 			} else {
 				// Should never get here
-				return ""; //$NON-NLS-1$
+				return Util.ZERO_LENGTH_STRING;
 			}
 			String suffix = breakpoint.getMarker().getAttribute(BREAKPOINT_LABEL_SUFFIX, null);
 			if (suffix == null) {
@@ -1545,7 +1546,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 		IMember member= BreakpointUtils.getMember(breakpoint);
 		String sourceName = breakpoint.getSourceName();
 		if (sourceName == null) {
-		    sourceName = ""; //$NON-NLS-1$
+			sourceName = Util.ZERO_LENGTH_STRING;
 		    IMarker marker = breakpoint.getMarker();
 		    if (marker != null) {
 		        IResource resource = marker.getResource();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugHover.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugHover.java
@@ -77,6 +77,7 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextHoverExtension;
 import org.eclipse.jface.text.ITextHoverExtension2;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.util.Util;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 
@@ -496,7 +497,7 @@ public class JavaDebugHover implements IJavaEditorTextHover, ITextHoverExtension
 		} else if (element instanceof ILocalVariable) {
 			signature = ((ILocalVariable) element).getTypeSignature();
 		} else {
-			signature = ""; //$NON-NLS-1$
+			signature = Util.ZERO_LENGTH_STRING;
 		}
 		return signature.startsWith("["); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugOptionsManager.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugOptionsManager.java
@@ -81,6 +81,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.window.Window;
@@ -483,7 +484,7 @@ public class JavaDebugOptionsManager implements IDebugEventSetListener, IPropert
 	 */
 	public static String serializeList(String[] list) {
 		if (list == null) {
-			return ""; //$NON-NLS-1$
+			return Util.ZERO_LENGTH_STRING;
 		}
 		return String.join(String.valueOf(','), list);
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
@@ -59,6 +59,7 @@ import org.eclipse.jdt.internal.debug.core.model.JDINullValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIReferenceListValue;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 
 import com.sun.jdi.InvocationException;
@@ -282,7 +283,7 @@ public class JavaDetailFormattersManager implements IPropertyChangeListener, IDe
 	}
 
 	public DetailFormatter getAssociatedDetailFormatter(IJavaType type) {
-		String typeName = ""; //$NON-NLS-1$
+		String typeName = Util.ZERO_LENGTH_STRING;
 		try {
 			while (type instanceof IJavaArrayType) {
 				type = ((IJavaArrayType)type).getComponentType();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AddExternalFolderAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AddExternalFolderAction.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.debug.ui.launcher.IClasspathViewer;
 import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.DirectoryDialog;
 
@@ -42,7 +43,7 @@ public class AddExternalFolderAction extends OpenDialogAction {
 
 		String lastUsedPath= getDialogSetting(LAST_PATH_SETTING);
 		if (lastUsedPath == null) {
-			lastUsedPath= ""; //$NON-NLS-1$
+			lastUsedPath = Util.ZERO_LENGTH_STRING;
 		}
 		DirectoryDialog dialog = new DirectoryDialog(getShell(), SWT.MULTI | SWT.SHEET);
 		dialog.setText(ActionMessages.AddExternalFolderAction_Folder_Selection_3);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AddExternalJarAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AddExternalJarAction.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
@@ -46,7 +47,7 @@ public class AddExternalJarAction extends OpenDialogAction {
 
 		String lastUsedPath = getDialogSetting(LAST_PATH_SETTING);
 		if (lastUsedPath == null) {
-			lastUsedPath = ""; //$NON-NLS-1$
+			lastUsedPath = Util.ZERO_LENGTH_STRING;
 		}
 		FileDialog dialog = new FileDialog(getShell(), SWT.MULTI | SWT.SHEET);
 		dialog.setText(ActionMessages.AddExternalJar_Jar_Selection_3);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/DisplayAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/DisplayAction.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.debug.eval.IEvaluationResult;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jdt.internal.debug.ui.display.IDataDisplay;
 import org.eclipse.jdt.internal.debug.ui.snippeteditor.JavaSnippetEditor;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPart;
@@ -69,7 +70,7 @@ public class DisplayAction extends EvaluateAction {
 				if (sig != null) {
 					resultString= NLS.bind(ActionMessages.DisplayAction_type_name_pattern, new Object[] { resultValue.getReferenceTypeName() });
 				} else {
-					resultString= ""; //$NON-NLS-1$
+					resultString = Util.ZERO_LENGTH_STRING;
 				}
 				getDebugModelPresentation().computeDetail(resultValue, new IValueDetailListener() {
 					@Override

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EvaluateAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EvaluateAction.java
@@ -62,6 +62,7 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -576,7 +577,7 @@ public abstract class EvaluateAction implements IEvaluationListener, IWorkbenchW
 	}
 
 	protected String getErrorMessage(String[] errors) {
-		String message= ""; //$NON-NLS-1$
+		String message = Util.ZERO_LENGTH_STRING;
 		for (int i= 0; i < errors.length; i++) {
 			String msg= errors[i];
 			if (i == 0) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExpressionInputDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExpressionInputDialog.java
@@ -44,6 +44,7 @@ import org.eclipse.jface.text.TextViewer;
 import org.eclipse.jface.text.TextViewerUndoManager;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -337,7 +338,7 @@ public class ExpressionInputDialog extends TrayDialog {
 	 */
 	protected void setErrorMessage(String message) {
 	    if (message == null) {
-	        message= ""; //$NON-NLS-1$
+			message = Util.ZERO_LENGTH_STRING;
 	    }
 	    fErrorText.setText(message);
 	    getButton(IDialogConstants.OK_ID).setEnabled(message.length() == 0);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OverrideDependenciesDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OverrideDependenciesDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -88,7 +89,7 @@ public class OverrideDependenciesDialog extends MessageDialog {
 		gd.widthHint = convertWidthInCharsToPixels(60);
 		fModuleArgumentsNewText.setLayoutData(gd);
 
-		String moduleCLIOptions = ""; //$NON-NLS-1$
+		String moduleCLIOptions = Util.ZERO_LENGTH_STRING;
 		try {
 			AbstractJavaLaunchConfigurationDelegate delegate = getJavaLaunchConfigurationDelegate();
 			if (delegate != null) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/breakpoints/StandardJavaBreakpointEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/breakpoints/StandardJavaBreakpointEditor.java
@@ -21,6 +21,7 @@ import org.eclipse.debug.internal.ui.SWTFactory;
 import org.eclipse.jdt.debug.core.IJavaBreakpoint;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
 import org.eclipse.jdt.internal.debug.ui.propertypages.PropertyPageMessages;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
@@ -186,7 +187,7 @@ public class StandardJavaBreakpointEditor extends AbstractJavaBreakpointEditor {
 		fBreakpoint = breakpoint;
 		boolean enabled = false;
 		boolean hasHitCount = false;
-		String text = ""; //$NON-NLS-1$
+		String text = Util.ZERO_LENGTH_STRING;
 		boolean suspendThread = true;
 		if (breakpoint != null) {
 			enabled = true;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/classpath/VariableClasspathEntryWorkbenchAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/classpath/VariableClasspathEntryWorkbenchAdapter.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.internal.launching.VariableClasspathEntry;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.Util;
 import org.eclipse.ui.model.IWorkbenchAdapter;
 
 /**
@@ -51,7 +52,7 @@ public class VariableClasspathEntryWorkbenchAdapter implements IWorkbenchAdapter
 		if (o instanceof VariableClasspathEntry) {
 			return ((VariableClasspathEntry)o).getName();
 		}
-		return ""; //$NON-NLS-1$
+		return Util.ZERO_LENGTH_STRING;
 	}
 	/* (non-Javadoc)
 	 * @see org.eclipse.ui.model.IWorkbenchAdapter#getParent(java.lang.Object)

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/ExecutionEnvironmentsPreferencePage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/ExecutionEnvironmentsPreferencePage.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
@@ -134,7 +135,7 @@ public class ExecutionEnvironmentsPreferencePage extends PreferencePage implemen
 		fJREsViewer.setInput(env);
 		String description = env.getDescription();
 		if (description == null) {
-			description = ""; //$NON-NLS-1$
+			description = Util.ZERO_LENGTH_STRING;
 		}
 		fDescription.setText(description);
 		IVMInstall jre = (IVMInstall) fDefaults.get(env);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/VMDetailsDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/VMDetailsDialog.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -90,7 +91,7 @@ public class VMDetailsDialog extends Dialog {
 			}
 		}
 		if (text == null) {
-			text = ""; //$NON-NLS-1$
+			text = Util.ZERO_LENGTH_STRING;
 		}
 		Text argText = SWTFactory.createText(parent, SWT.BORDER | SWT.WRAP | SWT.V_SCROLL, 2, text);
 		GridData gd = (GridData) argText.getLayoutData();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/VMLibraryBlock.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/VMLibraryBlock.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.launching.VMStandin;
 import org.eclipse.jdt.launching.environments.ExecutionEnvironmentDescription;
 import org.eclipse.jdt.ui.wizards.BuildPathDialogAccess;
 import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -302,7 +303,7 @@ public class VMLibraryBlock extends AbstractVMInstallPage implements SelectionLi
 		IDialogSettings dialogSettings= JDIDebugUIPlugin.getDefault().getDialogSettings();
 		String lastUsedPath= dialogSettings.get(LAST_PATH_SETTING);
 		if (lastUsedPath == null) {
-			lastUsedPath= ""; //$NON-NLS-1$
+			lastUsedPath = Util.ZERO_LENGTH_STRING;
 		}
 		FileDialog dialog = new FileDialog(fLibraryViewer.getControl().getShell(), SWT.MULTI | SWT.SHEET);
 		dialog.setText(JREMessages.VMLibraryBlock_10);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AbstractJavaMainTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/AbstractJavaMainTab.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.internal.debug.ui.actions.ControlAccessibleListener;
 import org.eclipse.jdt.internal.launching.JavaMigrationDelegate;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.ui.JavaElementLabelProvider;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.events.ModifyEvent;
@@ -79,7 +80,7 @@ private class WidgetListener implements ModifyListener, SelectionListener {
 	}
 }
 
-	protected static final String EMPTY_STRING = ""; //$NON-NLS-1$
+protected static final String EMPTY_STRING = Util.ZERO_LENGTH_STRING;
 	//Project UI widgets
 	protected Text fProjText;
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/RuntimeClasspathEntryLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/RuntimeClasspathEntryLabelProvider.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.osgi.util.NLS;
@@ -223,7 +224,7 @@ public class RuntimeClasspathEntryLabelProvider extends LabelProvider {
 				}
 				return name;
 		}
-		return ""; //$NON-NLS-1$
+		return Util.ZERO_LENGTH_STRING;
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/SharedJavaMainTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/SharedJavaMainTab.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionEvent;
@@ -140,7 +141,7 @@ public abstract class SharedJavaMainTab extends AbstractJavaMainTab {
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, name);
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MODULE_NAME, moduleName);
 		if (name.length() > 0) {
-			String category = ""; //$NON-NLS-1$
+			String category = Util.ZERO_LENGTH_STRING;
 			try {
 				category = config.getType().getIdentifier();
 			} catch (CoreException e) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/propertypages/ExceptionFilterEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/propertypages/ExceptionFilterEditor.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.internal.ui.filtertable.JavaFilterTable.DialogLabels;
 import org.eclipse.jdt.internal.ui.filtertable.JavaFilterTable.FilterStorage;
 import org.eclipse.jdt.internal.ui.filtertable.JavaFilterTable.FilterTableConfig;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ColumnLayoutData;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.TableLayout;
@@ -82,7 +83,7 @@ public class ExceptionFilterEditor {
 				for (Filter filter : filters) {
 					String name = filter.getName();
 					if (name.equals(DEFAULT_PACKAGE)) {
-						name = ""; //$NON-NLS-1$
+						name = Util.ZERO_LENGTH_STRING;
 					}
 					if (filter.isChecked()) {
 						inclusionFilters.add(name);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/JavaSnippetEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/JavaSnippetEditor.java
@@ -98,6 +98,7 @@ import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Image;
@@ -1283,7 +1284,7 @@ public class JavaSnippetEditor extends AbstractDecoratedTextEditor implements ID
 			IProject p= file.getProject();
 			projectName= p.getName();
 		}
-		String message= ""; //$NON-NLS-1$
+		String message = Util.ZERO_LENGTH_STRING;
 		if (projectName != null) {
 			message = projectName + SnippetMessages.getString("JavaSnippetEditor._is_not_a_Java_Project._n_1"); //$NON-NLS-1$
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SnippetEditorActionContributor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SnippetEditorActionContributor.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.BasicCompilationUnitEditorActionCo
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.util.Util;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchActionConstants;
 
@@ -111,7 +112,7 @@ public class SnippetEditorActionContributor extends BasicCompilationUnitEditorAc
 	}
 
 	protected void updateStatus(JavaSnippetEditor editor) {
-		String message= ""; //$NON-NLS-1$
+		String message = Util.ZERO_LENGTH_STRING;
 		if (editor != null && editor.isEvaluating()) {
 			message= SnippetMessages.getString("SnippetActionContributor.evalMsg");  //$NON-NLS-1$
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SnippetMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SnippetMessages.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.debug.ui.snippeteditor;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 
 public class SnippetMessages {
@@ -47,8 +48,9 @@ public class SnippetMessages {
 		} catch (MissingResourceException e) {
 			return "!" + key + "!";//$NON-NLS-2$ //$NON-NLS-1$
 		}
-		if (arg == null)
-			arg= ""; //$NON-NLS-1$
+		if (arg == null) {
+			arg= Util.ZERO_LENGTH_STRING;
+		}
 		return NLS.bind(format, new Object[] { arg });
 	}
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/sourcelookup/WorkbenchAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/sourcelookup/WorkbenchAdapter.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.launching.sourcelookup.containers.PackageFragmentRootSour
 import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.Util;
 import org.eclipse.ui.model.IWorkbenchAdapter;
 
 /**
@@ -129,7 +130,7 @@ public class WorkbenchAdapter implements IWorkbenchAdapter {
 				}
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return Util.ZERO_LENGTH_STRING;
 	}
 	/* (non-Javadoc)
 	 * @see org.eclipse.ui.model.IWorkbenchAdapter#getParent(java.lang.Object)


### PR DESCRIPTION
This commit refactors the classes in debug.ui by removing unnecessary "NON-NLS" comments that were previously used to mark empty strings. Instead, the `org.eclipse.jface.util.Util.ZERO_LENGTH_STRING` static constant is now leveraged for representing empty strings in these classes.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
