### PR TITLE
Primitive arrays and Lambdas type on variables view

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -507,7 +507,14 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 				buffer.append(' ');
 			}
 		}
-
+		if (buffer.isEmpty() && value instanceof IJavaArray javaArray) {
+			String label = javaArray.getJavaType().getName();
+			label = adjustTypeNameForArrayIndex(label, javaArray.getLength());
+			if (label != null) {
+				buffer.append(label);
+				buffer.append(' ');
+			}
+		}
 		// Put double quotes around Strings
 		if (valueString != null && (isString || valueString.length() > 0)) {
 			if (isString) {
@@ -1917,10 +1924,19 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 	/**
 	 * Return the simple name from a qualified name (non-generic)
 	 */
+	@SuppressWarnings("nls")
 	private String getSimpleName(String qualifiedName) {
 		int index = qualifiedName.lastIndexOf('.');
-		if (index >= 0) {
+		if (index >= 0 && !qualifiedName.contains("$Lambda.")) {
 			return qualifiedName.substring(index + 1);
+		}
+		if (index >= 0 && qualifiedName.contains("$Lambda.")) {
+			int indexLambdaStart = qualifiedName.indexOf("$Lambda.");
+			String temp = qualifiedName.substring(indexLambdaStart + 1);
+			if (temp.indexOf('.') != -1) {
+				temp = temp.substring(0, temp.indexOf('.'));
+				return temp;
+			}
 		}
 		return qualifiedName;
 	}


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/592

This commit provides fix for not showing primitive arrays and lambdas correctly in variables view.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/592


Before fix - 
<br>
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a5d6ca28-36f4-420d-a9db-39cf025ab43f" />
<br>
After - 
<img width="967" alt="image" src="https://github.com/user-attachments/assets/d7f1c1f4-c04f-40d6-9e14-194854ca96de" />

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
