### PR TITLE
HCR Failure pop up alignment changes

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ErrorDialogWithToggle.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ErrorDialogWithToggle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,15 +90,14 @@ public class ErrorDialogWithToggle extends ErrorDialog {
 	 * configuration data.
 	 */
 	private Button createCheckButton(Composite parent, String label) {
-		Button button= new Button(parent, SWT.CHECK | SWT.LEFT);
+		Button button = new Button(parent, SWT.CHECK | SWT.LEFT);
 		button.setText(label);
-
 		GridData data = new GridData(SWT.NONE);
+		data.horizontalIndent = 40;
 		data.horizontalSpan = 2;
-		data.horizontalAlignment= GridData.CENTER;
+		data.horizontalAlignment = GridData.BEGINNING;
 		button.setLayoutData(data);
 		button.setFont(parent.getFont());
-
 		return button;
 	}
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.TraverseEvent;
 import org.eclipse.swt.events.TraverseListener;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -63,6 +64,10 @@ public class HotCodeReplaceErrorDialog extends ErrorDialogWithToggle {
 		getButton(IDialogConstants.OK_ID).setText(DebugUIMessages.HotCodeReplaceErrorDialog_0);
 		boolean canTerminate= target.canTerminate();
 		boolean canDisconnect= target.canDisconnect();
+		GridData data = new GridData(SWT.CENTER);
+		data.horizontalAlignment = GridData.CENTER;
+		data.horizontalSpan = 2;
+		parent.setLayoutData(data);
 		if (canTerminate) {
 			createButton(parent, TERMINATE_ID, DebugUIMessages.HotCodeReplaceErrorDialog_1, false);
 		}
@@ -81,11 +86,10 @@ public class HotCodeReplaceErrorDialog extends ErrorDialogWithToggle {
 	 */
 	@Override
 	protected Button createButton(Composite parent, int id, String label, boolean defaultButton) {
-		Button button= super.createButton(parent, id, label, defaultButton);
+		Button button = super.createButton(parent, id, label, defaultButton);
 		blockMnemonicWithoutModifier(button);
 		return button;
 	}
-
 	/**
 	 * Ensures that simple key presses don't activate the given button.
 	 *


### PR DESCRIPTION
This commit aligns all checkbox options in HCR failure box to Left and other buttons to center.

based on https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/558#issuecomment-2595226235

Before : 

![image](https://github.com/user-attachments/assets/9ad9bbc9-6f53-4236-b97d-690a08491fde)

<img width="440" alt="image" src="https://github.com/user-attachments/assets/ee308d18-a224-4764-9584-144b838f7975" />

<br><br>
After : <br>
Checkboxes aligned to left,
Buttons aligned to center
<img width="722" alt="Screenshot 2025-01-21 at 8 23 08 AM" src="https://github.com/user-attachments/assets/a8d10fd8-e9a7-46b9-83f9-eeda1a5dc260" /> <br>
<img width="714" alt="Screenshot 2025-01-21 at 8 23 33 AM" src="https://github.com/user-attachments/assets/cbf6767e-e678-405d-a0a9-8e16bc6fa794" />


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
