### PR TITLE
Virtual thread debug view tests fix

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -635,7 +635,6 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				jp.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
 				cfgs.add(createLaunchConfiguration(jp, "Main1"));
 				cfgs.add(createLaunchConfiguration(jp, "Main2"));
-				cfgs.add(createLaunchConfiguration(jp, "Main21"));
 				loaded23 = true;
 				waitForBuild();
 				assertNoErrorMarkersExist(jp.getProject());
@@ -792,7 +791,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		}
 	}
 
-	void handleProjectCreationException(Exception e, String pname, IJavaProject jp) {
+	protected void handleProjectCreationException(Exception e, String pname, IJavaProject jp) {
 		StringWriter buf = new StringWriter();
 		String msg = e.getMessage();
     	if(msg == null) {

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/VirtualThreadsDebugViewTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/VirtualThreadsDebugViewTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation.
+ * Copyright (c) 2024, 2025 IBM Corporation.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.ui;
 
+import java.util.ArrayList;
+
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IThread;
 import org.eclipse.debug.internal.ui.views.console.ProcessConsole;
@@ -23,8 +27,10 @@ import org.eclipse.debug.ui.IDebugModelPresentation;
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.debug.ui.IDebugView;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.debug.core.IJavaBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.debug.tests.TestUtil;
 import org.eclipse.jdt.debug.ui.IJavaDebugUIConstants;
 import org.eclipse.jdt.internal.debug.core.model.JDIThread;
@@ -76,7 +82,33 @@ public class VirtualThreadsDebugViewTests extends AbstractDebugUiTests {
 
 	@Override
 	protected IJavaProject getProjectContext() {
-		return super.get23Project();
+		create23Project();
+		return getJavaProject(TWENTYTHREE_PROJECT_NAME);
+	}
+
+	synchronized void create23Project() {
+		IJavaProject jp = null;
+		ArrayList<ILaunchConfiguration> cfgs = new ArrayList<>(1);
+		try {
+			jp = createProject(TWENTYTHREE_PROJECT_NAME, JavaProjectHelper.TEST_23_SRC_DIR.toString(), JavaProjectHelper.JAVA_SE_23_EE_NAME, false);
+			jp.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_23);
+			jp.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
+			cfgs.add(createLaunchConfiguration(jp, "Main21"));
+			waitForBuild();
+			assertNoErrorMarkersExist(jp.getProject());
+		} catch (Exception e) {
+			try {
+				if (jp != null) {
+					jp.getProject().delete(true, true, null);
+					for (int i = 0; i < cfgs.size(); i++) {
+						cfgs.get(i).delete();
+					}
+				}
+			} catch (CoreException ce) {
+				// ignore
+			}
+			super.handleProjectCreationException(e, TWENTYTHREE_PROJECT_NAME, jp);
+		}
 	}
 
 	public void testVirtualThreadDebugView() throws Exception {


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/598

This commit will create a separate java 23 project configuration having disabled preview features for virtual thread debug view tests 

Partial fix :
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/553

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
