### PR TITLE
Additional Handling for Stack trace link generation

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceAmbiguityTest.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/JavaStackTraceAmbiguityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation.
+ * Copyright (c) 2024, 2025 IBM Corporation.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -417,6 +417,60 @@ public class JavaStackTraceAmbiguityTest extends AbstractJavaStackTraceConsoleTe
 		IHyperlink[] hyperlinks = fConsole.getHyperlinks();
 		assertEquals("Wrong hyperlinks, listing all links: " + allLinks(), 2, hyperlinks.length);
 		String expectedText = "System.out.println(\"Expected_VarArgs\");";
+		try {
+			for (IHyperlink hyperlink : hyperlinks) {
+				closeAllEditors();
+				hyperlink.linkActivated();
+				IEditorPart editor = waitForEditorOpen();
+				String[] selectedText = new String[1];
+				sync(() -> selectedText[0] = getSelectedText(editor));
+				selectedText[0] = selectedText[0].trim();
+				assertEquals("Wrong text selected after hyperlink navigation", expectedText, selectedText[0]);
+
+			}
+		} finally {
+			closeAllEditors();
+			boolean force = true;
+			project.getProject().delete(force, new NullProgressMonitor());
+		}
+	}
+
+	public void testLinkNavigationTrueForLinksWithSingleSpaceBeforeSignature() throws Exception {
+		String projectName = "StackTest";
+		IJavaProject project = createProject(projectName, "testfiles/AmbiguityTest/", JavaProjectHelper.JAVA_SE_1_8_EE_NAME, false);
+		waitForBuild();
+		waitForJobs();
+		consoleDocumentWithText("at a.Sample.testBlank (Sample.java:40)");
+		IHyperlink[] hyperlinks = fConsole.getHyperlinks();
+		assertEquals("Wrong hyperlinks, listing all links: " + allLinks(), 1, hyperlinks.length);
+		String expectedText = "System.out.println(\"Expected_No_Signature\");";
+		try {
+			for (IHyperlink hyperlink : hyperlinks) {
+				closeAllEditors();
+				hyperlink.linkActivated();
+				IEditorPart editor = waitForEditorOpen();
+				String[] selectedText = new String[1];
+				sync(() -> selectedText[0] = getSelectedText(editor));
+				selectedText[0] = selectedText[0].trim();
+				assertEquals("Wrong text selected after hyperlink navigation", expectedText, selectedText[0]);
+
+			}
+		} finally {
+			closeAllEditors();
+			boolean force = true;
+			project.getProject().delete(force, new NullProgressMonitor());
+		}
+	}
+
+	public void testLinkNavigationTrueForLinksWithMultiSpaceBeforeSignature() throws Exception {
+		String projectName = "StackTest";
+		IJavaProject project = createProject(projectName, "testfiles/AmbiguityTest/", JavaProjectHelper.JAVA_SE_1_8_EE_NAME, false);
+		waitForBuild();
+		waitForJobs();
+		consoleDocumentWithText("at a.Sample.testBlank\t\t(Sample.java:40)");
+		IHyperlink[] hyperlinks = fConsole.getHyperlinks();
+		assertEquals("Wrong hyperlinks, listing all links: " + allLinks(), 1, hyperlinks.length);
+		String expectedText = "System.out.println(\"Expected_No_Signature\");";
 		try {
 			for (IHyperlink hyperlink : hyperlinks) {
 				closeAllEditors();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
@@ -725,7 +725,18 @@ public class JavaStackTraceHyperlink implements IHyperlink {
 			if (linkStart == -1) {
 				linkStart = line.lastIndexOf('\t', regionOffsetInLine);
 			}
-
+			String extractedTrace = line.substring(linkStart == -1 ? 0 : linkStart + 1, linkEnd + 1).trim();
+			if (extractedTrace.charAt(0) == '(') {
+				int lastOpen = line.lastIndexOf('(');
+				if (lastOpen > 0) {
+					if (Character.isWhitespace(line.charAt(lastOpen - 1))) {
+						extractedTrace = line.substring(0, lastOpen - 1).trim() + line.substring(lastOpen);
+						linkStart = extractedTrace.lastIndexOf(' ', regionOffsetInLine);
+						linkEnd = extractedTrace.indexOf(')', linkStart);
+						return extractedTrace.substring(linkStart == -1 ? 0 : linkStart + 1, linkEnd + 1).trim();
+					}
+				}
+			}
 			return line.substring(linkStart == -1 ? 0 : linkStart + 1, linkEnd + 1).trim();
 		} catch (BadLocationException e) {
 			IStatus status = new Status(IStatus.ERROR, JDIDebugUIPlugin.getUniqueIdentifier(), 0, ConsoleMessages.JavaStackTraceHyperlink_Unable_to_retrieve_hyperlink_text__8, e);


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/605

This commit fixes incorrect stack trace link generation caused by extra space between method name and parameters

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/605

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
