### PR TITLE
Default formatter for Exception objects #125

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -409,6 +409,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				cfgs.add(createLaunchConfiguration(jp, "a.b.c.GenericMethodEntryTest"));
 				cfgs.add(createLaunchConfiguration(jp, "org.eclipse.debug.tests.targets.HcrClass", true));
 				cfgs.add(createLaunchConfiguration(jp, "a.b.c.Bug570988"));
+				cfgs.add(createLaunchConfiguration(jp, "a.b.c.ExceptionDefaultTest"));
 				loaded15 = true;
 				waitForBuild();
 	        }

--- a/org.eclipse.jdt.debug.tests/testsource-j2se-1.5/a/b/c/ExceptionDefaultTest.java
+++ b/org.eclipse.jdt.debug.tests/testsource-j2se-1.5/a/b/c/ExceptionDefaultTest.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package a.b.c;
+
+public class ExceptionDefaultTest {
+	public static void main(String[] args) {
+		Exception e = new Exception();
+		int p=10;
+	}
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
@@ -382,6 +382,7 @@ public class JavaDetailFormattersManager implements IPropertyChangeListener, IDe
 	 * @return the snippet for the given class / super class
 	 * @throws DebugException if there is a problem computing the snippet
 	 */
+	@SuppressWarnings("nls")
 	private String getDetailFormatterSuperClass(IJavaClassType type) throws DebugException {
 		if (type == null) {
 			return null;
@@ -389,6 +390,15 @@ public class JavaDetailFormattersManager implements IPropertyChangeListener, IDe
 		DetailFormatter detailFormatter= fDetailFormattersMap.get(type.getName());
 		if (detailFormatter != null && detailFormatter.isEnabled()) {
 			return detailFormatter.getSnippet();
+		}
+		if ((detailFormatter == null || !detailFormatter.isEnabled()) && type.getName().equals("java.lang.Throwable")) {
+			String snippet = """
+					java.io.ByteArrayOutputStream bout = new java.io.ByteArrayOutputStream();
+					java.io.PrintStream ps = new java.io.PrintStream(bout);
+					this.printStackTrace(ps);
+					return bout.toString();
+					""";
+			return snippet;
 		}
 		return getDetailFormatterSuperClass(type.getSuperclass());
 	}


### PR DESCRIPTION
This commit modifies the default detail formatter of Exception objects by showing Exception class name and its stack trace by default if no specific detail formatter configured for Exception objects

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/125
<br>
Before <br>
<img width="484" alt="image" src="https://github.com/user-attachments/assets/62584ce9-7143-4f7c-a0ce-4c155817f1f6" />
<br>
After <br>
<img width="536" alt="image" src="https://github.com/user-attachments/assets/4ce5ed7a-3dc7-4283-a369-6afa695046b4" /> <br>
<img width="525" alt="image" src="https://github.com/user-attachments/assets/b8a34acf-9782-4a9d-8073-f16a77a1e9b0" />


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
