### PR TITLE
Fix line number mismatch during stack trace navigation from Open Type window

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
@@ -292,9 +292,9 @@ public class JavaStackTraceHyperlink implements IHyperlink {
 			processSearchResult(exactMatchesFiltered.get(0), typeName, line);
 			return Status.OK_STATUS;
 		} else if (exactMatchesFiltered.size() > 0) {
-			return openClipboard(exactMatchesFiltered, line, typeName);
+			return openClipboard(exactMatchesFiltered, ++line, typeName);
 		} else {
-			return openClipboard(matches, line, typeName);
+			return openClipboard(matches, ++line, typeName);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/617

This commit resolves the issue where the line numbers were mis-aligned (n-1) when navigating through a stack trace via the Open Type window. The fix ensures proper synchronization of line numbers, providing an accurate navigation experience.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/617

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
