### PR TITLE
fix ConcurrentModificationException in JDIDebugTarget.cleanup

### DIFF
--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.core.resources.IFile;
@@ -247,7 +248,7 @@ public class JDIDebugTarget extends JDIDebugElement implements
 	 * Evaluation engine cache by Java project. Engines are disposed when this
 	 * target terminates.
 	 */
-	private final Map<IJavaProject, IAstEvaluationEngine> fEngines = new HashMap<>(2);
+	private final ConcurrentMap<IJavaProject, IAstEvaluationEngine> fEngines = new ConcurrentHashMap<>(2);
 
 	/**
 	 * List of step filters - each string is a pattern/fully qualified name of a
@@ -1836,12 +1837,10 @@ public class JDIDebugTarget extends JDIDebugElement implements
 		removeAllBreakpoints();
 		DebugPlugin.getDefault().getBreakpointManager().enableTriggerPoints(null, true);
 		fOutOfSynchTypes.clear();
-		Iterator<IAstEvaluationEngine> engines = fEngines.values().iterator();
-		while (engines.hasNext()) {
-			IAstEvaluationEngine engine = engines.next();
+		fEngines.values().removeIf((IAstEvaluationEngine engine) -> {
 			engine.dispose();
-		}
-		fEngines.clear();
+			return true;
+		});
 		fVirtualMachine = null;
 		setThreadStartHandler(null);
 		setEventDispatcher(null);


### PR DESCRIPTION
use concurrent datastructure

https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/561
