### PR TITLE
Fix SelectImportsDialog

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SelectImportsDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/SelectImportsDialog.java
@@ -59,7 +59,11 @@ public class SelectImportsDialog extends TitleAreaDialog {
 
 			@Override
 			public void setStoredFilters(IPreferenceStore store, Filter[] filters) {
-				fEditor.setImports(imports);
+				String[] newImports = new String[filters.length];
+				for (int i = 0; i < filters.length; i++) {
+					newImports[i] = filters[i].getName();
+				}
+				fEditor.setImports(newImports);
 			}
 
 		},


### PR DESCRIPTION
This is instead of saving the user input didn't do anything, because it was used the incorrect 'imports' not the user provided 'filters'

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
In the Java snippet editor previously the import dialog didn't work properly, it didn't save the user provided package names, this patch fixes it. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a Java snippet page
2. Open the package import settings
3. Add new packages
4. Click on save
5. Open the package import settings again - notice that the previously provided packages are there

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
