### PR TITLE
More locations need to handle version "24"

### DIFF
--- a/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug.tests; singleton:=true
-Bundle-Version: 3.12.600.qualifier
+Bundle-Version: 3.12.650.qualifier
 Bundle-ClassPath: javadebugtests.jar
 Bundle-Activator: org.eclipse.jdt.debug.testplugin.JavaTestPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug.tests/pom.xml
+++ b/org.eclipse.jdt.debug.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.tests</artifactId>
-  <version>3.12.600-SNAPSHOT</version>
+  <version>3.12.650-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -732,9 +732,9 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		        JavaProjectHelper.addSourceContainer(jp, JavaProjectHelper.SRC_DIR, JavaProjectHelper.BIN_DIR);
 
 		        // add VM specific JRE container
-				IExecutionEnvironment j2se14 = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(JavaProjectHelper.JAVA_SE_1_8_EE_NAME);
-		        assertNotNull("Missing J2SE-1.4 environment", j2se14);
-		        IPath path = JavaRuntime.newJREContainerPath(j2se14);
+				IExecutionEnvironment javase1_8 = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment(JavaProjectHelper.JAVA_SE_1_8_EE_NAME);
+				assertNotNull("Missing JavaSE-1.8 environment", javase1_8);
+				IPath path = JavaRuntime.newJREContainerPath(javase1_8);
 		        JavaProjectHelper.addContainerEntry(jp, path);
 		        loadedEE = true;
 		        waitForBuild();

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ExecutionEnvironmentTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ExecutionEnvironmentTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -23,8 +27,10 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.internal.launching.EECompilationParticipant;
 import org.eclipse.jdt.launching.AbstractVMInstall;
 import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.LibraryLocation;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
@@ -258,5 +264,28 @@ public class ExecutionEnvironmentTests extends AbstractDebugTest {
 			return; // expected
 		}
 		assertNotNull("Test should have thrown an exception", null);
+	}
+
+	/**
+	 * Test decoding of the latest JVM version
+	 */
+	public void testVMVersionDecoding() {
+		IVMInstall2 install = new IVMInstall2() {
+			@Override
+			public void setVMArgs(String vmArgs) {
+			}
+
+			@Override
+			public String getVMArgs() {
+				return null;
+			}
+
+			@Override
+			public String getJavaVersion() {
+				return JavaCore.latestSupportedJavaVersion() + ".xyz";
+			}
+		};
+		String compliance = EECompilationParticipant.getCompilerCompliance(install);
+		assertEquals(JavaCore.latestSupportedJavaVersion(), compliance);
 	}
 }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/VMInstallTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/VMInstallTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -282,6 +286,17 @@ public class VMInstallTests extends AbstractDebugTest {
 			assertEquals(packages, JavaRuntime.getProvidedVMPackages(vm, "definitivly-not-a-version"));
 		} catch (org.junit.AssumptionViolatedException e) {
 			// Ignore this test. TODO: remove this once this is a JUnit-4 or later test that handles assumptions correctly
+		}
+	}
+
+	public void testLatestJavadocLocation() {
+		String latest = JavaCore.latestSupportedJavaVersion();
+		URL javadocLocation = StandardVMType.getDefaultJavadocLocation(latest);
+		assertNotNull(javadocLocation);
+		if (!javadocLocation.getPath().contains(latest)) {
+			System.err.println("****************************WARNING!!**********************************");
+			System.err.println("Update for Java " + latest + " needed in StandardVMType.getDefaultJavadocLocation()");
+			System.err.println("***********************************************************************");
 		}
 	}
 

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 IBM Corporation and others.
+ * Copyright (c) 2008, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -234,54 +238,64 @@ public class EECompilationParticipant extends CompilationParticipant {
 		String version = vMInstall.getJavaVersion();
 		if (version == null) {
 			return null;
-		} else if (version.startsWith(JavaCore.VERSION_23)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_24)) {
+			return JavaCore.VERSION_24;
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_23)) {
 			return JavaCore.VERSION_23;
-		} else if (version.startsWith(JavaCore.VERSION_22)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_22)) {
 			return JavaCore.VERSION_22;
-		} else if (version.startsWith(JavaCore.VERSION_21)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_21)) {
 			return JavaCore.VERSION_21;
-		} else if (version.startsWith(JavaCore.VERSION_20)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_20)) {
 			return JavaCore.VERSION_20;
-		} else if (version.startsWith(JavaCore.VERSION_19)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_19)) {
 			return JavaCore.VERSION_19;
-		} else if (version.startsWith(JavaCore.VERSION_18)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_18)) {
 			return JavaCore.VERSION_18;
-		} else if (version.startsWith(JavaCore.VERSION_17)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_17)) {
 			return JavaCore.VERSION_17;
-		} else if (version.startsWith(JavaCore.VERSION_16)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_16)) {
 			return JavaCore.VERSION_16;
-		} else if (version.startsWith(JavaCore.VERSION_15)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_15)) {
 			return JavaCore.VERSION_15;
-		} else if (version.startsWith(JavaCore.VERSION_14)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_14)) {
 			return JavaCore.VERSION_14;
-		} else if (version.startsWith(JavaCore.VERSION_13)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_13)) {
 			return JavaCore.VERSION_13;
-		} else if (version.startsWith(JavaCore.VERSION_12)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_12)) {
 			return JavaCore.VERSION_12;
-		} else if (version.startsWith(JavaCore.VERSION_11)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_11)) {
 			return JavaCore.VERSION_11;
-		} else if (version.startsWith(JavaCore.VERSION_10)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_10)) {
 			return JavaCore.VERSION_10;
-		} else if (version.startsWith(JavaCore.VERSION_9)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_9)) {
 			return JavaCore.VERSION_9;
-		} else if (version.startsWith(JavaCore.VERSION_1_8)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_8)) {
 			return JavaCore.VERSION_1_8;
-		} else if (version.startsWith(JavaCore.VERSION_1_7)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_7)) {
 			return JavaCore.VERSION_1_7;
-		} else if (version.startsWith(JavaCore.VERSION_1_6)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_6)) {
 			return JavaCore.VERSION_1_6;
-		} else if (version.startsWith(JavaCore.VERSION_1_5)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_5)) {
 			return JavaCore.VERSION_1_5;
-		} else if (version.startsWith(JavaCore.VERSION_1_4)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_4)) {
 			return JavaCore.VERSION_1_4;
-		} else if (version.startsWith(JavaCore.VERSION_1_3)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_3)) {
 			return JavaCore.VERSION_1_3;
-		} else if (version.startsWith(JavaCore.VERSION_1_2)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_2)) {
 			return JavaCore.VERSION_1_3;
-		} else if (version.startsWith(JavaCore.VERSION_1_1)) {
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_1)) {
 			return JavaCore.VERSION_1_3;
 		}
 		return null;
+	}
+
+	private static boolean matchesMajorVersion(String currentVersion, String knownVersion) {
+		if (currentVersion.startsWith(knownVersion)) {
+			int knownLength = knownVersion.length();
+			return currentVersion.length() == knownLength || currentVersion.charAt(knownLength) == '.';
+		}
+		return false;
 	}
 
 	/**

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -809,8 +813,10 @@ public class StandardVMType extends AbstractVMInstallType {
 	 */
 	public static URL getDefaultJavadocLocation(String version) {
 		try {
-			if (version.startsWith(JavaCore.VERSION_23)) {
-				// To modify to version 23 after the release
+			if (version.startsWith(JavaCore.VERSION_24)) {
+				// To modify to version 24 after the release
+				return new URI("https://docs.oracle.com/en/java/javase/23/docs/api/").toURL(); //$NON-NLS-1$
+			} else if (version.startsWith(JavaCore.VERSION_23)) {
 				return new URI("https://docs.oracle.com/en/java/javase/23/docs/api/").toURL(); //$NON-NLS-1$
 			} else if (version.startsWith(JavaCore.VERSION_22)) {
 				return new URI("https://docs.oracle.com/en/java/javase/22/docs/api/").toURL(); //$NON-NLS-1$

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/JavaRuntime.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Frits Jalvingh - Contribution for Bug 459831 - [launching] Support attaching
@@ -88,6 +92,7 @@ import org.eclipse.jdt.internal.launching.CompositeId;
 import org.eclipse.jdt.internal.launching.DefaultEntryResolver;
 import org.eclipse.jdt.internal.launching.DefaultProjectClasspathEntry;
 import org.eclipse.jdt.internal.launching.DetectVMInstallationsJob;
+import org.eclipse.jdt.internal.launching.EECompilationParticipant;
 import org.eclipse.jdt.internal.launching.EEVMInstall;
 import org.eclipse.jdt.internal.launching.EEVMType;
 import org.eclipse.jdt.internal.launching.JREContainerInitializer;
@@ -3338,88 +3343,36 @@ public final class JavaRuntime {
 			LaunchingPlugin.log("Compliance needs an update."); //$NON-NLS-1$
 		}
         if (vm instanceof IVMInstall2) {
-            String javaVersion = ((IVMInstall2)vm).getJavaVersion();
-            if (javaVersion != null) {
-            	String compliance = null;
-				if (javaVersion.startsWith(JavaCore.VERSION_1_8)) {
-					compliance = JavaCore.VERSION_1_8;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_9)
-						&& (javaVersion.length() == JavaCore.VERSION_9.length() || javaVersion.charAt(JavaCore.VERSION_9.length()) == '.')) {
-					compliance = JavaCore.VERSION_9;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_10)
-						&& (javaVersion.length() == JavaCore.VERSION_10.length() || javaVersion.charAt(JavaCore.VERSION_10.length()) == '.')) {
-					compliance = JavaCore.VERSION_10;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_11)
-						&& (javaVersion.length() == JavaCore.VERSION_11.length() || javaVersion.charAt(JavaCore.VERSION_11.length()) == '.')) {
-					compliance = JavaCore.VERSION_11;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_12)
-						&& (javaVersion.length() == JavaCore.VERSION_12.length() || javaVersion.charAt(JavaCore.VERSION_12.length()) == '.')) {
-					compliance = JavaCore.VERSION_12;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_13)
-						&& (javaVersion.length() == JavaCore.VERSION_13.length() || javaVersion.charAt(JavaCore.VERSION_13.length()) == '.')) {
-					compliance = JavaCore.VERSION_13;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_14)
-						&& (javaVersion.length() == JavaCore.VERSION_14.length() || javaVersion.charAt(JavaCore.VERSION_14.length()) == '.')) {
-					compliance = JavaCore.VERSION_14;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_15)
-						&& (javaVersion.length() == JavaCore.VERSION_15.length() || javaVersion.charAt(JavaCore.VERSION_15.length()) == '.')) {
-					compliance = JavaCore.VERSION_15;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_16)
-						&& (javaVersion.length() == JavaCore.VERSION_16.length() || javaVersion.charAt(JavaCore.VERSION_16.length()) == '.')) {
-					compliance = JavaCore.VERSION_16;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_17)
-						&& (javaVersion.length() == JavaCore.VERSION_17.length() || javaVersion.charAt(JavaCore.VERSION_17.length()) == '.')) {
-					compliance = JavaCore.VERSION_17;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_18)
-						&& (javaVersion.length() == JavaCore.VERSION_18.length() || javaVersion.charAt(JavaCore.VERSION_18.length()) == '.')) {
-					compliance = JavaCore.VERSION_18;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_19)
-						&& (javaVersion.length() == JavaCore.VERSION_19.length() || javaVersion.charAt(JavaCore.VERSION_19.length()) == '.')) {
-					compliance = JavaCore.VERSION_19;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_20)
-						&& (javaVersion.length() == JavaCore.VERSION_20.length() || javaVersion.charAt(JavaCore.VERSION_20.length()) == '.')) {
-					compliance = JavaCore.VERSION_20;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_21)
-						&& (javaVersion.length() == JavaCore.VERSION_21.length() || javaVersion.charAt(JavaCore.VERSION_21.length()) == '.')) {
-					compliance = JavaCore.VERSION_21;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_22)
-						&& (javaVersion.length() == JavaCore.VERSION_22.length() || javaVersion.charAt(JavaCore.VERSION_22.length()) == '.')) {
-					compliance = JavaCore.VERSION_22;
-				} else if (javaVersion.startsWith(JavaCore.VERSION_23)
-						&& (javaVersion.length() == JavaCore.VERSION_23.length() || javaVersion.charAt(JavaCore.VERSION_23.length()) == '.')) {
-					compliance = JavaCore.VERSION_23;
-				} else {
-					compliance = JavaCore.VERSION_23; // use latest by default
-				}
+			String compliance = EECompilationParticipant.getCompilerCompliance((IVMInstall2) vm);
+			if (compliance == null) {
+				compliance = JavaCore.latestSupportedJavaVersion();
+			}
 
-            	Hashtable<String, String> options= JavaCore.getOptions();
+			Hashtable<String, String> options = JavaCore.getOptions();
 
-            	org.osgi.service.prefs.Preferences bundleDefaults = BundleDefaultsScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+			org.osgi.service.prefs.Preferences bundleDefaults = BundleDefaultsScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
 
-            	boolean isDefault =
-            			equals(JavaCore.COMPILER_COMPLIANCE, options, bundleDefaults) &&
-            			equals(JavaCore.COMPILER_SOURCE, options, bundleDefaults) &&
-            			equals(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, options, bundleDefaults) &&
-            			equals(JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, options, bundleDefaults) &&
-            			equals(JavaCore.COMPILER_PB_ENUM_IDENTIFIER, options, bundleDefaults);
-				if (JavaCore.compareJavaVersions(compliance, JavaCore.VERSION_10) > 0) {
-					isDefault = isDefault && equals(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, options, bundleDefaults)
-							&& equals(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, options, bundleDefaults);
-				}
-            	// only update the compliance settings if they are default settings, otherwise the
-            	// settings have already been modified by a tool or user
+			boolean isDefault = equals(JavaCore.COMPILER_COMPLIANCE, options, bundleDefaults)
+					&& equals(JavaCore.COMPILER_SOURCE, options, bundleDefaults)
+					&& equals(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, options, bundleDefaults)
+					&& equals(JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, options, bundleDefaults)
+					&& equals(JavaCore.COMPILER_PB_ENUM_IDENTIFIER, options, bundleDefaults);
+			if (JavaCore.compareJavaVersions(compliance, JavaCore.VERSION_10) > 0) {
+				isDefault = isDefault && equals(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, options, bundleDefaults)
+						&& equals(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, options, bundleDefaults);
+			}
+			// only update the compliance settings if they are default settings, otherwise the
+			// settings have already been modified by a tool or user
+			if (LaunchingPlugin.isVMLogging()) {
+				LaunchingPlugin.log("Compliance to be updated is: " + compliance); //$NON-NLS-1$
+			}
+			if (isDefault) {
+				JavaCore.setComplianceOptions(compliance, options);
+				JavaCore.setOptions(options);
 				if (LaunchingPlugin.isVMLogging()) {
-					LaunchingPlugin.log("Compliance to be updated is: " + compliance); //$NON-NLS-1$
+					LaunchingPlugin.log("Compliance Options are updated."); //$NON-NLS-1$
 				}
-            	if (isDefault) {
-					JavaCore.setComplianceOptions(compliance, options);
-					JavaCore.setOptions(options);
-					if (LaunchingPlugin.isVMLogging()) {
-						LaunchingPlugin.log("Compliance Options are updated."); //$NON-NLS-1$
-					}
-            	}
-
-            }
+			}
         }
 	}
 


### PR DESCRIPTION
Update:
+ StandardVMType
+ unify code from EECompilationParticipant and JavaRuntime

Test currency vis-a-vis JavaCore.latestSupportedJavaVersion()

Also update stale test still mentioning J2SE-1.4
