### PR TITLE
Allow JavaVariableLabelProvider's presentation to be overridden

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.debug.ui.variables;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
@@ -55,7 +56,7 @@ import org.eclipse.swt.graphics.FontData;
  */
 public class JavaVariableLabelProvider extends VariableLabelProvider implements IPreferenceChangeListener {
 
-	private final static JDIModelPresentation fLabelProvider = new JDIModelPresentation();
+	private static JDIModelPresentation fLabelProvider = new JDIModelPresentation();
 
 	/**
 	 * Map of view id to qualified name setting
@@ -289,5 +290,23 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		} else if (event.getKey().equals(IJDIPreferencesConstants.PREF_SHOW_DETAILS)) {
 			determineSerializationMode((String) event.getNewValue());
 		}
+	}
+
+	/**
+	 * @return the model presentation used to display Java elements, never {@code null}
+	 */
+	protected static JDIModelPresentation getModelPresentation() {
+		return fLabelProvider;
+	}
+
+	/**
+	 * Sets the model presentation used by this label provider to the specified object.
+	 *
+	 * @param presentation
+	 *            the new presentation, may not be {@code null}
+	 */
+	protected static void setModelPresentation(final JDIModelPresentation presentation) {
+		Assert.isNotNull(presentation);
+		fLabelProvider = presentation;
 	}
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableLabelProvider.java
@@ -81,20 +81,14 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.elements.adapters.VariableLabelAdapter#getValueText(org.eclipse.debug.core.model.IVariable, org.eclipse.debug.core.model.IValue)
-	 */
 	@Override
 	protected String getValueText(IVariable variable, IValue value, IPresentationContext context) throws CoreException {
-		if (value instanceof IJavaValue) {
-			return fLabelProvider.getFormattedValueText((IJavaValue) value);
+		if (value instanceof IJavaValue javaValue) {
+			return fLabelProvider.getFormattedValueText(javaValue);
 		}
 		return super.getValueText(variable, value, context);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.elements.adapters.VariableLabelAdapter#getValueTypeName(org.eclipse.debug.core.model.IVariable, org.eclipse.debug.core.model.IValue)
-	 */
 	@Override
 	protected String getValueTypeName(IVariable variable, IValue value, IPresentationContext context) throws CoreException {
 		String typeName= DebugUIMessages.JDIModelPresentation_unknown_type__2;
@@ -114,19 +108,15 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 			return result;
 		}
 		var element = elementPath.getLastSegment();
-		if (element instanceof IJavaVariable) {
-			var variable = (IJavaVariable) element;
+		if (element instanceof IJavaVariable variable) {
 			var value = variable.getValue();
-			if (value instanceof IJavaObject && ((IJavaObject) value).getLabel() != null) {
+			if (value instanceof IJavaObject javaObject && javaObject.getLabel() != null) {
 				return new FontData(result.getName(), result.getHeight(), result.getStyle() ^ SWT.BOLD);
 			}
 		}
 		return result;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.elements.adapters.VariableLabelAdapter#getVariableTypeName(org.eclipse.debug.core.model.IVariable)
-	 */
 	@Override
 	protected String getVariableTypeName(IVariable variable, IPresentationContext context) throws CoreException {
 		String typeName= DebugUIMessages.JDIModelPresentation_unknown_type__2;
@@ -143,7 +133,7 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 	 * Returns if the the specified presentation context is showing qualified names or not
 	 * @return true if the presentation context is showing qualified names, false otherwise
 	 */
-	private Boolean isShowQualfiiedNames(IPresentationContext context) {
+	private Boolean isShowQualifiedNames(IPresentationContext context) {
 		Boolean qualified = fQualifiedNameSettings.get(context.getId());
 		if (qualified == null) {
 			qualified = Boolean.valueOf(Platform.getPreferencesService().getBoolean(
@@ -156,14 +146,11 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		return qualified;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.elements.adapters.VariableLabelAdapter#getColumnText(org.eclipse.debug.core.model.IVariable, org.eclipse.debug.core.model.IValue, java.lang.String, org.eclipse.debug.internal.ui.viewers.provisional.IPresentationContext)
-	 */
 	@Override
 	protected String getColumnText(IVariable variable, IValue value, IPresentationContext context, String columnId) throws CoreException {
 		if (JavaVariableColumnPresentation.COLUMN_INSTANCE_ID.equals(columnId)) {
-			if (value instanceof JDIObjectValue) {
-				long uniqueId = ((JDIObjectValue)value).getUniqueId();
+			if (value instanceof JDIObjectValue objectValue) {
+				long uniqueId = objectValue.getUniqueId();
 				if (uniqueId >= 0) {
 					StringBuilder buffer = new StringBuilder();
 					buffer.append(uniqueId);
@@ -173,28 +160,26 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 			return ""; //$NON-NLS-1$
 		}
 		if (JavaVariableColumnPresentation.COLUMN_INSTANCE_COUNT.equals(columnId)) {
-			if (value instanceof IJavaObject) {
-				IJavaType jType = ((IJavaObject)value).getJavaType();
-				if (jType == null && variable instanceof IJavaVariable) {
-					jType = ((IJavaVariable)variable).getJavaType();
+			if (value instanceof IJavaObject javaObject) {
+				IJavaType jType = javaObject.getJavaType();
+				if (jType == null && variable instanceof IJavaVariable javaVariable) {
+					jType = javaVariable.getJavaType();
 				}
-				if (jType instanceof IJavaReferenceType) {
-					if (!(jType instanceof IJavaInterfaceType)) {
-						long count = ((IJavaReferenceType)jType).getInstanceCount();
-						if (count == -1) {
-							return DebugUIMessages.JavaVariableLabelProvider_0;
-						}
-						StringBuilder buffer = new StringBuilder();
-						buffer.append(count);
-						return buffer.toString();
+				if (jType instanceof IJavaReferenceType refType && !(jType instanceof IJavaInterfaceType)) {
+					long count = refType.getInstanceCount();
+					if (count == -1) {
+						return DebugUIMessages.JavaVariableLabelProvider_0;
 					}
+					StringBuilder buffer = new StringBuilder();
+					buffer.append(count);
+					return buffer.toString();
 				}
 			}
 			return ""; //$NON-NLS-1$
 		}
 		if (JavaVariableColumnPresentation.COLUMN_LABEL.equals(columnId)) {
-			if (value instanceof IJavaObject) {
-				String label = ((IJavaObject) value).getLabel();
+			if (value instanceof IJavaObject javaObject) {
+				String label = javaObject.getLabel();
 				if (label != null) {
 					return label;
 				}
@@ -209,7 +194,7 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 	 */
 	@Override
 	protected void retrieveLabel(ILabelUpdate update) throws CoreException {
-		Boolean showQ = isShowQualfiiedNames(update.getPresentationContext());
+		Boolean showQ = isShowQualifiedNames(update.getPresentationContext());
 		fQualifiedNames = showQ.booleanValue();
 		fLabelProvider.setAttribute(JDIModelPresentation.DISPLAY_QUALIFIED_NAMES, showQ);
 		super.retrieveLabel(update);
@@ -230,9 +215,6 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.model.elements.VariableLabelProvider#getLabel(org.eclipse.jface.viewers.TreePath, org.eclipse.debug.internal.ui.viewers.model.provisional.IPresentationContext, java.lang.String)
-	 */
 	@Override
 	protected String getLabel(TreePath elementPath, IPresentationContext context, String columnId) throws CoreException {
 		if (columnId == null) {
@@ -245,9 +227,6 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		return super.getLabel(elementPath, context, columnId);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.debug.internal.ui.model.elements.ElementLabelProvider#getRule(org.eclipse.debug.internal.ui.viewers.model.provisional.ILabelUpdate)
-	 */
 	@Override
 	protected ISchedulingRule getRule(ILabelUpdate update) {
 		IJavaStackFrame frame = null;
@@ -260,11 +239,11 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 			break;
 		case SERIALIZE_SOME:
 			Object element = update.getElement();
-			if (element instanceof IJavaVariable) {
+			if (element instanceof IJavaVariable javaVariable) {
 				try {
-					IValue value = ((IJavaVariable)element).getValue();
-					if (value instanceof IJavaValue) {
-						if (!fLabelProvider.isShowLabelDetails((IJavaValue)value)) {
+					IValue value = javaVariable.getValue();
+					if (value instanceof IJavaValue javaValue) {
+						if (!fLabelProvider.isShowLabelDetails(javaValue)) {
 							input = update.getViewerInput();
 							frame = (IJavaStackFrame) DebugPlugin.getAdapter(input, IJavaStackFrame.class);
 						}
@@ -280,9 +259,6 @@ public class JavaVariableLabelProvider extends VariableLabelProvider implements 
 		return null;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener#preferenceChange(org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent)
-	 */
 	@Override
 	public void preferenceChange(PreferenceChangeEvent event) {
 		if (event.getKey().endsWith(IJDIPreferencesConstants.PREF_SHOW_QUALIFIED_NAMES)) {


### PR DESCRIPTION
This mostly reverts a4eae7ff2f3dc3f51234053cc4a9374c2f6f8b51 (#580) for this file, as well as some code cleanup. Instead of making the fLabelProvider final, we initialize it to a default value as before but provide getters/setters so the field can still be private. Details in #580 for why I need this change, but in short it's because our product has a debugger that is tightly coupled to the JDT debugger, basically being an extension of it. Since this probably only affects me, your attention is greatly appreciated.

I don't understand this code enough to know why fLabelProvider is static, given that label providers are not meant to be shared, so I left it alone. Otherwise it would make more sense to have it as an instance field, maybe defined in an overloaded constructor.

I also thought to update the version of this plugin to 3.15 but Eclipse gave me an error when I did that about "no new APIs added" which I don't think is correct, but please let me know.

