### PR TITLE
Pin the address of the Y-build repo to 4.35-Y-builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <profile>
       <id>build-individual-bundles</id>
       <properties>
-      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
+      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.35-Y-builds</eclipse-p2-repo.url>
       	<skipAPIAnalysis>true</skipAPIAnalysis>
       </properties>
       <repositories>


### PR DESCRIPTION
Related to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2927


See also
* https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3809
* https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2089