### PR TITLE
Navigate to variable declaration from variable view

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.properties
+++ b/org.eclipse.jdt.debug.ui/plugin.properties
@@ -121,6 +121,9 @@ openDeclVarType.tooltip=Open the Variable's Declared Type
 openDeclVarTypeHierarchy.label=Open Declared Type &Hierarchy
 openDeclVarTypeHierarchy.tooltip=Open the Variable's Declared Type Hierarchy
 
+openDeclLocalVarNavigation.label=Navigate to Declaration
+openDeclLocalVarNavigation.tooltip=Navigates to variable's declaration
+
 openConcreteVarType.label=Open Act&ual Type
 openConcreteVarType.tooltip=Open the Variable's Actual Implementation Type
 

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -747,6 +747,23 @@
                enablesFor="1"
                id="org.eclipse.jdt.debug.ui.actions.OpenVariableDeclaredType">
          </action>
+         <action
+               label="%openDeclLocalVarNavigation.label"
+               helpContextId="open_variable_declared_type_hierarchy_action_context"
+               tooltip="%openDeclLocalVarNavigation.tooltip"
+               class="org.eclipse.jdt.internal.debug.ui.actions.NavigateToVarDeclAction"
+               menubarPath="emptyNavigationGroup"
+               enablesFor="1"
+               id="org.eclipse.jdt.debug.ui.actions.OpenDeclLocalVarNavigation">
+         </action>
+         <visibility>
+            <not>
+               <objectState
+                     name="JavaVariableFilter"
+                     value="isLocalVariableValue">
+               </objectState>
+            </not>
+         </visibility>
       </objectContribution>
       <objectContribution
             objectClass="org.eclipse.jdt.debug.core.IJavaVariable"

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaVarActionFilter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaVarActionFilter.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.debug.core.IJavaObject;
 import org.eclipse.jdt.debug.core.IJavaPrimitiveValue;
 import org.eclipse.jdt.debug.core.IJavaType;
 import org.eclipse.jdt.debug.core.IJavaVariable;
+import org.eclipse.jdt.internal.debug.core.model.JDILocalVariable;
 import org.eclipse.jdt.internal.debug.core.model.JDINullValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIObjectValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIPlaceholderValue;
@@ -206,6 +207,9 @@ public class JavaVarActionFilter implements IActionFilter {
 					}
 					if (value.equals("isFieldVariable")) { //$NON-NLS-1$
 						return var instanceof IJavaFieldVariable;
+					}
+					if (value.equals("isLocalVariableValue")) { //$NON-NLS-1$
+						return !(var instanceof JDILocalVariable);
 					}
 				}
 				else if (name.equals("ConcreteVariableActionFilter") && value.equals("isConcrete")) { //$NON-NLS-1$ //$NON-NLS-2$

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/NavigateToVarDeclAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/NavigateToVarDeclAction.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.internal.debug.ui.actions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.debug.core.IJavaStackFrame;
+import org.eclipse.jdt.debug.core.IJavaVariable;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public class NavigateToVarDeclAction extends ObjectActionDelegate {
+	@Override
+	public void run(IAction action) {
+		IStructuredSelection selection = getCurrentSelection();
+		if (selection == null) {
+			return;
+		}
+		try {
+			if (selection.getFirstElement() instanceof IJavaVariable varE) {
+				String name = varE.getName();
+				Object frame = DebugUITools.getDebugContext();
+				if (frame instanceof IStackFrame jFrame) {
+					if (jFrame instanceof IJavaStackFrame javaStackFrame) {
+						String type = javaStackFrame.getLaunch().getLaunchConfiguration().getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, (String) null);
+						IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(type);
+						IJavaProject iJavaProject = JavaCore.create(project);
+						IType iType = iJavaProject.findType(javaStackFrame.getReceivingTypeName());
+						String currentMethod = javaStackFrame.getMethodName();
+						List<String> frameParams = javaStackFrame.getArgumentTypeNames();
+						List<String> ref = frameParams.stream().map(e -> {
+							int dot = e.lastIndexOf('.');
+							if (dot >= 0) {
+								return e.substring(dot + 1);
+							}
+							return e;
+						}).collect(Collectors.toList());
+						ICompilationUnit cu = iType.getCompilationUnit();
+						ASTParser parse = ASTParser.newParser(AST.getJLSLatest());
+						parse.setSource(cu);
+						parse.setKind(ASTParser.K_COMPILATION_UNIT);
+						parse.setResolveBindings(true);
+						CompilationUnit ast = (CompilationUnit) parse.createAST(null);
+						ast.accept(new ASTVisitor() {
+							boolean meth = false;
+							boolean found = false;
+							@Override
+							public boolean visit(MethodDeclaration node) {
+								if (node.getName().getIdentifier().equals(currentMethod)) {
+									List<Object> parameters = node.parameters();
+									List<String> methodParams = parameters.stream().map(p -> ((SingleVariableDeclaration) p).getType().toString()).toList();
+									if (methodParams.equals(ref)) {
+										meth = true;
+										for (Object op : node.parameters()) {
+											SingleVariableDeclaration parm = (SingleVariableDeclaration) op;
+											if (parm.getName().getIdentifier().equals(name)) {
+												highlightLine(ast, cu, node.getStartPosition());
+												found = true;
+												return false;
+											}
+										}
+										return true;
+									}
+								}
+								return true;
+							}
+
+							@Override
+							public boolean visit(VariableDeclarationFragment node) {
+								if (found) {
+									return false;
+								}
+								if (meth && node.getName().getIdentifier().equals(name)) {
+									found = true;
+									highlightLine(ast, cu, node.getStartPosition());
+									return false;
+								}
+								return true;
+							}
+						});
+					}
+				}
+			}
+		} catch (Exception e) {
+			DebugUIPlugin.log(e);
+		}
+	}
+
+	/**
+	 * This method is responsible for highlighting a line.
+	 *
+	 * @param ast
+	 *            Abstract Syntax tree of the code
+	 * @param cu
+	 *            compilation unit of the code
+	 * @param startPos
+	 *            start position of the code want to highlight
+	 */
+	private void highlightLine(CompilationUnit ast, ICompilationUnit cu, int startPos) {
+		int line = ast.getLineNumber(startPos);
+		try {
+			IEditorPart editor = JavaUI.openInEditor(cu);
+			if (editor instanceof ITextEditor txtEd) {
+				IDocumentProvider prov = txtEd.getDocumentProvider();
+				IDocument doc = prov.getDocument(txtEd.getEditorInput());
+				IRegion lineReg = doc.getLineInformation(line - 1);
+				txtEd.selectAndReveal(lineReg.getOffset(), lineReg.getLength());
+			}
+		} catch (Exception e) {
+			DebugUIPlugin.log(e);
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
All necessary discussions so far have been added to the parent ticket.

This PR closes #640 

## How to test
**Steps**
=======

1. <img width="1145" alt="Screenshot 2025-03-18 at 8 14 36 AM" src="https://github.com/user-attachments/assets/8be12f2b-cefc-4e47-ade7-727b8c00666d" />
Right click on the variable in the variables view while on debug mode. A new option have beed added("Open local variable Navigation)
2. <img width="1212" alt="Screenshot 2025-03-18 at 8 15 58 AM" src="https://github.com/user-attachments/assets/9a13423e-1ee5-4e27-b727-216d465b05f6" />
Once it selected, the selected variable highlighted. 
3. <img width="1268" alt="Screenshot 2025-03-18 at 8 17 13 AM" src="https://github.com/user-attachments/assets/28f14da1-a257-407a-afed-32cc2c873585" />
The "Open local variable navigation" option would not available for unwanted items.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
