### PR TITLE
Remove Debug listener on HCR popup close

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/HotCodeReplaceErrorDialog.java
@@ -33,8 +33,8 @@ import org.eclipse.swt.events.TraverseListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * An error dialog reporting a problem with a debug
@@ -159,9 +159,14 @@ public class HotCodeReplaceErrorDialog extends ErrorDialogWithToggle implements 
 	@Override
 	public void handleDebugEvents(DebugEvent[] events) {
 		for (DebugEvent event : events) {
-			if (event.getSource() instanceof JDIThread de) {
-				if (de.isTerminated()) {
-					Display.getDefault().asyncExec(() -> this.close());
+			if (event.getSource() instanceof JDIThread jdiThread) {
+				if(!jdiThread.isTerminated()) {
+					continue;
+				}
+				if (jdiThread.getDebugTarget().equals(target.getDebugTarget())) {
+					DebugPlugin.getDefault().removeDebugEventListener(this);
+					PlatformUI.getWorkbench().getDisplay().asyncExec(this::close);
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/630/files#r2003358448

Remove debug event listener when HCR failure dialog is closed after thread termination

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
