### PR TITLE
Use the same icon for collapsed frames

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
@@ -755,6 +755,9 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 			if (item instanceof IJavaStackFrame) {
 				return getStackFrameImage((IJavaStackFrame) item);
 			}
+			if (item instanceof GroupedStackFrame) {
+				return getJavaDebugImage(JavaDebugImages.IMG_OBJS_GROUPED_STACK_FRAME, 0);
+			}
 			if (item instanceof IJavaThread || item instanceof IJavaDebugTarget) {
 				return getDebugElementImage(item);
 			}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugImages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugImages.java
@@ -108,6 +108,7 @@ public class JavaDebugImages {
 	public static final String IMG_OVR_TRIGGER_SUPPRESSED = "IMG_OVR_TRIGGER_SUPPRESSED"; //$NON-NLS-1$
 
 	public static final String IMG_JAVA_STACKTRACE_CONSOLE = "IMG_JAVA_STACKTRACE_CONSOLE"; //$NON-NLS-1$
+	public static final String IMG_OBJS_GROUPED_STACK_FRAME = "IMG_OBJ_GROUPED_STACKFRAME"; //$NON-NLS-1$
 
 	/*
 	 * Set of predefined Image Descriptors.
@@ -227,6 +228,7 @@ public class JavaDebugImages {
 		declareRegistryImage(IMG_OVR_TRIGGER_SUPPRESSED, T_OVR + "trigger_suppressed_ovr.png"); //$NON-NLS-1$
 
 		declareRegistryImage(IMG_JAVA_STACKTRACE_CONSOLE, T_OBJ + "javastacktrace_console.png"); //$NON-NLS-1$
+		declareRegistryImage(IMG_OBJS_GROUPED_STACK_FRAME, T_OBJ + "groupedframe.png"); //$NON-NLS-1$
 
 	}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Show an icon for the collapsed stack frames 


## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
