### PR TITLE
Do not collapse single frames under GroupedStackFrame

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/monitors/JavaThreadContentProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/monitors/JavaThreadContentProvider.java
@@ -156,12 +156,18 @@ public class JavaThreadContentProvider extends JavaElementContentProvider {
 				if (frame instanceof JDIStackFrame javaFrame) {
 					var category = javaFrame.getCategory();
 					if (category == null || !category.hideWhenCollapse()) {
+						if (lastGroupping != null) {
+							if (lastGroupping.getFrameCount() > 1) {
+								result.add(lastGroupping);
+							} else {
+								result.add(lastGroupping.getTopMostFrame());
+							}
+						}
 						result.add(javaFrame);
 						lastGroupping = null;
 					} else {
 						if (lastGroupping == null) {
 							lastGroupping = new GroupedStackFrame(javaFrame.getJavaDebugTarget());
-							result.add(lastGroupping);
 						}
 						lastGroupping.add(javaFrame);
 					}
@@ -169,6 +175,9 @@ public class JavaThreadContentProvider extends JavaElementContentProvider {
 					result.add(frame);
 				}
 			}
+		}
+		if (lastGroupping != null) {
+			result.add(lastGroupping);
 		}
 		return result;
 	}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Adjust the stack frame grouping logic, so if only one frame is in a group, we don't want to hide it.

## How to test
Start debugging, put breakpoint into a function called through a lambda, like:

```
	void a5() {
		Optional.of("aa").map(this::a6);
	}

	String a6(String s) {
		return s;
	}
```

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
