### PR TITLE
Discover JVM from more vendors #651

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -185,7 +185,11 @@ public class DetectVMInstallationsJob extends Job {
 	@SuppressWarnings("nls")
 	private void computeWindowsCandidates(Collection<File> rootDirectories) {
 		List<String> progFiles = List.of("ProgramFiles", "ProgramFiles(x86)");
-		List<String> subDirs = List.of("Eclipse Adoptium", "RedHat", "Java");
+		/// Could not find directory name for vendors:
+		/// - Alibaba - instructs to unzip in arbitrary directory
+		/// - IBM - each product carries its own installation of JDK
+		/// - SAP - each product carries its own installation of JDK
+		List<String> subDirs = List.of("Eclipse Adoptium", "RedHat", "Java", "Axiom", "Zulu", "BellSoft", "Microsoft", "Amazon Corretto");
 		rootDirectories.addAll(
 		progFiles.stream()
 			.map(name -> System.getenv(name))


### PR DESCRIPTION
Fixes #651
Follow-up for #231

## What it does
Only JVMs from following vendors had a chance to be automatically discovered on Windows:

- Eclipse Adoptium
- RedHat
- Java (Oracle)

Now the list is extended.

## How to test
To test
- Install  https://aka.ms/download-jdk/microsoft-jdk-21.0.6-windows-x64.msi with default settings for all users
- ensure the new JVM is detected after JDT restart

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

/label Windows