### PR TITLE
Some dynamic discovery for environment versions

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.launching;
 
+import java.lang.Runtime.Version;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -283,7 +284,12 @@ public class EECompilationParticipant extends CompilationParticipant {
 		} else if (matchesMajorVersion(version, JavaCore.VERSION_1_1)) {
 			return JavaCore.VERSION_1_3;
 		}
-		return null;
+		try {
+			Version v = Version.parse(version);
+			return Integer.toString(v.feature());
+		} catch (IllegalArgumentException ex) {
+			return null;
+		}
 	}
 
 	private static boolean matchesMajorVersion(String currentVersion, String knownVersion) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.Runtime.Version;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -854,6 +855,10 @@ public class StandardVMType extends AbstractVMInstallType {
 			} else if (version.startsWith(JavaCore.VERSION_1_3)) {
 				// archived: http://download.oracle.com/javase/1.3/docs/api/
 				return new URL("https://docs.oracle.com/javase/1.5.0/docs/api/"); //$NON-NLS-1$
+			} else {
+				// heurisitc for not-yet declared versions
+				var v = Version.parse(version);
+				return new URI("https://docs.oracle.com/en/java/javase/" + v.feature() + "/docs/api/").toURL(); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} catch (URISyntaxException | MalformedURLException e) {
 		}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
@@ -34,9 +34,9 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.launching.LaunchingPlugin;
@@ -253,6 +253,16 @@ public class EnvironmentsManager implements IExecutionEnvironmentsManager, IVMIn
 			return JavaCore.VERSION_1_1;
 		} else if (desc.indexOf("1.0") != -1) { //$NON-NLS-1$
 			return "1.0"; //$NON-NLS-1$
+		} else {
+			// an optimistic strategy for not-yet-declared versions
+			int lastNumberIndex = desc.length() - 1;
+			while (lastNumberIndex >= 0 && Character.isDigit(desc.charAt(lastNumberIndex))) {
+				lastNumberIndex--;
+			}
+			lastNumberIndex++; // fix consumed non-digit char
+			if (lastNumberIndex < desc.length()) {
+				return desc.substring(lastNumberIndex, desc.length());
+			}
 		}
 		return JavaCore.VERSION_1_3;
 	}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Provides some capability for environments that are not yet statically described in JDT.

This is a step towards
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/661

## How to test

Just ensure no regressions.
Because further guards are in place (eg checking Compiler support for given EE compliance), this would usually be a no-op as for the EE to be returned by the EEManager, the compiler must also declare support for next version.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
