### PR TITLE
Remove OpenDeclareType and OpenTypeHierarchy for Primitive Types and Arrays

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -709,6 +709,31 @@
       <objectContribution
             objectClass="org.eclipse.jdt.debug.core.IJavaVariable"
             id="org.eclipse.jdt.debug.ui.FilteredJavaVariableActions">
+         <filter
+               name="PrimitiveVariableActionFilter"
+               value="isPrimitive">
+         </filter>
+         <action
+               label="%openDeclLocalVarNavigation.label"
+               helpContextId="open_variable_declared_type_hierarchy_action_context"
+               tooltip="%openDeclLocalVarNavigation.tooltip"
+               class="org.eclipse.jdt.internal.debug.ui.actions.NavigateToVarDeclAction"
+               menubarPath="emptyNavigationGroup"
+               enablesFor="1"
+               id="org.eclipse.jdt.debug.ui.actions.OpenDeclLocalVarNavigation">
+         </action>
+         <visibility>
+            <not>
+               <objectState
+                     name="JavaVariableFilter"
+                     value="isLocalVariableValue">
+               </objectState>
+            </not>
+         </visibility>
+      </objectContribution>
+      <objectContribution
+            objectClass="org.eclipse.jdt.debug.core.IJavaVariable"
+            id="org.eclipse.jdt.debug.ui.FilteredJavaVariableActions">
          <visibility>
             <and>
             <not>
@@ -747,20 +772,11 @@
                enablesFor="1"
                id="org.eclipse.jdt.debug.ui.actions.OpenVariableDeclaredType">
          </action>
-         <action
-               label="%openDeclLocalVarNavigation.label"
-               helpContextId="open_variable_declared_type_hierarchy_action_context"
-               tooltip="%openDeclLocalVarNavigation.tooltip"
-               class="org.eclipse.jdt.internal.debug.ui.actions.NavigateToVarDeclAction"
-               menubarPath="emptyNavigationGroup"
-               enablesFor="1"
-               id="org.eclipse.jdt.debug.ui.actions.OpenDeclLocalVarNavigation">
-         </action>
          <visibility>
             <not>
                <objectState
                      name="JavaVariableFilter"
-                     value="isLocalVariableValue">
+                     value="isNonPrimitiveNonArray">
                </objectState>
             </not>
          </visibility>

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaVarActionFilter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaVarActionFilter.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.debug.core.model.JDILocalVariable;
 import org.eclipse.jdt.internal.debug.core.model.JDINullValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIObjectValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIPlaceholderValue;
+import org.eclipse.jdt.internal.debug.core.model.JDIPrimitiveValue;
 import org.eclipse.jdt.internal.debug.core.model.JDIReferenceListVariable;
 import org.eclipse.jdt.internal.debug.ui.display.JavaInspectExpression;
 import org.eclipse.ui.IActionFilter;
@@ -48,6 +49,7 @@ public class JavaVarActionFilter implements IActionFilter {
 	 * The set or primitive types
 	 */
 	private static final Set<String> fgPrimitiveTypes = initPrimitiveTypes();
+	private static final Set<String> fgArrays = initArrays();
 
 	/**
 	 * The predefined set of primitive types
@@ -68,8 +70,28 @@ public class JavaVarActionFilter implements IActionFilter {
 	}
 
 	/**
+	 * The predefined set of primitive arrays
+	 *
+	 * @return the set of predefined primitive arrays types
+	 */
+	private static Set<String> initArrays() {
+		HashSet<String> set = new HashSet<>(8);
+		set.add("short[]"); //$NON-NLS-1$
+		set.add("int[]"); //$NON-NLS-1$
+		set.add("long[]"); //$NON-NLS-1$
+		set.add("float[]"); //$NON-NLS-1$
+		set.add("double[]"); //$NON-NLS-1$
+		set.add("boolean[]"); //$NON-NLS-1$
+		set.add("byte[]"); //$NON-NLS-1$
+		set.add("char[]"); //$NON-NLS-1$
+		return set;
+	}
+
+	/**
 	 * Determines if the declared value is the same as the concrete value
-	 * @param var the variable to inspect
+	 *
+	 * @param var
+	 *            the variable to inspect
 	 * @return true if the types are the same, false otherwise
 	 */
 	protected boolean isDeclaredSameAsConcrete(IJavaVariable var) {
@@ -210,6 +232,10 @@ public class JavaVarActionFilter implements IActionFilter {
 					}
 					if (value.equals("isLocalVariableValue")) { //$NON-NLS-1$
 						return !(var instanceof JDILocalVariable);
+					}
+					if (value.equals("isNonPrimitiveNonArray")) { //$NON-NLS-1$
+						boolean primArray = fgArrays.contains(var.getJavaType().getName());
+						return (varValue instanceof JDIPrimitiveValue || primArray);
 					}
 				}
 				else if (name.equals("ConcreteVariableActionFilter") && value.equals("isConcrete")) { //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
Removed the OpenDeclareType & OpenTypeHierarchy for the primitive types and the arrays from from the variable view

<br>
<img width="828" alt="Screenshot 2025-04-15 at 2 06 18 PM" src="https://github.com/user-attachments/assets/03e5e350-3e73-4140-b12c-68d61bfcbebb" />
</br>
<br>
<img width="761" alt="Screenshot 2025-04-15 at 2 06 02 PM" src="https://github.com/user-attachments/assets/f4b3a821-e1b5-4343-ac7d-b995f9663cf8" />
</br>

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/665

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
