### PR TITLE
Fixed Trigger point disabled automatically

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/TriggerPointBreakpointsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/TriggerPointBreakpointsTests.java
@@ -13,8 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.breakpoints;
 
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.core.model.IVariable;
 import org.eclipse.jdt.debug.core.IJavaBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaPrimitiveValue;
 import org.eclipse.jdt.debug.core.IJavaStackFrame;
@@ -130,6 +133,35 @@ public class TriggerPointBreakpointsTests extends AbstractDebugTest {
 			assertEquals("Breakpoint should not resume as condition is false", 21, lineNumber);
 			bp1.delete();
 			bp2.delete();
+		} finally {
+			terminateAndRemove(thread);
+			removeAllBreakpoints();
+		}
+	}
+
+	// see bug : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/546
+	public void testTriggerPointAutoEnableAfterConditionalBp() throws Exception {
+		String typeName = "TriggerPoint_01";
+		IJavaLineBreakpoint bp1 = createLineBreakpoint(20, typeName);
+		IJavaLineBreakpoint bp2 = createLineBreakpoint(21, typeName);
+		bp1.setTriggerPoint(true);
+		bp2.setCondition("true");
+		bp2.setConditionEnabled(true);
+		bp2.setConditionSuspendOnTrue(true);
+		IJavaThread thread = null;
+		try {
+			thread = launchToBreakpoint(typeName);
+			IJavaStackFrame frame = (IJavaStackFrame) thread.getTopStackFrame();
+			int lineNumber = frame.getLineNumber();
+			assertEquals("Breakpoint should hit at triggeroint", 20, lineNumber);
+			IJavaDebugTarget debugTarget = (IJavaDebugTarget) thread.getDebugTarget();
+			ILaunch launch = debugTarget.getLaunch();
+			thread.getLaunch().terminate();
+			Thread.sleep(3000);
+			IBreakpoint[] bps = getBreakpointManager().getBreakpoints();
+			boolean enabledStatus = bps[0].isEnabled();
+			assertTrue("Trigger point should be enabled after termination", enabledStatus);
+			getLaunchManager().removeLaunch(launch);
 		} finally {
 			terminateAndRemove(thread);
 			removeAllBreakpoints();

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -1480,9 +1480,15 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 						return true;
 					}
 				}
-				DebugPlugin.getDefault().getBreakpointManager().enableTriggerPoints(null, false);
-					// make a note that we auto-disabled the trigger point for this breakpoint.
-					// we re enable it at cleanup of JDITarget
+				try {
+					if (breakpoint.isTriggerPoint()) {
+						DebugPlugin.getDefault().getBreakpointManager().enableTriggerPoints(null, false);
+						// make a note that we auto-disabled the trigger point for this breakpoint.
+						// we re enable it at cleanup of JDITarget
+					}
+				} catch (CoreException e) {
+					logError(e);
+				}
 			}
 		}
 


### PR DESCRIPTION
The trigger point is being disabled during debugging when a conditional breakpoint is hit.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/546

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test

1. Open a child eclipse.
2. Add a trigger point in the code. Also add a conditional break point.
3. Debug the code
4. First focus goes to trigger point-> then resume.
5. Now the focus is in the conditional breakpoint.
6. Then terminate/resume the debug process. You can see the trigger point automatically disabled.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
