### PR TITLE
Don't use Display.syncExec() for refresh in RuntimeClasspathViewer

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/classpath/RuntimeClasspathViewer.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/classpath/RuntimeClasspathViewer.java
@@ -64,17 +64,7 @@ public class RuntimeClasspathViewer implements IClasspathViewer {
 
 		@Override
 		public void preferenceChange(PreferenceChangeEvent event) {
-			if (DebugUIPlugin.getStandardDisplay().getThread().equals(Thread.currentThread())) {
-				refresh(true);
-			} else {
-				DebugUIPlugin.getStandardDisplay().syncExec(new Runnable() {
-					@Override
-					public void run() {
-						refresh(true);
-					}
-				});
-			}
-
+			DebugUIPlugin.getStandardDisplay().asyncExec(() -> refresh(true));
 		}
 	};
 
@@ -395,6 +385,9 @@ public class RuntimeClasspathViewer implements IClasspathViewer {
 
 	@Override
 	public void refresh(Object entry) {
+		if (fTree.isDisposed()) {
+			return;
+		}
 		getTreeViewer().refresh();
 	}
 


### PR DESCRIPTION
The listener may be called from a background thread that already holds some locks. To refresh RuntimeClasspathViewer UI in the current case, syncExec is not needed, asyncExec is enough and it would not acquire the UI lock from an unknown thread.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/672
