### PR TITLE
Modify existing behaviour of opening Exception Stack trace

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
@@ -473,4 +473,5 @@ public class DebugUIMessages extends NLS {
 	public static String CompareObjectsFailedException;
 
 	public static String ListSameElementsFor2;
+	public static String fExceptionBreakpointMsg;
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -436,3 +436,4 @@ CompareObjectsReference=Reference Mismatch
 ObjectsReferenceDifferent=Different in {0}
 ObjectsReferenceSameAndDifferent=Same in {0}, but different in {1}
 ObjectsExtractedSame=Same in {0}
+fExceptionBreakpointMsg=Create/Show Exception breakpoint on clicking exception names in stacktrace

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugPreferencePage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugPreferencePage.java
@@ -101,6 +101,7 @@ public class JavaDebugPreferencePage extends PreferencePage implements IWorkbenc
 	private Button fShowStepResult;
 	private Button fShowStepResultRemote;
 	private Button fAdvancedSourcelookup;
+	private Button fExceptionBreakpoint;
 
 	// Timeout preference widgets
 	private JavaDebugIntegerFieldEditor fTimeoutText;
@@ -187,6 +188,7 @@ public class JavaDebugPreferencePage extends PreferencePage implements IWorkbenc
 		fPromptDeleteConditionalBreakpoint= SWTFactory.createCheckButton(composite, DebugUIMessages.JavaDebugPreferencePage_promptWhenDeletingCondidtionalBreakpoint, null, false, 1);
 		fFilterUnrelatedBreakpoints = SWTFactory.createCheckButton(composite, DebugUIMessages.JavaDebugPreferencePage_filterUnrelatedBreakpoints, null, false, 1);
 
+		fExceptionBreakpoint = SWTFactory.createCheckButton(composite, DebugUIMessages.fExceptionBreakpointMsg, null, true, 1);
 		SWTFactory.createVerticalSpacer(composite, 1);
 		fOnlyIncludeExportedEntries = SWTFactory.createCheckButton(composite, DebugUIMessages.JavaDebugPreferencePage_only_include_exported_entries, null, false, 1);
 
@@ -251,6 +253,7 @@ public class JavaDebugPreferencePage extends PreferencePage implements IWorkbenc
 			prefs.putInt(JDIDebugModel.PREF_REQUEST_TIMEOUT, fTimeoutText.getIntValue());
 			prefs.putBoolean(JDIDebugModel.PREF_FILTER_BREAKPOINTS_FROM_UNRELATED_SOURCES, fFilterUnrelatedBreakpoints.getSelection());
 			prefs.putBoolean(JDIDebugPlugin.PREF_ENABLE_ADVANCED_SOURCELOOKUP, fAdvancedSourcelookup.getSelection());
+			prefs.putBoolean(JDIDebugModel.PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK, fExceptionBreakpoint.getSelection());
 			try {
 				prefs.flush();
 			}
@@ -300,6 +303,7 @@ public class JavaDebugPreferencePage extends PreferencePage implements IWorkbenc
 			fShowStepTimeoutText.setStringValue(Integer.toString(prefs.getInt(JDIDebugModel.PREF_SHOW_STEP_RESULT, JDIDebugModel.DEF_SHOW_STEP_TIMEOUT)));
 			fTimeoutText.setStringValue(Integer.toString(prefs.getInt(JDIDebugModel.PREF_REQUEST_TIMEOUT, JDIDebugModel.DEF_REQUEST_TIMEOUT)));
 			fFilterUnrelatedBreakpoints.setSelection(prefs.getBoolean(JDIDebugModel.PREF_FILTER_BREAKPOINTS_FROM_UNRELATED_SOURCES, true));
+			fExceptionBreakpoint.setSelection(prefs.getBoolean(JDIDebugModel.PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK, true));
 			fAdvancedSourcelookup.setSelection(prefs.getBoolean(JDIDebugPlugin.PREF_ENABLE_ADVANCED_SOURCELOOKUP, true));
 		}
 		prefs = DefaultScope.INSTANCE.getNode(LaunchingPlugin.ID_PLUGIN);
@@ -343,6 +347,7 @@ public class JavaDebugPreferencePage extends PreferencePage implements IWorkbenc
 		fShowStepTimeoutText.setStringValue(Integer.toString(prefs.getInt(bundleId, JDIDebugModel.PREF_SHOW_STEP_TIMEOUT, JDIDebugModel.DEF_SHOW_STEP_TIMEOUT, null)));
 		fTimeoutText.setStringValue(Integer.toString(prefs.getInt(bundleId, JDIDebugModel.PREF_REQUEST_TIMEOUT, JDIDebugModel.DEF_REQUEST_TIMEOUT, null)));
 		fFilterUnrelatedBreakpoints.setSelection(prefs.getBoolean(bundleId, JDIDebugModel.PREF_FILTER_BREAKPOINTS_FROM_UNRELATED_SOURCES, true, null));
+		fExceptionBreakpoint.setSelection(prefs.getBoolean(bundleId, JDIDebugModel.PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK, true, null));
 		fAdvancedSourcelookup.setSelection(prefs.getBoolean(bundleId, JDIDebugPlugin.PREF_ENABLE_ADVANCED_SOURCELOOKUP, true, null));
 
 		bundleId = LaunchingPlugin.ID_PLUGIN;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaExceptionHyperLink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaExceptionHyperLink.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -26,6 +27,7 @@ import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.debug.core.IJavaExceptionBreakpoint;
 import org.eclipse.jdt.debug.core.JDIDebugModel;
+import org.eclipse.jdt.internal.debug.core.JDIDebugPlugin;
 import org.eclipse.jdt.internal.debug.core.JavaDebugUtils;
 import org.eclipse.jdt.internal.debug.ui.BreakpointUtils;
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin;
@@ -98,6 +100,11 @@ public class JavaExceptionHyperLink extends JavaStackTraceHyperlink {
 	 */
 	@Override
 	protected void processSearchResult(Object source, String typeName, int lineNumber) {
+		boolean isCreateExceptionBreakpointDisabled = !Platform.getPreferencesService().getBoolean(JDIDebugPlugin.getUniqueIdentifier(), JDIDebugModel.PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK, true, null);
+		if (isCreateExceptionBreakpointDisabled) {
+			super.processSearchResult(source, typeName, lineNumber);
+			return;
+		}
 		try {
 			source = JavaDebugUtils.getJavaElement(source);
 			IResource res = ResourcesPlugin.getWorkspace().getRoot();

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/JDIDebugModel.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/JDIDebugModel.java
@@ -104,6 +104,14 @@ public class JDIDebugModel {
 			+ ".do_not_install_breakpoints_from_unrelated_sources"; //$NON-NLS-1$
 
 	/**
+	 * Boolean preference for controlling whether an exception breakpoint should be created or managed
+	 * when clicked on an exception type in the console.
+	 *
+	 * @since 3.23
+	 */
+	public static final String PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK = getPluginIdentifier() + ".create_exception_breakpoint_on_click"; //$NON-NLS-1$
+
+	/**
 	 * Preference key for specifying if the value returned or thrown should be displayed as variable after a "step return" or "step over" (if
 	 * supported by the vm)
 	 * @since 3.11

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JDIDebugPluginPreferenceInitializer.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/JDIDebugPluginPreferenceInitializer.java
@@ -50,5 +50,6 @@ public class JDIDebugPluginPreferenceInitializer extends
 		node.putBoolean(JDIDebugModel.PREF_SHOW_STEP_RESULT_REMOTE, false);
 		node.putInt(JDIDebugModel.PREF_SHOW_STEP_TIMEOUT, JDIDebugModel.DEF_SHOW_STEP_TIMEOUT);
 		node.putBoolean(JDIDebugPlugin.PREF_ENABLE_ADVANCED_SOURCELOOKUP, true);
+		node.putBoolean(JDIDebugModel.PREF_CREATE_EXCEPTION_BREAKPOINTS_ON_CLICK, true);
 	}
 }


### PR DESCRIPTION
Modify existing behaviour of opening Exception Stack trace

Fix: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/670

All the necessary information has been updated in the parent ticket.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
