### PR TITLE
Additional handling for Disable on Hit

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/BreakpointListenerManager.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/BreakpointListenerManager.java
@@ -151,13 +151,6 @@ public class BreakpointListenerManager {
 		public int breakpointHit(IJavaThread thread, IJavaBreakpoint breakpoint) {
 			IJavaBreakpointListener delegate = getDelegate();
 			if (delegate != null) {
-				try {
-					if (breakpoint.isDisableOnHit()) {
-						breakpoint.setEnabled(false);
-					}
-				} catch (CoreException e) {
-					JDIDebugPlugin.log(e);
-				}
 				return delegate.breakpointHit(thread, breakpoint);
 			}
 			return IJavaBreakpointListener.DONT_CARE;

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1518,6 +1518,9 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 					suspend = true;
 				}
 			}
+		}
+		if (suspend) {
+			handleDisableOnHit(breakpoint);
 		}
 		return suspend;
 	}
@@ -3734,5 +3737,16 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 
 	boolean isBreakpointHandlingOngoing() {
 		return fCompletingBreakpointHandling.get() || fHandlingSuspendForBreakpoint.get();
+	}
+
+	private void handleDisableOnHit(JavaBreakpoint breakpoint) {
+		try {
+			if (breakpoint.isDisableOnHit()) {
+				breakpoint.setEnabled(false);
+				breakpoint.setDisableOnHit(false);
+			}
+		} catch (CoreException e) {
+			JDIDebugPlugin.log(e);
+		}
 	}
 }


### PR DESCRIPTION
Refactors the logic related to the "Disable on hit" functionality by relocating its check to the JDIThread class.
Additionally, when the "Disable on hit" is executed, then the option will be unchecked.
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
