### PR TITLE
Method Breakpoint does not recognised when set at end of a method

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -402,6 +402,9 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 				deleteTracepoint(breakpoint, part, monitor);
 				BreakpointToggleUtils.setUnsetTracepoints(false);
 			} else {
+				if (ValidBreakpointLocationLocator.LOCATION_METHOD_CLOSE) {
+					ValidBreakpointLocationLocator.LOCATION_METHOD_CLOSE = false;
+				}
 				deleteBreakpoint(breakpoint, part, monitor);
 			}
 			return;
@@ -444,6 +447,11 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 				methodBreakpoint.setConditionSuspendOnTrue(true);
 			}
 			BreakpointToggleUtils.setUnsetTracepoints(false);
+		}
+		if (ValidBreakpointLocationLocator.LOCATION_METHOD_CLOSE) {
+			methodBreakpoint.setEntry(false);
+			methodBreakpoint.setExit(true);
+			ValidBreakpointLocationLocator.LOCATION_METHOD_CLOSE = false;
 		}
 	}
 
@@ -1548,7 +1556,7 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 			lambdaEntryBP = true;
 			BreakpointToggleUtils.setUnsetLambdaEntryBreakpoint(false);
 		} else {
-			loc = new ValidBreakpointLocationLocator(unit, ts.getStartLine() + 1, true, true, ts.getOffset(), ts.getLength());
+			loc = new ValidBreakpointLocationLocator(unit, ts.getStartLine() + 1, true, true, ts.getOffset(), ts.getLength(), true);
 		}
 		unit.accept(loc);
 


### PR DESCRIPTION
This PR fixes the issue where breakpoints set at the end of a method did not behave like method breakpoints, ensuring both entry and exit events are consistently shown.

All the necessary information has been added to the [parent ticket](https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/697).

Fix: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/697

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
