### PR TITLE
Variable Navigation throwing NPE and support for lambda

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/NavigateToVarDeclAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/NavigateToVarDeclAction.java
@@ -17,31 +17,30 @@ package org.eclipse.jdt.internal.debug.ui.actions;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.debug.core.IJavaStackFrame;
 import org.eclipse.jdt.debug.core.IJavaVariable;
-import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.ITextEditor;
 
@@ -58,10 +57,7 @@ public class NavigateToVarDeclAction extends ObjectActionDelegate {
 				Object frame = DebugUITools.getDebugContext();
 				if (frame instanceof IStackFrame jFrame) {
 					if (jFrame instanceof IJavaStackFrame javaStackFrame) {
-						String type = javaStackFrame.getLaunch().getLaunchConfiguration().getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, (String) null);
-						IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(type);
-						IJavaProject iJavaProject = JavaCore.create(project);
-						IType iType = iJavaProject.findType(javaStackFrame.getReceivingTypeName());
+						int currentLine = javaStackFrame.getLineNumber();
 						String currentMethod = javaStackFrame.getMethodName();
 						List<String> frameParams = javaStackFrame.getArgumentTypeNames();
 						List<String> ref = frameParams.stream().map(e -> {
@@ -71,49 +67,112 @@ public class NavigateToVarDeclAction extends ObjectActionDelegate {
 							}
 							return e;
 						}).collect(Collectors.toList());
-						ICompilationUnit cu = iType.getCompilationUnit();
-						ASTParser parse = ASTParser.newParser(AST.getJLSLatest());
-						parse.setSource(cu);
-						parse.setKind(ASTParser.K_COMPILATION_UNIT);
-						parse.setResolveBindings(true);
-						CompilationUnit ast = (CompilationUnit) parse.createAST(null);
-						ast.accept(new ASTVisitor() {
-							boolean meth = false;
-							boolean found = false;
-							@Override
-							public boolean visit(MethodDeclaration node) {
-								if (node.getName().getIdentifier().equals(currentMethod)) {
-									List<Object> parameters = node.parameters();
-									List<String> methodParams = parameters.stream().map(p -> ((SingleVariableDeclaration) p).getType().toString()).toList();
-									if (methodParams.equals(ref)) {
-										meth = true;
-										for (Object op : node.parameters()) {
-											SingleVariableDeclaration parm = (SingleVariableDeclaration) op;
-											if (parm.getName().getIdentifier().equals(name)) {
-												highlightLine(ast, cu, node.getStartPosition());
-												found = true;
-												return false;
+						final ICompilationUnit[] cu = { null };
+						IWorkbenchWindow window = getWorkbenchWindow();
+						IEditorPart editor = window.getActivePage().getActiveEditor();
+						IJavaElement element = JavaUI.getEditorInputJavaElement(editor.getEditorInput());
+
+						if (element instanceof ICompilationUnit icu) {
+							cu[0] = icu;
+						} else if (element instanceof IClassFile icf) {
+							cu[0] = icf.getWorkingCopy(new WorkingCopyOwner() {
+							}, null);
+						} else {
+							cu[0] = null;
+						}
+
+						ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+						parser.setSource(cu[0]);
+						parser.setKind(ASTParser.K_COMPILATION_UNIT);
+						parser.setResolveBindings(true);
+
+						if (parser.createAST(null) instanceof CompilationUnit ast) {
+							ast.accept(new ASTVisitor() {
+								boolean meth = false;
+								boolean found = false;
+								boolean inTargetContext = false;
+								@Override
+								public boolean visit(MethodDeclaration node) {
+									if (node.getName().getIdentifier().equals(currentMethod)) {
+										List<Object> parameters = node.parameters();
+										List<String> methodParams = parameters.stream().map(p -> ((SingleVariableDeclaration) p).getType().toString()).toList();
+										int start = node.getStartPosition();
+										int end = start + node.getLength();
+										int startLine = ast.getLineNumber(start);
+										int endLine = ast.getLineNumber(end);
+										if (currentLine >= startLine && currentLine <= endLine) {
+											inTargetContext = true;
+											if (methodParams.equals(ref)) {
+												meth = true;
+												for (Object op : node.parameters()) {
+													if (op instanceof SingleVariableDeclaration param) {
+														if (param.getName().getIdentifier().equals(name)) {
+															final ICompilationUnit finalCu = cu[0];
+															highlightLine(ast, finalCu, param.getStartPosition(), editor);
+															found = true;
+															return false;
+														}
+													}
+												}
+												return true;
 											}
 										}
-										return true;
 									}
+									return true;
 								}
-								return true;
-							}
 
-							@Override
-							public boolean visit(VariableDeclarationFragment node) {
-								if (found) {
-									return false;
+								@Override
+								public void endVisit(MethodDeclaration node) {
+									inTargetContext = false;
+
 								}
-								if (meth && node.getName().getIdentifier().equals(name)) {
-									found = true;
-									highlightLine(ast, cu, node.getStartPosition());
-									return false;
+
+								@Override
+								public boolean visit(VariableDeclarationFragment node) {
+									if (found) {
+										return false;
+									}
+									if ((meth || inTargetContext) && node.getName().getIdentifier().equals(name)) {
+										found = true;
+										final ICompilationUnit finalCu = cu[0];
+										highlightLine(ast, finalCu, node.getStartPosition(), editor);
+										return false;
+									}
+									return true;
 								}
-								return true;
-							}
-						});
+
+								@Override
+								public boolean visit(LambdaExpression node) {
+									if (found) {
+										return false;
+									}
+									List<Object> parameters = node.parameters();
+									int start = node.getStartPosition();
+									int end = start + node.getLength();
+									int startLine = ast.getLineNumber(start);
+									int endLine = ast.getLineNumber(end);
+									if (currentLine >= startLine && currentLine <= endLine) {
+										inTargetContext = true;
+										for (Object param : parameters) {
+											if (param instanceof SingleVariableDeclaration svd) {
+												if (svd.getName().getIdentifier().equals(name)) {
+													highlightLine(ast, cu[0], svd.getStartPosition(), editor);
+													found = true;
+													return false;
+												}
+											}
+										}
+									}
+									return true;
+								}
+
+								@Override
+								public void endVisit(LambdaExpression node) {
+									inTargetContext = false;
+								}
+							});
+
+						}
 					}
 				}
 			}
@@ -131,15 +190,17 @@ public class NavigateToVarDeclAction extends ObjectActionDelegate {
 	 *            compilation unit of the code
 	 * @param startPos
 	 *            start position of the code want to highlight
+	 * @param editor
+	 *            active editor info
 	 */
-	private void highlightLine(CompilationUnit ast, ICompilationUnit cu, int startPos) {
+	private void highlightLine(CompilationUnit ast, ICompilationUnit cu, int startPos, IEditorPart editor) {
 		int line = ast.getLineNumber(startPos);
 		try {
-			IEditorPart editor = JavaUI.openInEditor(cu);
 			if (editor instanceof ITextEditor txtEd) {
 				IDocumentProvider prov = txtEd.getDocumentProvider();
 				IDocument doc = prov.getDocument(txtEd.getEditorInput());
-				IRegion lineReg = doc.getLineInformation(line - 1);
+				int adjustedLine = Math.max(0, line - 1);
+				IRegion lineReg = doc.getLineInformation(adjustedLine);
 				txtEd.selectAndReveal(lineReg.getOffset(), lineReg.getLength());
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Variable Navigation throwing NPE and support for variable navigation in lambda for non-java projects

Fix: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/712

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
1. Open child Eclipse and import JDT.Debug project (Go to Project explorer -> Right click then import -> General -> Projects from Folder or Archive -> select the project from file explorer)
2. Open third third eclipse from the second one. 
3. Create a java project from the third child and debug the code snippet provided in the [parent ticket](https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/712#issuecomment-2942652788).
4. Place breakpoint and then Navigate to Decoration from the variables view. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
