### PR TITLE
[25] update version to ensure greater than master

### DIFF
--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.23.150.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName


### PR DESCRIPTION
Master recently bumped o.e.j.debug to 3.23.100. Now we go to 3.23.150 in beta branch to ensure that this is understood as being newer than master (we do have changes in the branch since dc73593d91bc0d89f7cef76878891bf245e61850 ).