### PR TITLE
[25] InstanceMainMethodsTests.testStaticMainWithoutArgs doesn't find it's project

### DIFF
--- a/org.eclipse.jdt.debug.tests/build.properties
+++ b/org.eclipse.jdt.debug.tests/build.properties
@@ -27,7 +27,8 @@ bin.includes = plugin.xml,\
                java9/,\
                java16_/,\
                java23/,\
-               java24/
+               java24/,\
+               java25/
 source.javadebugtests.jar = test plugin/,\
                             tests/,\
                             console tests/


### PR DESCRIPTION
Folow-up of renaming test folder java24 to java25
