### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.jdi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDI Tests
 Bundle-SymbolicName: org.eclipse.jdt.debug.jdi.tests; singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse
 Require-Bundle: org.junit,

--- a/org.eclipse.jdt.debug.jdi.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.debug.jdi.tests/forceQualifierUpdate.txt
@@ -1,0 +1,2 @@
+
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3137

--- a/org.eclipse.jdt.debug.jdi.tests/pom.xml
+++ b/org.eclipse.jdt.debug.jdi.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug.jdi.tests</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>


### PR DESCRIPTION
Changes to ecj are to remove redundant bytecode, see: eclipse-jdt/eclipse.jdt.core#3465

See: eclipse-platform/eclipse.platform.releng.aggregator#3137

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
