### PR TITLE
[25] Fix and re-enable ConditionalBreakpointsWithFileClass.testFileConditionalBreakpointforTrue()

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
@@ -51,8 +51,7 @@ public class ConditionalBreakpointsWithFileClass extends AbstractDebugTest {
 		}
 	}
 
-	// FIXME disabled to unblock BETA_JAVA25
-	public void _testFileConditionalBreakpointforTrue() throws Exception {
+	public void testFileConditionalBreakpointforTrue() throws Exception {
 		String typeName = "FileConditionSnippet2";
 		IJavaLineBreakpoint bp3 = createLineBreakpoint(20, typeName);
 		IJavaThread mainThread = null;


### PR DESCRIPTION
+ try re-enabling (couldn't reproduce locally, so no fix)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/695
