### PR TITLE
Class cast exception fix

### DIFF
--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/JavaPrimitiveRuntimeContext.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/JavaPrimitiveRuntimeContext.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.eval.ast.engine;
 
+import java.util.List;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
@@ -21,6 +23,11 @@ import org.eclipse.jdt.debug.core.IJavaPrimitiveValue;
 import org.eclipse.jdt.debug.core.IJavaReferenceType;
 import org.eclipse.jdt.debug.core.IJavaThread;
 import org.eclipse.jdt.debug.core.IJavaVariable;
+import org.eclipse.jdt.internal.debug.core.model.JDIClassType;
+import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget;
+
+import com.sun.jdi.ClassType;
+import com.sun.jdi.ReferenceType;
 
 public class JavaPrimitiveRuntimeContext extends AbstractRuntimeContext {
 	/**
@@ -70,7 +77,11 @@ public class JavaPrimitiveRuntimeContext extends AbstractRuntimeContext {
 	 */
 	@Override
 	public IJavaReferenceType getReceivingType() throws CoreException {
-		return (IJavaReferenceType) getThisPrimitive().getJavaType();
+		JDIDebugTarget target = (JDIDebugTarget) getThisPrimitive().getJavaType().getDebugTarget();
+		List<ReferenceType> ref = target.getVM().classesByName("java.lang.Object"); //$NON-NLS-1$
+		ClassType classType = (ClassType) ref.get(0);
+		JDIClassType jdiClassType = new JDIClassType(target, classType);
+		return jdiClassType;
 	}
 
 	/**


### PR DESCRIPTION
This commit processes a java.lang.Object class for JavaPrimitiveRuntimeContext.getReceivingType() when a valid IJavaReferenceType is required for primitive detail formatter calculation

fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/734

With fix  
<img width="648" alt="image" src="https://github.com/user-attachments/assets/9cabe76f-142a-454f-9bc4-e1ff5ce1dff3" />

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
