### PR TITLE
Remove now unnecessary suppression of warning about missing serial-UID

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/FileHashing.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/sourcelookup/advanced/FileHashing.java
@@ -128,7 +128,6 @@ public class FileHashing {
 
 		private final Map<CacheKey, HashCode> cache;
 
-		@SuppressWarnings("serial")
 		public HasherImpl(int cacheSize) {
 			this.cache = new LinkedHashMap<>() {
 				@Override


### PR DESCRIPTION
## What it does

See
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4210#issuecomment-3084969064


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
