### PR TITLE
Allow selecting JavaSE-25 from the environments list for debugging

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Export-Package: org.eclipse.jdt.internal.launching;x-friends:="org.eclipse.jdt.d
  org.eclipse.jdt.launching.sourcelookup.advanced,
  org.eclipse.jdt.launching.sourcelookup.containers
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.14.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.40.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.43.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.jdt.debug;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/EnvironmentsManager.java
@@ -203,7 +203,9 @@ public class EnvironmentsManager implements IExecutionEnvironmentsManager, IVMIn
 
 	private String getExecutionEnvironmentCompliance(IExecutionEnvironment executionEnvironment) {
 		String desc = executionEnvironment.getId();
-		if (desc.indexOf(JavaCore.VERSION_24) != -1) {
+		if (desc.indexOf(JavaCore.VERSION_25) != -1) {
+			return JavaCore.VERSION_25;
+		} else if (desc.indexOf(JavaCore.VERSION_24) != -1) {
 			return JavaCore.VERSION_24;
 		} else if (desc.indexOf(JavaCore.VERSION_23) != -1) {
 			return JavaCore.VERSION_23;


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/744
