### PR TITLE
Show actual Object value when detail formatter has module conflict

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDetailFormattersManager.java
@@ -33,6 +33,7 @@ import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.debug.ui.IValueDetailListener;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.debug.core.IEvaluationRunnable;
 import org.eclipse.jdt.debug.core.IJavaArray;
 import org.eclipse.jdt.debug.core.IJavaArrayType;
@@ -466,6 +467,17 @@ public class JavaDetailFormattersManager implements IPropertyChangeListener, IDe
 						.getCompiledExpression(snippet, javaObject);
 				if (res != null) {
 					Expression exp = new Expression(res, evaluationEngine);
+					if (exp.getExpression().hasErrors()) {
+						boolean hasModuleError = false;
+						for (int prblemID : exp.getExpression().getProblemIDs()) {
+							if (prblemID == IProblem.ConflictingPackageFromModules || prblemID == IProblem.ConflictingPackageFromOtherModules) {
+								hasModuleError = true;
+							}
+						}
+						if (hasModuleError) {
+							return null;
+						}
+					}
 					fCacheMap.put(key, exp);
 					return exp;
 				}

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.23.100.qualifier
+Bundle-Version: 3.24.0.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/debug/eval/ICompiledExpression.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/debug/eval/ICompiledExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.debug.eval;
+
+import java.util.List;
 
 import org.eclipse.jdt.core.dom.Message;
 
@@ -61,5 +63,13 @@ public interface ICompiledExpression {
 	 * @since 2.1
 	 */
 	public String[] getErrorMessages();
+
+	/**
+	 * Returns the list of <code>IProblem</code> id's of the compiled expression
+	 *
+	 * @return the list of IProblem id's of the compiled expression
+	 * @since 3.24
+	 */
+	public List<Integer> getProblemIDs();
 
 }

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/ASTEvaluationEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -630,6 +630,7 @@ public class ASTEvaluationEngine implements IAstEvaluationEngine {
 						DebugPlugin.log(new Status(IStatus.WARNING, DebugPlugin.getUniqueIdentifier(), "Compile error during code evaluation: " //$NON-NLS-1$
 								+ problem.getMessage()));
 					}
+					errorSequence.addProblemID(problemId);
 				}
 			}
 			if (snippetError || runMethodError) {

--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/InstructionSequence.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/InstructionSequence.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,11 +30,13 @@ public class InstructionSequence implements ICompiledExpression {
 	private final List<String> fErrors;
 	private final String fSnippet;
 	private CoreException fException;
+	private final List<Integer> fProblemIDs;
 
 	public InstructionSequence(String snippet) {
 		fInstructions = new ArrayList<>(10);
 		fErrors = new ArrayList<>();
 		fSnippet = snippet;
+		fProblemIDs = new ArrayList<>();
 	}
 
 	/**
@@ -147,4 +149,20 @@ public class InstructionSequence implements ICompiledExpression {
 	public int getEnd() {
 		return fInstructions.size() - 1;
 	}
+
+	/**
+	 * Adds the <code>IProblem<code> id of the error.
+	 */
+	public void addProblemID(int probID) {
+		fProblemIDs.add(probID);
+	}
+
+	/**
+	 * @see org.eclipse.jdt.debug.eval.ICompiledExpression#getProblemIDs()
+	 */
+	@Override
+	public List<Integer> getProblemIDs() {
+		return fProblemIDs;
+	}
+
 }


### PR DESCRIPTION
This commit cancels detail formatting process of objects whenever the generated expression have module related errors during expression compilation. Resulting in showing the actual object value in variables view and in debug hover to provide a consistent user experience

<img width="871" height="217" alt="image" src="https://github.com/user-attachments/assets/c049116a-0961-4f35-8f40-01c309779a75" />


Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/747

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
