### PR TITLE
Fix toggle breakpoint type's order

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -1050,13 +1050,6 @@
                menubarPath="debug">
          </action>
          <action
-               label="%EnableBreakpoint.label"
-               helpContextId="enable_disable_breakpoint_action_context"
-               class="org.eclipse.debug.ui.actions.RulerEnableDisableBreakpointActionDelegate"
-               menubarPath="debug"
-               id="org.eclipse.jdt.debug.ui.actions.EnableDisableBreakpointRulerActionDelegate">
-         </action>
-         <action
                class="org.eclipse.jdt.internal.debug.ui.actions.RulerToggleHitBreakpointActionDelegate"
                icon="icons/full/obj16/brkp_obj.png"
                id="org.eclipse.jdt.debug.ui.actions.HitBreakpointRulerActionDelegate"
@@ -1069,6 +1062,13 @@
                id="org.eclipse.jdt.debug.ui.actions.TriggerBreakpointRulerActionDelegate"
                label="%ToggleTriggerpointAction.label"
                menubarPath="debug">
+         </action>
+         <action
+               label="%EnableBreakpoint.label"
+               helpContextId="enable_disable_breakpoint_action_context"
+               class="org.eclipse.debug.ui.actions.RulerEnableDisableBreakpointActionDelegate"
+               menubarPath="debug"
+               id="org.eclipse.jdt.debug.ui.actions.EnableDisableBreakpointRulerActionDelegate">
          </action>
          <action
                class="org.eclipse.debug.ui.actions.RulerToggleBreakpointActionDelegate"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
In light of the discussions https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/652#issuecomment-3142786884

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
