### PR TITLE
Support launching Multi-Release-Compiled Projects

### DIFF
--- a/org.eclipse.jdt.debug.tests/multirelease/src/p/Main.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src/p/Main.java
@@ -1,0 +1,10 @@
+package p;
+
+public class Main {
+
+	public static void main(String[] args) {
+		System.out.println("Java: "+java.lang.Runtime.version().feature());
+		new X().greet();
+	}
+
+}

--- a/org.eclipse.jdt.debug.tests/multirelease/src/p/X.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src/p/X.java
@@ -1,0 +1,7 @@
+package p;
+
+public class X {
+	public void greet() {
+		System.out.println("X: 11");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/multirelease/src/p/Y.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src/p/Y.java
@@ -1,0 +1,7 @@
+package p;
+
+public class Y {
+	public void y() {
+		System.out.println("Y: 11");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/multirelease/src17/p/X.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src17/p/X.java
@@ -1,0 +1,8 @@
+package p;
+
+public class X {
+	public void greet() {
+		System.out.println("X: 17");
+		new Y().y();
+	}
+}

--- a/org.eclipse.jdt.debug.tests/multirelease/src17/p/Z.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src17/p/Z.java
@@ -1,0 +1,7 @@
+package p;
+
+public class Z {
+	public static void z() {
+		System.out.println("Z: 17");
+	}
+}

--- a/org.eclipse.jdt.debug.tests/multirelease/src21/p/Y.java
+++ b/org.eclipse.jdt.debug.tests/multirelease/src21/p/Y.java
@@ -1,0 +1,8 @@
+package p;
+
+public class Y {
+	public void y() {
+		System.out.println("Y: 21");
+		Z.z();
+	}
+}

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaProjectHelper.java
@@ -38,6 +38,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -110,6 +111,11 @@ public class JavaProjectHelper {
 	 * path to the 25 test source
 	 */
 	public static final IPath TEST_25_SRC_DIR = new Path("java25");
+
+	/**
+	 * path to the multirelease test source
+	 */
+	public static final IPath TEST_MR_SRC_DIR = new Path("multirelease");
 
 	/**
 	 * path to the compiler error java file
@@ -323,9 +329,12 @@ public class JavaProjectHelper {
 
 	/**
 	 * Adds a new source container specified by the container name to the source path of the specified project
+	 *
+	 * @param extra
+	 *            optional extra classpath attributes
 	 * @return the package fragment root of the container name
 	 */
-	public static IPackageFragmentRoot addSourceContainer(IJavaProject jproject, String containerName) throws CoreException {
+	public static IPackageFragmentRoot addSourceContainer(IJavaProject jproject, String containerName, IClasspathAttribute... extra) throws CoreException {
 		IProject project= jproject.getProject();
 		IContainer container= null;
 		if (containerName == null || containerName.length() == 0) {
@@ -339,7 +348,7 @@ public class JavaProjectHelper {
 		}
 		IPackageFragmentRoot root= jproject.getPackageFragmentRoot(container);
 
-		IClasspathEntry cpe= JavaCore.newSourceEntry(root.getPath());
+		IClasspathEntry cpe = JavaCore.newSourceEntry(root.getPath(), ClasspathEntry.INCLUDE_ALL, ClasspathEntry.EXCLUDE_NONE, null, extra);
 		addToClasspath(jproject, cpe);
 		return root;
 	}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -87,6 +87,7 @@ import org.eclipse.jdt.debug.tests.core.LineTrackerTests;
 import org.eclipse.jdt.debug.tests.core.LiteralTests17;
 import org.eclipse.jdt.debug.tests.core.LocalVariableTests;
 import org.eclipse.jdt.debug.tests.core.ModuleOptionsTests;
+import org.eclipse.jdt.debug.tests.core.MultiReleaseLaunchTests;
 import org.eclipse.jdt.debug.tests.core.ProcessTests;
 import org.eclipse.jdt.debug.tests.core.ResolveRuntimeClasspathTests;
 import org.eclipse.jdt.debug.tests.core.RuntimeClasspathEntryTests;
@@ -291,6 +292,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(WorkingDirectoryTests.class));
 		addTest(new TestSuite(EventDispatcherTest.class));
 		addTest(new TestSuite(SyntheticVariableTests.class));
+		addTest(new TestSuite(MultiReleaseLaunchTests.class));
 
 	// Refactoring tests
 		//TODO: project rename

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/MultiReleaseLaunchTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/MultiReleaseLaunchTests.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.core;
+
+import java.io.File;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.debug.core.IJavaDebugTarget;
+import org.eclipse.jdt.debug.tests.ui.AbstractDebugUiTests;
+import org.eclipse.jdt.internal.launching.DetectVMInstallationsJob;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
+import org.eclipse.jdt.launching.IVMInstallType;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.VMStandin;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.TextConsole;
+
+/**
+ * <b>IMPORTANT</b> This test requires some different JVM installs to be present (see {@link #JAVA_11}, {@link #JAVA_17}, {@link #JAVA_21})) if such
+ * JVMs can not be found, the test will fail! One can specify a basedir to search for such jvms with the {@link #JVM_SEARCH_BASE} system property.
+ */
+public class MultiReleaseLaunchTests extends AbstractDebugUiTests {
+
+	private static final String JVM_SEARCH_BASE = "MultiReleaseLaunchTests.rootDir";
+	private static final RequiredJavaVersion JAVA_11 = new RequiredJavaVersion(11, 16);
+	private static final RequiredJavaVersion JAVA_17 = new RequiredJavaVersion(17, 20);
+	private static final RequiredJavaVersion JAVA_21 = new RequiredJavaVersion(21, Integer.MAX_VALUE);
+
+	private List<Runnable> disposeVms = new ArrayList<>();
+
+	public MultiReleaseLaunchTests(String name) {
+		super(name);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		final Set<File> existingLocations = new HashSet<>();
+		List<RequiredJavaVersion> requiredJavaVersions = new ArrayList<>(List.of(JAVA_11, JAVA_17, JAVA_21));
+		removeExistingJavaVersions(requiredJavaVersions, existingLocations);
+		if (!requiredJavaVersions.isEmpty()) {
+			final File rootDir = new File(System.getProperty(JVM_SEARCH_BASE, "/opt/tools/java/openjdk/"));
+			final List<File> locations = new ArrayList<>();
+			final List<IVMInstallType> types = new ArrayList<>();
+			DetectVMInstallationsJob.search(rootDir, locations, types, existingLocations, new NullProgressMonitor());
+			for (int i = 0; i < locations.size(); i++) {
+				File location = locations.get(i);
+				IVMInstallType type = types.get(i);
+				String id = "MultiReleaseLaunchTests-" + UUID.randomUUID() + "-" + i;
+				VMStandin workingCopy = new VMStandin(type, id);
+				workingCopy.setInstallLocation(location);
+				workingCopy.setName(id);
+				IVMInstall install = workingCopy.convertToRealVM();
+				if (removeIfMatch(requiredJavaVersions, install)) {
+					disposeVms.add(() -> type.disposeVMInstall(id));
+				} else {
+					type.disposeVMInstall(id);
+				}
+			}
+		}
+		assertTrue("The following java versions are required by this test but can not be found: "
+				+ requiredJavaVersions, requiredJavaVersions.isEmpty());
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		disposeVms.forEach(Runnable::run);
+	}
+
+	@Override
+	protected IJavaProject getProjectContext() {
+		return getMultireleaseProject();
+	}
+
+	public void testMultiReleaseLaunch() throws Exception {
+		ILaunchConfiguration config = getLaunchConfiguration("p.Main");
+		Properties result = launchAndReadResult(config, 11);
+		assertTrue("Was not launched with a proper Java installation " + result, JAVA_11.matches(result.getProperty("Java")));
+		assertEquals("X should be executed from Java 11 version: " + result, "11", result.get("X"));
+		assertNull("Y should not be executed from Java 11 version: " + result, result.get("Y"));
+		assertNull("Z should not be executed from Java 11 version: " + result, result.get("Z"));
+		Properties result17 = launchAndReadResult(config, 17);
+		assertTrue("Was not launched with a proper Java installation " + result17, JAVA_17.matches(result17.getProperty("Java")));
+		assertEquals("X should be executed from Java 17 version: " + result17, "17", result17.get("X"));
+		assertEquals("Y should be executed from Java 11 version: " + result17, "11", result17.get("Y"));
+		assertNull("Z should not be executed from Java 17 version: " + result17, result17.get("Z"));
+		Properties result21 = launchAndReadResult(config, 21);
+		assertTrue("Was not launched with a proper Java installation " + result21, JAVA_21.matches(result21.getProperty("Java")));
+		assertEquals("X should be executed from Java 17 version: " + result21, "17", result21.get("X"));
+		assertEquals("Y should be executed from Java 21 version: " + result21, "21", result21.get("Y"));
+		assertEquals("Z should be executed from Java 17 version: " + result21, "17", result21.get("Z"));
+	}
+
+	private Properties launchAndReadResult(ILaunchConfiguration config, int javaVersion) throws Exception {
+		ILaunchConfigurationWorkingCopy workingCopy = config.getWorkingCopy();
+		workingCopy.setAttribute("org.eclipse.jdt.launching.JRE_CONTAINER", "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-"
+				+ javaVersion + "/");
+		Properties properties = new Properties();
+		IJavaDebugTarget target = launchAndTerminate(workingCopy.doSave(), DEFAULT_TIMEOUT);
+		processUiEvents();
+		final IConsole console = DebugUITools.getConsole(target.getProcess());
+		final TextConsole textConsole = (TextConsole) console;
+		final IDocument consoleDocument = textConsole.getDocument();
+		String content = consoleDocument.get();
+		properties.load(new StringReader(content));
+		DebugPlugin.getDefault().getLaunchManager().removeLaunch(target.getLaunch());
+		return properties;
+	}
+
+	private static int getJavaVersion(IVMInstall install) {
+		if (install instanceof IVMInstall2 vm) {
+			try {
+				String javaVersion = vm.getJavaVersion().split("\\.")[0]; //$NON-NLS-1$
+				return Integer.parseInt(javaVersion);
+			} catch (RuntimeException rte) {
+				// can't know then...
+			}
+		}
+		return -1;
+	}
+
+	private static void removeExistingJavaVersions(Collection<RequiredJavaVersion> requiredJavaVersions, Set<File> existingLocations) {
+		IVMInstallType[] installTypes = JavaRuntime.getVMInstallTypes();
+		for (IVMInstallType installType : installTypes) {
+			IVMInstall[] vmInstalls = installType.getVMInstalls();
+			for (IVMInstall install : vmInstalls) {
+				if (requiredJavaVersions.isEmpty()) {
+					return;
+				}
+				existingLocations.add(install.getInstallLocation());
+				removeIfMatch(requiredJavaVersions, install);
+			}
+		}
+	}
+
+	protected static boolean removeIfMatch(Collection<RequiredJavaVersion> requiredJavaVersions, IVMInstall install) {
+		int javaVersion = getJavaVersion(install);
+		for (Iterator<RequiredJavaVersion> iterator = requiredJavaVersions.iterator(); iterator.hasNext();) {
+			if (iterator.next().matches(javaVersion)) {
+				iterator.remove();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static record RequiredJavaVersion(int from, int to) {
+
+		public boolean matches(int version) {
+			return (version >= from() && version <= to());
+		}
+
+		public boolean matches(String v) {
+			return matches(Integer.parseInt(v));
+		}
+	}
+
+}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/InstalledJREsBlock.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/InstalledJREsBlock.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
@@ -910,7 +909,7 @@ public class InstalledJREsBlock implements IAddVMDialogRequestor, ISelectionProv
 			@Override
 			public void run(IProgressMonitor monitor) {
 				monitor.beginTask(JREMessages.InstalledJREsBlock_11, IProgressMonitor.UNKNOWN);
-				search(rootDir, locations, types, exstingLocations, monitor);
+				DetectVMInstallationsJob.search(rootDir, locations, types, exstingLocations, monitor);
 				monitor.done();
 			}
 		};
@@ -1029,75 +1028,6 @@ public class InstalledJREsBlock implements IAddVMDialogRequestor, ISelectionProv
 		} while (vmType.findVMInstall(id) != null || id.equals(fgLastUsedID));
 		fgLastUsedID = id;
 		return id;
-	}
-
-	/**
-	 * Searches the specified directory recursively for installed VMs, adding each
-	 * detected VM to the <code>found</code> list. Any directories specified in
-	 * the <code>ignore</code> are not traversed.
-	 */
-	protected void search(File directory, List<File> found, List<IVMInstallType> types, Set<File> ignore, IProgressMonitor monitor) {
-		if (monitor.isCanceled()) {
-			return;
-		}
-
-		String[] fileNames = directory.list();
-		if (fileNames == null) {
-			return; // not a directory
-		}
-		List<String> names = new ArrayList<>();
-		names.add(null); // self
-		names.addAll(List.of(fileNames));
-		List<File> subDirs = new ArrayList<>();
-		for (String name : names) {
-			if (monitor.isCanceled()) {
-				return;
-			}
-			File file = name == null ? directory : new File(directory, name);
-			monitor.subTask(NLS.bind(JREMessages.InstalledJREsBlock_14, Integer.toString(found.size()),
-					file.toPath().normalize().toAbsolutePath().toString().replace("&", "&&") )); // @see bug 29855 //$NON-NLS-1$ //$NON-NLS-2$
-			IVMInstallType[] vmTypes = JavaRuntime.getVMInstallTypes();
-			if (file.isDirectory()) {
-				if (ignore.add(file)) {
-					boolean validLocation = false;
-
-					// Take the first VM install type that claims the location as a
-					// valid VM install.  VM install types should be smart enough to not
-					// claim another type's VM, but just in case...
-					for (int j = 0; j < vmTypes.length; j++) {
-						if (monitor.isCanceled()) {
-							return;
-						}
-						IVMInstallType type = vmTypes[j];
-						IStatus status = type.validateInstallLocation(file);
-						if (status.isOK()) {
-							String filePath = file.getPath();
-							int index = filePath.lastIndexOf(File.separatorChar);
-							File newFile = file;
-							// remove bin folder from install location as java executables are found only under bin for Java 9 and above
-							if (index > 0 && filePath.substring(index + 1).equals("bin")) { //$NON-NLS-1$
-								newFile = new File(filePath.substring(0, index));
-							}
-							found.add(newFile);
-							types.add(type);
-							validLocation = true;
-							break;
-						}
-					}
-					if (!validLocation) {
-						subDirs.add(file);
-					}
-				}
-			}
-		}
-		while (!subDirs.isEmpty()) {
-			File subDir = subDirs.remove(0);
-			search(subDir, found, types, ignore, monitor);
-			if (monitor.isCanceled()) {
-				return;
-			}
-		}
-
 	}
 
 	/**

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.java
@@ -45,7 +45,6 @@ public class JREMessages extends NLS {
 	public static String InstalledJREsBlock_11;
 	public static String InstalledJREsBlock_12;
 	public static String InstalledJREsBlock_13;
-	public static String InstalledJREsBlock_14;
 	public static String InstalledJREsBlock_15;
 	public static String InstalledJREsBlock_16;
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREMessages.properties
@@ -36,7 +36,6 @@ InstalledJREsBlock_10=Directory Selection
 InstalledJREsBlock_11=Searching...
 InstalledJREsBlock_12=Information
 InstalledJREsBlock_13=No JREs found in {0}
-InstalledJREsBlock_14=Found {0} - Searching {1}
 InstalledJREsBlock_15=Installed &JREs:
 InstalledJREsBlock_16=Dupli&cate...
 InstalledJREsBlock_19={0} (contributed)

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.java
@@ -18,6 +18,8 @@ import org.eclipse.osgi.util.NLS;
 public class LaunchingMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.jdt.internal.launching.LaunchingMessages";//$NON-NLS-1$
 
+	public static String SearchingJVMs;
+
 	public static String AbstractJavaLaunchConfigurationDelegate_Java_project_not_specified_9;
 	public static String AbstractJavaLaunchConfigurationDelegate_JRE_home_directory_for__0__does_not_exist___1__6;
 	public static String AbstractJavaLaunchConfigurationDelegate_JRE_home_directory_not_specified_for__0__5;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/LaunchingMessages.properties
@@ -207,3 +207,4 @@ VMLogging_2=Creating Library with Java Install path:
 VMLogging_3=Default Install retrieved:
 lookupInstalledJVMs=Detect installed JVMs
 configuringJVM=Configuring installed JVM {0}
+SearchingJVMs=Found {0} - Searching {1}


### PR DESCRIPTION
Currently when one launches a multi-release compiled project one always gets the type from the default project folder.

This now first checks what JRE is used to launch, then adds all valid folders in reverse version order to the classpath to emulate the behavior of loading a multi-release jar at runtime.

Fix https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/755

@stephan-herrmann can you review? This is basically applying what we did for the compile case but at runtime.