### PR TITLE
Add support to detect prefixed JAVA_HOME_ env variables for installation

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.23.400.qualifier
+Bundle-Version: 3.23.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -156,7 +156,7 @@ public class DetectVMInstallationsJob extends Job {
 			.map(dir -> dir.listFiles(File::isDirectory))
 			.flatMap(Arrays::stream)
 			.filter(Objects::nonNull)
-			.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(HashSet::new));
 
 		// particular VM installations
 		String javaHome = System.getenv("JAVA_HOME"); //$NON-NLS-1$
@@ -167,6 +167,11 @@ public class DetectVMInstallationsJob extends Job {
 		if (jdkHome != null) {
 			directories.add(new File(jdkHome));
 		}
+		System.getenv().entrySet().forEach(entry -> {
+			if (entry.getKey().startsWith("JAVA_HOME_")) { //$NON-NLS-1$
+				directories.add(new File(entry.getValue()));
+			}
+		});
 		// other common/standard lookup strategies can be added here
 		return directories.stream()
 			.filter(Objects::nonNull)

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.23.400-SNAPSHOT</version>
+  <version>3.23.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
The setup-java github actions defines by default java installations in env variable starting with JAVA_HOME_ but this is currently not detected.

This now additionally also supports this form of JVM installs and fixes an issue with relying on toSet returning a modifiable set (what is not guaranteed).

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
