### PR TITLE
Select the best matching JRE for an EE from the list of compatible JVMs

### DIFF
--- a/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching; singleton:=true
-Bundle-Version: 3.23.500.qualifier
+Bundle-Version: 3.24.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.launching.LaunchingPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JREContainerInitializer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/JREContainerInitializer.java
@@ -19,7 +19,6 @@ package org.eclipse.jdt.internal.launching;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -178,31 +177,16 @@ public class JREContainerInitializer extends ClasspathContainerInitializer {
 		}
 		IVMInstall vm = environment.getDefaultVM();
 		if (vm == null) {
-			IVMInstall[] installs = environment.getCompatibleVMs();
-			// take the first strictly compatible VM if there is no default
-			if (installs.length == 0 && LaunchingPlugin.DEBUG_JRE_CONTAINER) {
+			vm = environment.getCompatibleVM();
+			if (vm == null) {
 				LaunchingPlugin.trace("\t*** NO COMPATIBLE VMS ***"); //$NON-NLS-1$
+				return null;
 			}
-			for (int i = 0; i < installs.length; i++) {
-				IVMInstall install = installs[i];
-				if (environment.isStrictlyCompatible(install)) {
-					vm = install;
-					if (LaunchingPlugin.DEBUG_JRE_CONTAINER) {
-						LaunchingPlugin.trace("\tPerfect Match: " + vm.getName()); //$NON-NLS-1$
-					}
-					break;
-				}
-			}
-			//try the default VM install: https://bugs.eclipse.org/bugs/show_bug.cgi?id=371300
-			// if default vm is a match https://bugs.eclipse.org/bugs/show_bug.cgi?id=484026
-			if (vm == null && installs.length > 0 && Arrays.asList(installs).contains(JavaRuntime.getDefaultVMInstall())) {
-				vm = JavaRuntime.getDefaultVMInstall();
-			}
-			// use the first VM failing that
-			if (vm == null && installs.length > 0) {
-				vm = installs[0];
-				if (LaunchingPlugin.DEBUG_JRE_CONTAINER) {
-					LaunchingPlugin.trace("\tFirst Match: " + vm.getName()); //$NON-NLS-1$
+			if (LaunchingPlugin.DEBUG_JRE_CONTAINER) {
+				if (environment.isStrictlyCompatible(vm)) {
+					LaunchingPlugin.trace("\tPerfect Match: " + vm.getName()); //$NON-NLS-1$
+				} else {
+					LaunchingPlugin.trace("\tUse compatible VM: " + vm.getName()); //$NON-NLS-1$
 				}
 			}
 		} else {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironment.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/environments/IExecutionEnvironment.java
@@ -65,6 +65,19 @@ public interface IExecutionEnvironment {
 	public IVMInstall[] getCompatibleVMs();
 
 	/**
+	 * Return the vm that is best matching this environment that is:
+	 *
+	 * <ol>
+	 * <li>if a strictly compatible is found this one is returned, if multiple are strictly compatible it picks one randomly</li>
+	 * <li>in all other case it choose the one with the lowest version, if multiple match the same version it picks one randomly</li>
+	 * </ol>
+	 *
+	 * @return the best compatible VM or <code>null</code> if none is found
+	 * @since 3.24
+	 */
+	public IVMInstall getCompatibleVM();
+
+	/**
 	 * Returns whether the specified VM install is strictly compatible with
 	 * this environment. Returns <code>true</code> to indicate the VM install
 	 * is strictly compatible with this environment and <code>false</code> to indicate

--- a/org.eclipse.jdt.launching/pom.xml
+++ b/org.eclipse.jdt.launching/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching</artifactId>
-  <version>3.23.500-SNAPSHOT</version>
+  <version>3.24.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <build>


### PR DESCRIPTION
Currently the selection of a compatible JRE for an EE seems quite random for the user, e.g. it can happen that for an EE10 with some JRE11/17/24 it chooses 24. This is actually a bad choice as newer java might _remove_ API during release, so the _lowest_ possible java version among others would be the best choice here.

This now do the following:

- introduce a new method IExecutionEnvironment#getCompatibleVM that selects the best matching from the set of selected JVMs (but ignoring the default)
- in the JREContainerInitializer check if there is a default vm selected, then use that
- if not ask the EE for a compatible one (with the new method)

See
- https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/760