### PR TITLE
Constants for Java 26

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/EECompilationParticipant.java
@@ -234,6 +234,8 @@ public class EECompilationParticipant extends CompilationParticipant {
 		String version = vMInstall.getJavaVersion();
 		if (version == null) {
 			return null;
+		} else if (matchesMajorVersion(version, JavaCore.VERSION_26)) {
+			return JavaCore.VERSION_26;
 		} else if (matchesMajorVersion(version, JavaCore.VERSION_25)) {
 			return JavaCore.VERSION_25;
 		} else if (matchesMajorVersion(version, JavaCore.VERSION_24)) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/StandardVMType.java
@@ -808,7 +808,10 @@ public class StandardVMType extends AbstractVMInstallType {
 	 */
 	public static URL getDefaultJavadocLocation(String version) {
 		try {
-			if (version.startsWith(JavaCore.VERSION_25)) {
+			if (version.startsWith(JavaCore.VERSION_26)) {
+				// Java 26 docs aren't published yet
+				return new URI("https://docs.oracle.com/en/java/javase/25/docs/api/").toURL(); //$NON-NLS-1$
+			} else if (version.startsWith(JavaCore.VERSION_25)) {
 				return new URI("https://docs.oracle.com/en/java/javase/25/docs/api/").toURL(); //$NON-NLS-1$
 			} else if (version.startsWith(JavaCore.VERSION_24)) {
 				return new URI("https://docs.oracle.com/en/java/javase/24/docs/api/").toURL(); //$NON-NLS-1$

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/environments/ExecutionEnvironmentAnalyzer.java
@@ -41,6 +41,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 
 	// XXX: Note that this string is not yet standardized by OSGi, see http://wiki.osgi.org/wiki/Execution_Environment
 
+	private static final String JavaSE_26 = "JavaSE-26"; //$NON-NLS-1$
 	private static final String JavaSE_25 = "JavaSE-25"; //$NON-NLS-1$
 	private static final String JavaSE_24 = "JavaSE-24"; //$NON-NLS-1$
 	private static final String JavaSE_23 = "JavaSE-23"; //$NON-NLS-1$
@@ -115,6 +116,7 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 		mappings.put(JavaSE_23, new String[] { JavaSE_22 });
 		mappings.put(JavaSE_24, new String[] { JavaSE_23 });
 		mappings.put(JavaSE_25, new String[] { JavaSE_24 });
+		mappings.put(JavaSE_26, new String[] { JavaSE_25 });
 	}
 	@Override
 	public CompatibleEnvironment[] analyze(IVMInstall vm, IProgressMonitor monitor) throws CoreException {
@@ -140,7 +142,9 @@ public class ExecutionEnvironmentAnalyzer implements IExecutionEnvironmentAnalyz
 					types = getTypes(CDC_FOUNDATION_1_1);
 				}
 			} else {
-				if (javaVersion.startsWith("25")) { //$NON-NLS-1$
+				if (javaVersion.startsWith("26")) { //$NON-NLS-1$
+					types = getTypes(JavaSE_26);
+				} else if (javaVersion.startsWith("25")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_25);
 				} else if (javaVersion.startsWith("24")) { //$NON-NLS-1$
 					types = getTypes(JavaSE_24);

--- a/org.eclipse.jdt.launching/plugin.properties
+++ b/org.eclipse.jdt.launching/plugin.properties
@@ -87,6 +87,7 @@ environment.description.26 = Java Platform, Standard Edition 22
 environment.description.27 = Java Platform, Standard Edition 23
 environment.description.28 = Java Platform, Standard Edition 24
 environment.description.29 = Java Platform, Standard Edition 25
+environment.description.30 = Java Platform, Standard Edition 26
 
 classpathVariableInitializer.deprecated = Use the JRE System Library instead
 

--- a/org.eclipse.jdt.launching/plugin.xml
+++ b/org.eclipse.jdt.launching/plugin.xml
@@ -399,6 +399,11 @@
             id="JavaSE-25"
             compliance="25">
       </environment>
+      <environment
+            description="%environment.description.30"
+            id="JavaSE-26"
+            compliance="26">
+      </environment>
       <analyzer
             class="org.eclipse.jdt.internal.launching.environments.ExecutionEnvironmentAnalyzer"
             id="org.eclipse.jdt.launching.eeAnalyzer"/>


### PR DESCRIPTION
## What it does

Adds the constants necessary for debugging an application using Java 26.

## How to test

I think I'm missing something; I can't select Java 26 as an Execution Environment when configuring the Java application debug/launch, this is how I was testing.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
