### PR TITLE
Remove useless p2.inf file in o.e.jdt.launching.ui.macosx

### DIFF
--- a/org.eclipse.jdt.launching.ui.macosx/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.launching.ui.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.launching.ui.macosx;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.launching.ui.macosx/META-INF/p2.inf
+++ b/org.eclipse.jdt.launching.ui.macosx/META-INF/p2.inf
@@ -1,4 +1,0 @@
-# ensure that the applicable implementation fragment gets installed (bug 361901)
-requires.0.namespace = org.eclipse.equinox.p2.iu
-requires.0.name = org.eclipse.swt.cocoa.macosx.x86_64
-requires.0.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=x86_64))

--- a/org.eclipse.jdt.launching.ui.macosx/pom.xml
+++ b/org.eclipse.jdt.launching.ui.macosx/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.launching.ui.macosx</artifactId>
-  <version>1.4.400-SNAPSHOT</version>
+  <version>1.4.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
It was introduced via
https://github.com/eclipse-jdt/eclipse.jdt.debug/commit/de871731ac372abbf0c3e792261edb556f7ea8dd most likely to workaround org.eclipse.swt host not mandating dependency on the correct os/arch specific fragment. As SWT does that this is useless and just generates issues with maven publishing. Pointed out in
eclipse-platform/eclipse.platform.releng.aggregator#3264 (comment)
