### PR TITLE
Re-Enable Conditional breakpoint for file class test

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -398,9 +398,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(TestToggleBreakpointsTarget.class));
 		addTest(new TestSuite(TriggerPointBreakpointsTests.class));
 		addTest(new TestSuite(JavaThreadEventHandlerTests.class));
-		if (!JavaProjectHelper.isJava25_Compatible()) { // Disabling since consistent failure on Java 25
-			addTest(new TestSuite(ConditionalBreakpointsWithFileClass.class));
-		}
+		addTest(new TestSuite(ConditionalBreakpointsWithFileClass.class));
 		addTest(new TestSuite(CompareObjectsTest.class));
 		addTest(new TestSuite(DisableOnHitTest.class));
 

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.debug.tests.breakpoints;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.debug.tests.AbstractDebugTest;
 
 public class ConditionalBreakpointsWithFileClass extends AbstractDebugTest {
@@ -54,19 +55,30 @@ public class ConditionalBreakpointsWithFileClass extends AbstractDebugTest {
 	public void testFileConditionalBreakpointforTrue() throws Exception {
 		String typeName = "FileConditionSnippet2";
 		IJavaLineBreakpoint bp3 = createLineBreakpoint(20, typeName);
+		IJavaLineBreakpoint bp2;
 		IJavaThread mainThread = null;
 
 		try {
 			Thread.sleep(10);
 			mainThread = launchToBreakpoint(typeName);
 			mainThread.getTopStackFrame().stepInto();
-			IJavaLineBreakpoint bp2 = createConditionalLineBreakpoint(364, "java.io.File", "true", true);
+
+			if (JavaProjectHelper.isJava25_Compatible()) {
+				bp2 = createConditionalLineBreakpoint(369, "java.io.File", "true", true);
+			} else {
+				bp2 = createConditionalLineBreakpoint(364, "java.io.File", "true", true);
+			}
+
 			int hitLine = 0;
 			mainThread.resume();
 			Thread.sleep(1000);
 			assertTrue("Thread should be suspended", mainThread.isSuspended());
 			hitLine = mainThread.getStackFrames()[0].getLineNumber();
-			assertEquals("Didn't suspend at the expected line", 364, hitLine);
+			if (JavaProjectHelper.isJava25_Compatible()) {
+				assertEquals("Didn't suspend at the expected line", 369, hitLine);
+			} else {
+				assertEquals("Didn't suspend at the expected line", 364, hitLine);
+			}
 
 			bp2.delete();
 			bp3.delete();


### PR DESCRIPTION
This commit re-enables ConditionalBreakpointsWithFileClass for all java versions

fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/695

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
