### PR TITLE
Don't pass null values to Signature.createArraySignature(String, int)

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
@@ -1267,7 +1267,11 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 					return "Ljava/lang/Object;"; //$NON-NLS-1$
 				}
 				String bound = Signature.createTypeSignature(bounds[0], false);
-				return Signature.createArraySignature(resolveTypeSignature(method, bound), count);
+				String signature = resolveTypeSignature(method, bound);
+				if (signature == null) {
+					return null;
+				}
+				return Signature.createArraySignature(signature, count);
     		}
             // the type name cannot be resolved
             return null;

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaBreakpointImportParticipant.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaBreakpointImportParticipant.java
@@ -394,10 +394,11 @@ public class JavaBreakpointImportParticipant implements
 			}
 			case ASTNode.ARRAY_TYPE: {
 				ArrayType a = (ArrayType) type;
-				return Signature
-						.createArraySignature(
-								getTypeSignature(a.getElementType()),
-								a.getDimensions());
+				String typeSignature = getTypeSignature(a.getElementType());
+				if (typeSignature == null) {
+					return null;
+				}
+				return Signature.createArraySignature(typeSignature, a.getDimensions());
 			}
 			case ASTNode.PARAMETERIZED_TYPE: {
 				// we don't need to care about the other scoping types only the


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4448
