### PR TITLE
Fix JavaTestPlugin.getFileInPlugin(IPath) to handle not found file

### DIFF
--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaTestPlugin.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/JavaTestPlugin.java
@@ -90,7 +90,13 @@ public class JavaTestPlugin extends AbstractUIPlugin {
 		try {
 			Bundle bundle = getDefault().getBundle();
 			URL installURL = bundle.getEntry("/" + path.toString());
+			if (installURL == null) {
+				return null;
+			}
 			URL localURL= FileLocator.toFileURL(installURL);//Platform.asLocalURL(installURL);
+			if (localURL == null) {
+				return null;
+			}
 			return new File(localURL.getFile());
 		} catch (IOException e) {
 			return null;


### PR DESCRIPTION
JavaTestPlugin.getFileInPlugin(IPath) claims to return `null` if the path is not found. But actually it runs into a NPE if it can not convert the path to a file first.

This now adds checks on the place where `null` can happen.

See
- https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/786
FYI @iloveeclipse this now first fix the method to not run into NPE if something is not found.