### PR TITLE
Remove @SuppressWarnings annotation no longer raised by ecj

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIStackFrame.java
@@ -1571,7 +1571,6 @@ public class JDIStackFrame extends JDIDebugElement implements IJavaStackFrame {
 	/**
 	 * @see org.eclipse.debug.core.model.IFilteredStep#stepWithFilters()
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public void stepWithFilters() throws DebugException {
 		((IJavaThread) getThread()).stepWithFilters();


### PR DESCRIPTION
Due to https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4293 ecj no longer warns about using a method inherited from a deprecated type

See also https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4553