### PR TITLE
Remove @SuppressWarnings annotation no longer raised by ecj, take 2

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
@@ -1894,7 +1894,6 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 	 * @return the type root or <code>null</code> if one cannot be derived
 	 * @since 3.8
 	 */
-	@SuppressWarnings("deprecation")
 	private static String getCodeTemplate(ITextSelection textSelection, JavaEditor part) {
 		ITextViewer viewer = part.getViewer();
 		if (viewer == null) {
@@ -1906,7 +1905,6 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 		return templateBuffer.get();
 	}
 
-	@SuppressWarnings("deprecation")
 	private static void doGetCodeTemplate(ITextSelection textSelection, JavaEditor part, ITextViewer viewer, TemplateContextType contextType, AtomicReference<String> templateBuffer) {
 		ITextEditor editor = getTextEditor(part);
 		if (editor == null) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/contentassist/JavaDebugContentAssistProcessor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/contentassist/JavaDebugContentAssistProcessor.java
@@ -56,8 +56,6 @@ public class JavaDebugContentAssistProcessor implements IContentAssistProcessor 
 	private final IJavaDebugContentAssistContext fContext;
 	private ContentAssistant fAssistant;
 
-
-	@SuppressWarnings("deprecation")
 	public JavaDebugContentAssistProcessor(IJavaDebugContentAssistContext context) {
 		fContext = context;
 		TemplateContextType contextType= JavaPlugin.getDefault().getTemplateContextRegistry().getContextType(JavaContextType.ID_ALL);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/JavaSnippetCompletionProcessor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/snippeteditor/JavaSnippetCompletionProcessor.java
@@ -53,7 +53,6 @@ public class JavaSnippetCompletionProcessor implements IContentAssistProcessor {
 
 	public JavaSnippetCompletionProcessor(JavaSnippetEditor editor) {
 		fEditor= editor;
-		@SuppressWarnings("deprecation")
 		TemplateContextType contextType= JavaPlugin.getDefault().getTemplateContextRegistry().getContextType("java"); //$NON-NLS-1$
 		if (contextType != null) {
 			fTemplateEngine= new TemplateEngine(contextType);


### PR DESCRIPTION
Fixes remaining `@SuppressWarnings("deprecation")` annotations flagged as unnecessary by
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4564

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4553
