### PR TITLE
React to new info warnings from ecj

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/JavaSourceLookupDialog.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/JavaSourceLookupDialog.java
@@ -73,6 +73,7 @@ public class JavaSourceLookupDialog extends Dialog {
 	 * @param configuration the launch configuration from which the source lookup
 	 *  path is retrieved and (possibly) updated
 	 */
+	@Deprecated
 	public JavaSourceLookupDialog(Shell shell, String message, ILaunchConfiguration configuration) {
 		super(shell);
 		fSourceLookupBlock= new SourceLookupBlock();
@@ -87,6 +88,7 @@ public class JavaSourceLookupDialog extends Dialog {
 	 *
 	 * @return whether the "do not ask again" check box is selected in the dialog
 	 */
+	@Deprecated
 	public boolean isNotAskAgain() {
 		return fNotAskAgain;
 	}
@@ -94,6 +96,7 @@ public class JavaSourceLookupDialog extends Dialog {
 	/* (non-Javadoc)
 	 * @see org.eclipse.jface.dialogs.Dialog#createDialogArea(org.eclipse.swt.widgets.Composite)
 	 */
+	@Deprecated
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		Font font = parent.getFont();
@@ -132,6 +135,7 @@ public class JavaSourceLookupDialog extends Dialog {
 	/* (non-Javadoc)
 	 * @see org.eclipse.jface.dialogs.Dialog#okPressed()
 	 */
+	@Deprecated
 	@Override
 	protected void okPressed() {
 		try {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/JavaUISourceLocator.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/JavaUISourceLocator.java
@@ -77,6 +77,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * Identifier for the 'Prompting Java Source Locator' extension
 	 * (value <code>"org.eclipse.jdt.debug.ui.javaSourceLocator"</code>).
 	 */
+	@Deprecated
 	public static final String ID_PROMPTING_JAVA_SOURCE_LOCATOR = IJavaDebugUIConstants.PLUGIN_ID + ".javaSourceLocator"; //$NON-NLS-1$
 
 	/**
@@ -86,6 +87,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 *
 	 * @since 2.1
 	 */
+	@Deprecated
 	public static final String ATTR_FIND_ALL_SOURCE_ELEMENTS = IJavaDebugUIConstants.PLUGIN_ID + ".ATTR_FIND_ALL_SOURCE_ELEMENTS"; //$NON-NLS-1$
 
 	/**
@@ -120,6 +122,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	/**
 	 * Constructs an empty source locator.
 	 */
+	@Deprecated
 	public JavaUISourceLocator() {
 		fSourceLocator = new JavaSourceLocator();
 		fAllowedToAsk = true;
@@ -135,6 +138,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * 	as well
 	 * @throws CoreException if the underlying {@link JavaSourceLocator} fails to be created
 	 */
+	@Deprecated
 	public JavaUISourceLocator(IJavaProject[] projects,	boolean includeRequired) throws CoreException {
 		fSourceLocator = new JavaSourceLocator(projects, includeRequired);
 		fAllowedToAsk = true;
@@ -150,6 +154,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * @exception CoreException if unable to read the project's
 	 * 	 build path
 	 */
+	@Deprecated
 	public JavaUISourceLocator(IJavaProject project) throws CoreException {
 		fJavaProject = project;
 		IJavaSourceLocation[] sls =
@@ -164,6 +169,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	/**
 	 * @see org.eclipse.debug.core.model.ISourceLocator#getSourceElement(IStackFrame)
 	 */
+	@Deprecated
 	@Override
 	public Object getSourceElement(IStackFrame stackFrame) {
 		Object res = findSourceElement(stackFrame);
@@ -280,6 +286,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	/**
 	 * @see IPersistableSourceLocator#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		String memento = fSourceLocator.getMemento();
@@ -300,6 +307,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	/**
 	 * @see IPersistableSourceLocator#initializeDefaults(ILaunchConfiguration)
 	 */
+	@Deprecated
 	@Override
 	public void initializeDefaults(ILaunchConfiguration configuration)
 		throws CoreException {
@@ -312,6 +320,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	/**
 	 * @see IPersistableSourceLocator#initializeFromMemento(String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFromMemento(String memento) throws CoreException {
 		if (memento.startsWith("<project>")) { //$NON-NLS-1$
@@ -347,6 +356,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * @return the locations that this source locator is currently
 	 * searching, in the order that they are searched
 	 */
+	@Deprecated
 	public IJavaSourceLocation[] getSourceLocations() {
 		return fSourceLocator.getSourceLocations();
 	}
@@ -359,6 +369,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * @param locations the locations that will be searched, in the order
 	 *  to be searched
 	 */
+	@Deprecated
 	public void setSourceLocations(IJavaSourceLocation[] locations) {
 		fSourceLocator.setSourceLocations(locations);
 	}
@@ -374,6 +385,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * source elements that correspond to a stack frame
 	 * @since 2.1
 	 */
+	@Deprecated
 	public boolean isFindAllSourceElements() {
 		return fIsFindAllSourceElements;
 	}
@@ -386,6 +398,7 @@ public class JavaUISourceLocator implements IPersistableSourceLocator {
 	 * elements that correspond to a stack frame
 	 * @since 2.1
 	 */
+	@Deprecated
 	public void setFindAllSourceElement(boolean findAll) {
 		fIsFindAllSourceElements = findAll;
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaSourceLookupTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaSourceLookupTab.java
@@ -52,11 +52,13 @@ import org.eclipse.ui.PlatformUI;
 @Deprecated
 public class JavaSourceLookupTab extends JavaLaunchTab {
 
+	@Deprecated
 	protected SourceLookupBlock fSourceLookupBlock;
 
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#createControl(Composite)
 	 */
+	@Deprecated
 	@Override
 	public void createControl(Composite parent) {
 		Composite comp = new Composite(parent, SWT.NONE);
@@ -82,6 +84,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#setDefaults(ILaunchConfigurationWorkingCopy)
 	 */
+	@Deprecated
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		// be default, use a prompting source locator
@@ -93,6 +96,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#initializeFrom(ILaunchConfiguration)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		fSourceLookupBlock.initializeFrom(configuration);
@@ -101,6 +105,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#performApply(ILaunchConfigurationWorkingCopy)
 	 */
+	@Deprecated
 	@Override
 	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
 		configuration.setAttribute(ILaunchConfiguration.ATTR_SOURCE_LOCATOR_ID, JavaUISourceLocator.ID_PROMPTING_JAVA_SOURCE_LOCATOR);
@@ -112,6 +117,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	 *
 	 * @since 3.3
 	 */
+	@Deprecated
 	@Override
 	public String getId() {
 		return "org.eclipse.jdt.debug.ui.javaSourceLookupTab"; //$NON-NLS-1$
@@ -120,6 +126,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getName()
 	 */
+	@Deprecated
 	@Override
 	public String getName() {
 		return LauncherMessages.JavaSourceLookupTab_Source_1;
@@ -128,6 +135,7 @@ public class JavaSourceLookupTab extends JavaLaunchTab {
 	/**
 	 * @see org.eclipse.debug.ui.ILaunchConfigurationTab#getImage()
 	 */
+	@Deprecated
 	@Override
 	public Image getImage() {
 		return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJ_FILE);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaSourceLocationWorkbenchAdapterFactory.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaSourceLocationWorkbenchAdapterFactory.java
@@ -37,6 +37,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 @Deprecated
 /*package*/ class JavaSourceLocationWorkbenchAdapterFactory implements IAdapterFactory {
 
+	@Deprecated
 	class SourceLocationPropertiesAdapter implements IWorkbenchAdapter {
 
 		private final JavaElementLabelProvider fJavaElementLabelProvider = new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_BASICS);
@@ -44,6 +45,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 		/**
 		 * @see IWorkbenchAdapter#getChildren(Object)
 		 */
+		@Deprecated
 		@Override
 		public Object[] getChildren(Object o) {
 			return new Object[0];
@@ -52,6 +54,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 		/**
 		 * @see IWorkbenchAdapter#getImageDescriptor(Object)
 		 */
+		@Deprecated
 		@Override
 		public ImageDescriptor getImageDescriptor(Object o) {
 			if (o instanceof JavaProjectSourceLocation) {
@@ -67,6 +70,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 		/**
 		 * @see IWorkbenchAdapter#getLabel(Object)
 		 */
+		@Deprecated
 		@Override
 		public String getLabel(Object o) {
 			if (o instanceof JavaProjectSourceLocation) {
@@ -87,6 +91,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 		/**
 		 * @see IWorkbenchAdapter#getParent(Object)
 		 */
+		@Deprecated
 		@Override
 		public Object getParent(Object o) {
 			return null;
@@ -96,6 +101,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 	/**
 	 * @see IAdapterFactory#getAdapter(Object, Class)
 	 */
+	@Deprecated
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getAdapter(Object obj, Class<T> adapterType) {
@@ -113,6 +119,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 	/**
 	 * @see IAdapterFactory#getAdapterList()
 	 */
+	@Deprecated
 	@Override
 	public Class<?>[] getAdapterList() {
 		return new Class[] {

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/IJavaPatternBreakpoint.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/IJavaPatternBreakpoint.java
@@ -38,6 +38,7 @@ public interface IJavaPatternBreakpoint extends IJavaLineBreakpoint {
 	 *                if unable to access the property from this breakpoint's
 	 *                underlying marker
 	 */
+	@Deprecated
 	public String getPattern() throws CoreException;
 
 	/**
@@ -51,6 +52,7 @@ public interface IJavaPatternBreakpoint extends IJavaLineBreakpoint {
 	 *                if unable to access the property from this breakpoint's
 	 *                underlying marker
 	 */
+	@Deprecated
 	public String getSourceName() throws CoreException;
 
 }

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/IRuntimeContainerComparator.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/IRuntimeContainerComparator.java
@@ -42,6 +42,7 @@ public interface IRuntimeContainerComparator {
 	 * @return whether this container is a duplicate of the container
 	 * identified by the given path
 	 */
+	@Deprecated
 	public boolean isDuplicate(IPath containerPath);
 
 }

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ArchiveSourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ArchiveSourceLocation.java
@@ -95,6 +95,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 * This method is only to be called by the launching
 	 * plug-in.
 	 */
+	@Deprecated
 	public static void closeArchives() {
 		synchronized (fZipFileCache) {
 			Iterator<ZipFile> iter = fZipFileCache.values().iterator();
@@ -131,6 +132,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 * Constructs a new empty source location to be initialized with
 	 * a memento.
 	 */
+	@Deprecated
 	public ArchiveSourceLocation() {
 	}
 
@@ -143,6 +145,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 *  specified archive, or <code>null</code> if the root source folder
 	 *  is the root of the archive
 	 */
+	@Deprecated
 	public ArchiveSourceLocation(String archiveName, String sourceRoot) {
 		super();
 		setName(archiveName);
@@ -152,6 +155,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#findSourceElement(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public Object findSourceElement(String name) throws CoreException {
 		try {
@@ -237,6 +241,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 * @throws IOException if unable to create the zip
 	 * 	file associated with this location
 	 */
+	@Deprecated
 	protected ZipFile getArchive() throws IOException {
 		return getZipFile(getName());
 	}
@@ -268,6 +273,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 * the archive, or <code>null</code> if the root source
 	 * folder is the root of the archive
 	 */
+	@Deprecated
 	public IPath getRootPath() {
 		return fRootPath;
 	}
@@ -279,6 +285,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	 * @return the name of the archive associated with this
 	 *  source location
 	 */
+	@Deprecated
 	public String getName() {
 		return fName;
 	}
@@ -297,6 +304,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	/* (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Deprecated
 	@Override
 	public boolean equals(Object object) {
 		return object instanceof ArchiveSourceLocation archivceSource && getName().equals(archivceSource.getName());
@@ -305,6 +313,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Deprecated
 	@Override
 	public int hashCode() {
 		return getName().hashCode();
@@ -313,6 +322,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		Document doc = DebugPlugin.newDocument();
@@ -329,6 +339,7 @@ public class ArchiveSourceLocation extends PlatformObject implements IJavaSource
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#initializeFrom(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFrom(String memento) throws CoreException {
 		Exception ex = null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/DirectorySourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/DirectorySourceLocation.java
@@ -67,6 +67,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	 * Constructs a new empty source location to be initialized from
 	 * a memento.
 	 */
+	@Deprecated
 	public DirectorySourceLocation() {
 	}
 
@@ -76,6 +77,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	 *
 	 * @param directory a directory
 	 */
+	@Deprecated
 	public DirectorySourceLocation(File directory) {
 		setDirectory(directory);
 	}
@@ -83,6 +85,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#findSourceElement(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public Object findSourceElement(String name) throws CoreException {
 		if (getDirectory() == null) {
@@ -131,6 +134,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	 *
 	 * @return directory
 	 */
+	@Deprecated
 	public File getDirectory() {
 		return fDirectory;
 	}
@@ -138,6 +142,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	/* (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Deprecated
 	@Override
 	public boolean equals(Object object) {
 		return object instanceof DirectorySourceLocation &&
@@ -147,6 +152,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Deprecated
 	@Override
 	public int hashCode() {
 		return getDirectory().hashCode();
@@ -155,6 +161,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		Document doc = DebugPlugin.newDocument();
@@ -167,6 +174,7 @@ public class DirectorySourceLocation extends PlatformObject implements IJavaSour
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#initializeFrom(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFrom(String memento) throws CoreException {
 		Exception ex = null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/IJavaSourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/IJavaSourceLocation.java
@@ -56,6 +56,7 @@ public interface IJavaSourceLocation extends IAdaptable {
 	 * @exception CoreException if an exception occurs while searching
 	 *  for the specified source element
 	 */
+	@Deprecated
 	public Object findSourceElement(String name) throws CoreException;
 
 	/**
@@ -65,6 +66,7 @@ public interface IJavaSourceLocation extends IAdaptable {
 	 * @return a memento for this source location
 	 * @exception CoreException if unable to create a memento
 	 */
+	@Deprecated
 	public String getMemento() throws CoreException;
 
 	/**
@@ -74,6 +76,7 @@ public interface IJavaSourceLocation extends IAdaptable {
 	 * @exception CoreException if unable to initialize this source
 	 * 	location
 	 */
+	@Deprecated
 	public void initializeFrom(String memento) throws CoreException;
 
 }

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaProjectSourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaProjectSourceLocation.java
@@ -74,6 +74,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	 * Constructs a new empty source location to be initialized
 	 * by a memento.
 	 */
+	@Deprecated
 	public JavaProjectSourceLocation() {
 	}
 
@@ -83,6 +84,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	 *
 	 * @param project Java project
 	 */
+	@Deprecated
 	public JavaProjectSourceLocation(IJavaProject project) {
 		setJavaProject(project);
 	}
@@ -90,6 +92,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#findSourceElement(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public Object findSourceElement(String name) throws CoreException {
 		if (fRootLocations != null) {
@@ -135,6 +138,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	 *
 	 * @return Java project
 	 */
+	@Deprecated
 	public IJavaProject getJavaProject() {
 		return fProject;
 	}
@@ -142,6 +146,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	/* (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Deprecated
 	@Override
 	public boolean equals(Object object) {
 		return object instanceof JavaProjectSourceLocation &&
@@ -151,6 +156,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Deprecated
 	@Override
 	public int hashCode() {
 		return getJavaProject().hashCode();
@@ -159,6 +165,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		Document doc = DebugPlugin.newDocument();
@@ -171,6 +178,7 @@ public class JavaProjectSourceLocation extends PlatformObject implements IJavaSo
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#initializeFrom(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFrom(String memento) throws CoreException {
 		Exception ex = null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaSourceLocator.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/JavaSourceLocator.java
@@ -102,6 +102,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * Identifier for the 'Java Source Locator' extension
 	 * (value <code>"org.eclipse.jdt.launching.javaSourceLocator"</code>).
 	 */
+	@Deprecated
 	public static final String ID_JAVA_SOURCE_LOCATOR = LaunchingPlugin.getUniqueIdentifier() + ".javaSourceLocator"; //$NON-NLS-1$
 
 	/**
@@ -112,6 +113,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	/**
 	 * Constructs a new empty JavaSourceLocator.
 	 */
+	@Deprecated
 	public JavaSourceLocator() {
 		setSourceLocations(new IJavaSourceLocation[0]);
 	}
@@ -126,6 +128,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * 	as well
 	 * @throws CoreException if a new locator fails to be created
 	 */
+	@Deprecated
 	public JavaSourceLocator(IJavaProject[] projects, boolean includeRequired) throws CoreException {
 		ArrayList<IJavaProject> requiredProjects = new ArrayList<>();
 		for (int i= 0; i < projects.length; i++) {
@@ -169,6 +172,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @param locations the source locations to search for
 	 *  source, in the order they should be searched
 	 */
+	@Deprecated
 	public JavaSourceLocator(IJavaSourceLocation[] locations) {
 		setSourceLocations(locations);
 	}
@@ -181,6 +185,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @exception CoreException if an exception occurs reading
 	 *  the classpath of the given or any required project
 	 */
+	@Deprecated
 	public JavaSourceLocator(IJavaProject project) throws CoreException {
 		setSourceLocations(getDefaultSourceLocations(project));
 	}
@@ -192,6 +197,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @param locations the locations that will be searched, in the order
 	 *  to be searched
 	 */
+	@Deprecated
 	public void setSourceLocations(IJavaSourceLocation[] locations) {
 		fLocations = locations;
 	}
@@ -203,6 +209,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @return the locations that this source locator is currently
 	 * searching, in the order that they are searched
 	 */
+	@Deprecated
 	public IJavaSourceLocation[] getSourceLocations() {
 		return fLocations;
 	}
@@ -216,6 +223,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * the given stack frame, or <code>null</code> if none
 	 * @since 2.1
 	 */
+	@Deprecated
 	public Object[] getSourceElements(IStackFrame stackFrame) {
 		if (stackFrame instanceof IJavaStackFrame frame) {
 			String name = null;
@@ -252,6 +260,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	/* (non-Javadoc)
 	 * @see org.eclipse.debug.core.model.ISourceLocator#getSourceElement(org.eclipse.debug.core.model.IStackFrame)
 	 */
+	@Deprecated
 	@Override
 	public Object getSourceElement(IStackFrame stackFrame) {
 		if (stackFrame instanceof IJavaStackFrame frame) {
@@ -331,6 +340,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @param res the list to add all required projects too
 	 * @throws JavaModelException if there is a problem with the backing Java model
 	 */
+	@Deprecated
 	protected static void collectRequiredProjects(IJavaProject proj, ArrayList<IJavaProject> res) throws JavaModelException {
 		if (!res.contains(proj)) {
 			res.add(proj);
@@ -361,6 +371,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	 * @exception CoreException if an exception occurs reading
 	 *  computing the default locations
 	 */
+	@Deprecated
 	public static IJavaSourceLocation[] getDefaultSourceLocations(IJavaProject project) throws CoreException {
 		// create a temporary launch config
 		ILaunchConfigurationType type = DebugPlugin.getDefault().getLaunchManager().getLaunchConfigurationType(IJavaLaunchConfigurationConstants.ID_JAVA_APPLICATION);
@@ -374,6 +385,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	/* (non-Javadoc)
 	 * @see org.eclipse.debug.core.model.IPersistableSourceLocator#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		Document doc = DebugPlugin.newDocument();
@@ -393,6 +405,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	/* (non-Javadoc)
 	 * @see org.eclipse.debug.core.model.IPersistableSourceLocator#initializeDefaults(org.eclipse.debug.core.ILaunchConfiguration)
 	 */
+	@Deprecated
 	@Override
 	public void initializeDefaults(ILaunchConfiguration configuration) throws CoreException {
 		IRuntimeClasspathEntry[] entries = JavaRuntime.computeUnresolvedSourceLookupPath(configuration);
@@ -403,6 +416,7 @@ public class JavaSourceLocator implements IPersistableSourceLocator {
 	/* (non-Javadoc)
 	 * @see org.eclipse.debug.core.model.IPersistableSourceLocator#initializeFromMemento(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFromMemento(String memento) throws CoreException {
 		Exception ex = null;

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/LocalFileStorage.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/LocalFileStorage.java
@@ -37,6 +37,7 @@ public class LocalFileStorage extends org.eclipse.debug.core.sourcelookup.contai
 	 *
 	 * @param file a local file
 	 */
+	@Deprecated
 	public LocalFileStorage(File file){
 		super(file);
 	}

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/PackageFragmentRootSourceLocation.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/PackageFragmentRootSourceLocation.java
@@ -66,6 +66,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/**
 	 * Creates an empty source location.
 	 */
+	@Deprecated
 	public PackageFragmentRootSourceLocation() {
 	}
 
@@ -74,6 +75,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	 *
 	 * @param root package fragment root
 	 */
+	@Deprecated
 	public PackageFragmentRootSourceLocation(IPackageFragmentRoot root) {
 		setPackageFragmentRoot(root);
 	}
@@ -81,6 +83,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#findSourceElement(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public Object findSourceElement(String name) throws CoreException {
 		if (name != null && getPackageFragmentRoot() != null) {
@@ -121,6 +124,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#getMemento()
 	 */
+	@Deprecated
 	@Override
 	public String getMemento() throws CoreException {
 		Document doc = DebugPlugin.newDocument();
@@ -137,6 +141,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.launching.sourcelookup.IJavaSourceLocation#initializeFrom(java.lang.String)
 	 */
+	@Deprecated
 	@Override
 	public void initializeFrom(String memento) throws CoreException {
 		Exception ex = null;
@@ -184,6 +189,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	 * @return the package fragment root associated with this
 	 *  source location, or <code>null</code> if none
 	 */
+	@Deprecated
 	public IPackageFragmentRoot getPackageFragmentRoot() {
 		return fRoot;
 	}
@@ -209,6 +215,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/* (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Deprecated
 	@Override
 	public boolean equals(Object object) {
 		if (object instanceof PackageFragmentRootSourceLocation) {
@@ -224,6 +231,7 @@ public class PackageFragmentRootSourceLocation extends PlatformObject implements
 	/* (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Deprecated
 	@Override
 	public int hashCode() {
 		if (getPackageFragmentRoot() == null) {

--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ZipEntryStorage.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/launching/sourcelookup/ZipEntryStorage.java
@@ -40,6 +40,7 @@ public class ZipEntryStorage extends org.eclipse.debug.core.sourcelookup.contain
 	 * @param archive zip file
 	 * @param entry zip entry
 	 */
+	@Deprecated
 	public ZipEntryStorage(ZipFile archive, ZipEntry entry) {
 		super(archive, entry);
 	}


### PR DESCRIPTION
Add `@Deprecated` to members of truly deprecated classes
+ most classes have a replacement for a long time already
+ still in use and no replacement specified:
  - JavaSourceLocationWorkbenchAdapterFactory

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4568
Changes created using https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2587