### PR TITLE
Disable breakpoint  Entry&Exit toggle actions for lambda breakpoints

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EntryToggleAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EntryToggleAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,7 @@ public class EntryToggleAction extends BreakpointToggleAction {
 		Iterator<?> iter= selection.iterator();
 		while (iter.hasNext()) {
 			Object element = iter.next();
-			if (!(element instanceof IJavaMethodBreakpoint)) {
+			if (!(element instanceof IJavaMethodBreakpoint javaMethodBp && !javaMethodBp.isLambdaBreakpoint())) {
 				return false;
 			}
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExitToggleAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExitToggleAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,7 @@ public class ExitToggleAction extends BreakpointToggleAction {
 		Iterator<?> iter= selection.iterator();
 		while (iter.hasNext()) {
 			Object element = iter.next();
-			if (!(element instanceof IJavaMethodBreakpoint)) {
+			if (!(element instanceof IJavaMethodBreakpoint javaMethodBp && !javaMethodBp.isLambdaBreakpoint())) {
 				return false;
 			}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->


This PR will disable toggling Entry and Exit options for lambda breakpoints, enabling Exit in lambda will make debugger suspend at random lambdas




## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
