### PR TITLE
Remove invalid line breakpoints on non-breakpointable locations on Edit

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/BreakpointMarkerUpdater.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/BreakpointMarkerUpdater.java
@@ -137,7 +137,8 @@ public class BreakpointMarkerUpdater implements IMarkerUpdater {
 				return false;
 			}
 
-			if (loc.getLocationType() == ValidBreakpointLocationLocator.LOCATION_FIELD && breakpoint instanceof JavaLineBreakpoint) {
+			if (loc.getLocationType() == ValidBreakpointLocationLocator.LOCATION_FIELD && breakpoint instanceof JavaLineBreakpoint
+					&& !(breakpoint instanceof IJavaWatchpoint)) {
 				return false;
 			}
 			int line = loc.getLineLocation();


### PR DESCRIPTION
Java line breakpoints set on `LOCATION_FIELD` locations are not executable. This change removes such invalid breakpoints to prevent confusing markers in the editor and Breakpoints view.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/807



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
