### PR TITLE
Added generated jar files to gitignore

### DIFF
--- a/org.eclipse.jdt.debug.tests/.gitignore
+++ b/org.eclipse.jdt.debug.tests/.gitignore
@@ -1,0 +1,1 @@
+/javadebugtests.jar

--- a/org.eclipse.jdt.debug/.gitignore
+++ b/org.eclipse.jdt.debug/.gitignore
@@ -1,1 +1,2 @@
 /jdi-bin/
+/jdimodel.jar


### PR DESCRIPTION
These files are generated during SDK build and make the working tree dirty after the build:

```
git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        org.eclipse.jdt.debug.tests/javadebugtests.jar
        org.eclipse.jdt.debug/jdimodel.jar
```
