### PR TITLE
Fix conditional breakpoint Test failure

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/ConditionalBreakpointsWithFileClass.java
@@ -76,7 +76,9 @@ public class ConditionalBreakpointsWithFileClass extends AbstractDebugTest {
 			Thread.sleep(1000);
 			assertTrue("Thread should be suspended", mainThread.isSuspended());
 			hitLine = mainThread.getStackFrames()[0].getLineNumber();
-			if (JavaProjectHelper.isJava25_Compatible()) {
+			if (isJRE26plus) {
+				assertEquals("Didn't suspend at the expected line", 374, hitLine);
+			} else if (JavaProjectHelper.isJava25_Compatible()) {
 				assertEquals("Didn't suspend at the expected line", 369, hitLine);
 			} else {
 				assertEquals("Didn't suspend at the expected line", 364, hitLine);


### PR DESCRIPTION
This part was missed in  https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/827 
which caused new failure : _`Didn't suspend at the expected line expected:<369> but was:<374>`_  in https://download.eclipse.org/eclipse/downloads/drops4/Y20251211-1000/testresults/html/org.eclipse.jdt.debug.tests_ep439Y-unit-linux-x86_64-java26_linux.gtk.x86_64_26.html

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
