### PR TITLE
Cleanup : Use instanceof Pattern matching 

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AttachSourceAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/AttachSourceAction.java
@@ -68,8 +68,7 @@ public class AttachSourceAction extends RuntimeClasspathAction {
 		int i = 0;
 		while (iterator.hasNext()) {
 			Object selected= iterator.next();
-			if (selected instanceof IRuntimeClasspathEntry) {
-				IRuntimeClasspathEntry entry = (IRuntimeClasspathEntry)selected;
+			if (selected instanceof IRuntimeClasspathEntry entry) {
 				int type = entry.getType();
 				switch (type) {
 					case IRuntimeClasspathEntry.VARIABLE:

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EditClasspathEntryAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/EditClasspathEntryAction.java
@@ -89,8 +89,7 @@ public class EditClasspathEntryAction extends RuntimeClasspathAction {
 	protected boolean updateSelection(IStructuredSelection selection) {
 		if (selection.size() == 1) {
 			Object element = selection.getFirstElement();
-			if (element instanceof IRuntimeClasspathEntry) {
-				IRuntimeClasspathEntry entry = (IRuntimeClasspathEntry) element;
+			if (element instanceof IRuntimeClasspathEntry entry) {
 				IClasspathEditor editor = getEditor(entry);
 				if (editor != null) {
 					return editor.canEdit(fConfiguration, new IRuntimeClasspathEntry[]{((ClasspathEntry)entry).getDelegate()});
@@ -101,8 +100,7 @@ public class EditClasspathEntryAction extends RuntimeClasspathAction {
 	}
 
 	protected IClasspathEditor getEditor(IRuntimeClasspathEntry entry) {
-		if (entry instanceof IAdaptable) {
-			IAdaptable adaptable = (IAdaptable) entry;
+		if (entry instanceof IAdaptable adaptable) {
 			return adaptable.getAdapter(IClasspathEditor.class);
 		}
 		return null;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExcludeExceptionLocationAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ExcludeExceptionLocationAction.java
@@ -52,8 +52,7 @@ public class ExcludeExceptionLocationAction extends ObjectActionDelegate {
 				}
 				for (int i = 0; i < breakpoints.length; i++) {
 					IBreakpoint breakpoint = breakpoints[i];
-					if (breakpoint instanceof IJavaExceptionBreakpoint) {
-						IJavaExceptionBreakpoint exBreakpoint= (IJavaExceptionBreakpoint)breakpoint;
+					if (breakpoint instanceof IJavaExceptionBreakpoint exBreakpoint) {
 						String[] current= exBreakpoint.getExclusionFilters();
 						String[] newFilters= new String[current.length+1];
 						System.arraycopy(current, 0, newFilters, 0, current.length);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/InstanceFiltersAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/InstanceFiltersAction.java
@@ -128,12 +128,10 @@ public class InstanceFiltersAction extends ObjectActionDelegate {
 		}
 
 		Object o = selection.getFirstElement();
-		if (o instanceof IJavaVariable) {
-			final IJavaVariable var = (IJavaVariable)o;
+		if (o instanceof final IJavaVariable var) {
 			try {
 				IValue value = var.getValue();
-				if (value instanceof IJavaObject) {
-					final IJavaObject object = (IJavaObject)value;
+				if (value instanceof final IJavaObject object) {
 					final List<IJavaBreakpoint> breakpoints = getApplicableBreakpoints(var, object);
 					final IDebugModelPresentation modelPresentation= DebugUITools.newDebugModelPresentation();
 
@@ -238,12 +236,9 @@ public class InstanceFiltersAction extends ObjectActionDelegate {
 
 			IBreakpoint[] allBreakpoints = DebugPlugin.getDefault().getBreakpointManager().getBreakpoints();
 			for (int i = 0; i < allBreakpoints.length; i++) {
-				if (allBreakpoints[i] instanceof IJavaBreakpoint) {
-					IJavaBreakpoint jbp = (IJavaBreakpoint)allBreakpoints[i];
+				if (allBreakpoints[i] instanceof IJavaBreakpoint jbp) {
 					IJavaBreakpoint valid = null;
-					if (jbp instanceof IJavaWatchpoint && variable instanceof IJavaFieldVariable) {
-						IJavaWatchpoint wp = (IJavaWatchpoint)jbp;
-						IJavaFieldVariable fv = (IJavaFieldVariable)variable;
+					if (jbp instanceof IJavaWatchpoint wp && variable instanceof IJavaFieldVariable fv) {
 						if (variable.getName().equals(wp.getFieldName()) && fv.getDeclaringType().getName().equals(wp.getTypeName())) {
 							valid = wp;
 						}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaBreakpointPropertiesAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaBreakpointPropertiesAction.java
@@ -55,8 +55,7 @@ public class JavaBreakpointPropertiesAction implements IObjectActionDelegate {
 	 */
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss= (IStructuredSelection)selection;
+		if (selection instanceof IStructuredSelection ss) {
 			if (ss.isEmpty() || ss.size() > 1) {
 				return;
 			}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaObjectValueEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaObjectValueEditor.java
@@ -221,13 +221,11 @@ public class JavaObjectValueEditor implements IVariableValueEditor {
             return evaluationResult;
         }
         var value = evaluationResult.getValue();
-        if (value instanceof IJavaPrimitiveValue) {
-            var primValue = (IJavaPrimitiveValue) value;
+        if (value instanceof IJavaPrimitiveValue primValue) {
             if (variable instanceof IJavaVariable) {
                 try {
                     var type = ((IJavaVariable) variable).getJavaType();
-                    if (type instanceof IJavaClassType) {
-                        var classType = (IJavaClassType) type;
+                    if (type instanceof IJavaClassType classType) {
                         var javaDebug = thread.getDebugTarget().getAdapter(IJavaDebugTarget.class);
                         switch (classType.getName()) {
                             case "java.lang.Long": //$NON-NLS-1$
@@ -283,8 +281,7 @@ public class JavaObjectValueEditor implements IVariableValueEditor {
      * (copied from EvaluateAction)
      */
 	protected String getExceptionMessage(Throwable exception) {
-		if (exception instanceof CoreException) {
-			CoreException ce = (CoreException)exception;
+		if (exception instanceof CoreException ce) {
 			Throwable throwable= ce.getStatus().getException();
 			if (throwable instanceof com.sun.jdi.InvocationException) {
 				return getInvocationExceptionMessage((com.sun.jdi.InvocationException)throwable);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaVariableValueEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaVariableValueEditor.java
@@ -66,8 +66,7 @@ public class JavaVariableValueEditor implements IVariableValueEditor {
 		}
 
         // set the value of chars directly if expression is a single character (not an expression to evaluate)
-    	if (expression.length() == 1 && variable instanceof IJavaVariable){
-    		IJavaVariable javaVariable = (IJavaVariable)variable;
+    	if (expression.length() == 1 && variable instanceof IJavaVariable javaVariable){
     		try {
 				if (javaVariable.getJavaType() != null && javaVariable.getJavaType().getSignature() == Signature.SIG_CHAR){
 					javaVariable.setValue(expression);
@@ -87,8 +86,7 @@ public class JavaVariableValueEditor implements IVariableValueEditor {
 	 * @return {@code false} to prohibit editing a variable
 	 */
 	protected boolean isAllowedToModifyValue(IVariable variable) {
-		if (variable instanceof IJavaModifiers) {
-			IJavaModifiers modifiers = (IJavaModifiers) variable;
+		if (variable instanceof IJavaModifiers modifiers) {
 			boolean allowed = isAllowedToModifyFinalValue(modifiers);
 			if (!allowed) {
 				// prohibit editing a variable that is declared as final

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenDeclaringTypeAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenDeclaringTypeAction.java
@@ -29,8 +29,7 @@ public class OpenDeclaringTypeAction extends OpenStackFrameAction {
 	 */
 	@Override
 	protected IJavaType getTypeToOpen(IDebugElement element) throws CoreException {
-		if (element instanceof IJavaStackFrame) {
-			IJavaStackFrame frame = (IJavaStackFrame) element;
+		if (element instanceof IJavaStackFrame frame) {
 			return frame.getReferenceType();
 		}
 		return null;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenFromClipboardAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenFromClipboardAction.java
@@ -523,8 +523,7 @@ public class OpenFromClipboardAction implements IWorkbenchWindowActionDelegate {
 	private static void openJavaElements(Object[] elements, int line) {
 		for (int i = 0; i < elements.length; i++) {
 			Object ob = elements[i];
-			if (ob instanceof IJavaElement) {
-				IJavaElement element = (IJavaElement) ob;
+			if (ob instanceof IJavaElement element) {
 				try {
 					IEditorPart editorPart = JavaUI.openInEditor(element);
 					gotoLine(editorPart, line, element);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenReceivingTypeAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenReceivingTypeAction.java
@@ -30,8 +30,7 @@ public class OpenReceivingTypeAction extends OpenStackFrameAction {
 	 */
 	@Override
 	protected IJavaType getTypeToOpen(IDebugElement element) throws CoreException {
-		if (element instanceof IJavaStackFrame) {
-			IJavaStackFrame frame = (IJavaStackFrame) element;
+		if (element instanceof IJavaStackFrame frame) {
 			if (frame.isStatic()) {
 				return frame.getReferenceType();
 			}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableConcreteTypeAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableConcreteTypeAction.java
@@ -39,8 +39,7 @@ public class OpenVariableConcreteTypeAction extends OpenVariableTypeAction {
 	 */
 	@Override
 	protected IJavaType getTypeToOpen(IDebugElement element) throws CoreException {
-		if (element instanceof IJavaVariable) {
-			IJavaVariable variable = (IJavaVariable) element;
+		if (element instanceof IJavaVariable variable) {
 			return ((IJavaValue)variable.getValue()).getJavaType();
 		}
 		return null;
@@ -48,8 +47,7 @@ public class OpenVariableConcreteTypeAction extends OpenVariableTypeAction {
 
 	@Override
 	public boolean openElement(IAction action, Object element) throws DebugException, CoreException {
-		if (element instanceof JDIVariable) {
-			final var jdiVariable = (JDIVariable) element;
+		if (element instanceof final JDIVariable jdiVariable) {
 			if (isInterfaceType(jdiVariable)) {
 				final var val = (JDIObjectValue) jdiVariable.getValue();
 				if (val.getJavaType().toString().contains("$$Lambda$")) { //$NON-NLS-1$

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableDeclarationAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableDeclarationAction.java
@@ -29,8 +29,7 @@ public class OpenVariableDeclarationAction extends OpenVariableConcreteTypeActio
 
 	@Override
 	protected IJavaType getTypeToOpen(IDebugElement element) throws CoreException {
-		if (element instanceof IJavaFieldVariable) {
-			var variable = (IJavaFieldVariable) element;
+		if (element instanceof IJavaFieldVariable variable) {
 			return variable.getDeclaringType();
 		}
 		return null;
@@ -38,8 +37,7 @@ public class OpenVariableDeclarationAction extends OpenVariableConcreteTypeActio
 
 	@Override
 	protected void openInEditor(Object element, IType sourceElement) throws CoreException {
-		if (element instanceof JDIFieldVariable) {
-			var field = (JDIFieldVariable) element;
+		if (element instanceof JDIFieldVariable field) {
 			var fieldElement = sourceElement.getField(field.getName());
 			var editor = JavaUI.openInEditor(fieldElement);
 			if (editor != null) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableDeclaredTypeAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/OpenVariableDeclaredTypeAction.java
@@ -29,8 +29,7 @@ public class OpenVariableDeclaredTypeAction extends OpenVariableTypeAction {
 	 */
 	@Override
 	protected IJavaType getTypeToOpen(IDebugElement element) throws CoreException {
-		if (element instanceof IJavaVariable) {
-			IJavaVariable variable = (IJavaVariable) element;
+		if (element instanceof IJavaVariable variable) {
 			return variable.getJavaType();
 		}
 		return null;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/RunToLineAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/RunToLineAdapter.java
@@ -125,8 +125,7 @@ public class RunToLineAdapter implements IRunToLineTarget {
 
 	@Override
 	public boolean canRunToLine(IWorkbenchPart part, ISelection selection, ISuspendResume target) {
-	    if (target instanceof IDebugElement && target.canResume()) {
-            IDebugElement element = (IDebugElement) target;
+	    if (target instanceof IDebugElement element && target.canResume()) {
             IJavaDebugTarget adapter = element.getDebugTarget().getAdapter(IJavaDebugTarget.class);
             return adapter != null;
         }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/SetObjectLabelAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/SetObjectLabelAction.java
@@ -44,19 +44,16 @@ public class SetObjectLabelAction extends ObjectActionDelegate {
 		try {
 			String name;
 			IValue value;
-			if (element instanceof IJavaVariable) {
-				IJavaVariable variable = (IJavaVariable) element;
+			if (element instanceof IJavaVariable variable) {
 				name = variable.getName();
 				value = variable.getValue();
-			} else if (element instanceof JavaInspectExpression) {
-				JavaInspectExpression jie = (JavaInspectExpression) element;
+			} else if (element instanceof JavaInspectExpression jie) {
 				name = jie.getExpressionText();
 				value = jie.getValue();
 			} else {
 				return;
 			}
-			if (value instanceof IJavaObject) {
-				final IJavaObject javaValue = (IJavaObject) value;
+			if (value instanceof final IJavaObject javaValue) {
 				if (!javaValue.isNull()) {
 					askForLabel(javaValue, name);
 				}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ShowNullArrayEntriesAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ShowNullArrayEntriesAction.java
@@ -47,8 +47,7 @@ public class ShowNullArrayEntriesAction extends ViewFilterAction {
 			// when on, filter nothing
 			return true;
 		}
-		if (element instanceof JDIArrayEntryVariable) {
-			JDIArrayEntryVariable variable = (JDIArrayEntryVariable)element;
+		if (element instanceof JDIArrayEntryVariable variable) {
 			try {
 				return !variable.getValue().equals(((IJavaDebugTarget)variable.getDebugTarget()).nullValue());
 			} catch (DebugException e) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/StepIntoSelectionUtils.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/StepIntoSelectionUtils.java
@@ -107,10 +107,9 @@ public class StepIntoSelectionUtils {
 	 */
 	@SuppressWarnings("deprecation")
 	public static IMethod getFirstMethodOnLine(int offset, IEditorPart activeEditor, IJavaElement element) throws JavaModelException {
-		if (! (activeEditor instanceof ITextEditor) || ! (element instanceof ICodeAssist)) {
+		if (! (activeEditor instanceof ITextEditor editor) || ! (element instanceof ICodeAssist)) {
 			return null;
 		}
-		ITextEditor editor = (ITextEditor)activeEditor;
 		IDocumentProvider documentProvider = editor.getDocumentProvider();
 		if (documentProvider == null) {
 			return null;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/TerminateEvaluationAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/TerminateEvaluationAction.java
@@ -82,8 +82,7 @@ public class TerminateEvaluationAction implements IObjectActionDelegate, IDebugE
 
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss= (IStructuredSelection)selection;
+		if (selection instanceof IStructuredSelection ss) {
 			if (ss.isEmpty() || ss.size() > 1) {
 				return;
 			}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/WatchAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/WatchAction.java
@@ -35,8 +35,7 @@ public class WatchAction extends InspectAction {
 	@Override
 	public void run() {
 		Object selectedObject= getSelectedObject();
-		if (selectedObject instanceof IStructuredSelection) {
-			IStructuredSelection selection = (IStructuredSelection)selectedObject;
+		if (selectedObject instanceof IStructuredSelection selection) {
 			Iterator<IJavaVariable> elements = selection.iterator();
 			while (elements.hasNext()) {
 				try {


### PR DESCRIPTION
Use InstanceOf pattern matching in few classes in o.e.jdt.internal.debug.ui.actions

 -- Automated cleanup 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
