### PR TITLE
Remove stale breakpoint on toggling method entry / exit

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/ToggleBreakpointAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1676,7 +1676,11 @@ public class ToggleBreakpointAdapter implements IToggleBreakpointsTargetExtensio
 		if (loc.getLocationType() == ValidBreakpointLocationLocator.LOCATION_LAMBDA_METHOD) {
 			toggleLambdaMethodBreakpoints(part, ts, loc);
 		} else if (loc.getLocationType() == ValidBreakpointLocationLocator.LOCATION_METHOD) {
-			toggleMethodBreakpoints(part, ts);
+			if (breakpoint != null) { // Issue : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/836
+				deleteBreakpoint(breakpoint, part, null);
+			} else {
+				toggleMethodBreakpoints(part, ts);
+			}
 		} else if (loc.getLocationType() == ValidBreakpointLocationLocator.LOCATION_FIELD) {
 			if (BreakpointToggleUtils.isToggleTracepoint()) {
 				BreakpointToggleUtils.report(ActionMessages.TracepointToggleAction_Unavailable, part);


### PR DESCRIPTION
This commit fixes creation of method breakpoints if a stale breakpoint is present at the method entry or exit line and remove the stale breakpoint

fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/836

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
