### PR TITLE
Dispose Clipboard instance

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/CompareObjectWithClipboard.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/CompareObjectWithClipboard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation.
+ * Copyright (c) 2025, 2026 IBM Corporation.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -156,7 +156,11 @@ public class CompareObjectWithClipboard extends ObjectActionDelegate {
 	 */
 	private Object getClipboard() {
 		Clipboard clip = new Clipboard(Display.getDefault());
-		return clip.getContents(TextTransfer.getInstance());
+		try {
+			return clip.getContents(TextTransfer.getInstance());
+		} finally {
+			clip.dispose();
+		}
 	}
 
 }


### PR DESCRIPTION
This commit will make sure the Clipboard instance is disposed in Compare with Clipboard context

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
