### PR TITLE
IProblem.UninternedIdentityComparison should be suppressed while inspecting expressions during debugging #856

### DIFF
--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/EvaluationSourceGenerator.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/engine/EvaluationSourceGenerator.java
@@ -370,6 +370,8 @@ public class EvaluationSourceGenerator {
 			}
 		}
 		options.put(JavaCore.COMPILER_TASK_TAGS, ""); //$NON-NLS-1$
+		// We don't need this jdt.core developer specific comparison in debug mode - just disable it.
+		options.put("org.eclipse.jdt.core.compiler.problem.uninternedIdentityComparison", "disabled"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		toSupportedVersion(options, COMPILER_COMPLIANCE);
 		toSupportedVersion(options, COMPILER_CODEGEN_TARGET_PLATFORM);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #856

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
