### PR TITLE
Revert "Fix ModuleOptionsTests failure on macOS Java 21 (#853)"

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ModuleOptionsTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/ModuleOptionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2026 GK Software SE and others.
+ * Copyright (c) 2019, 2024 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -60,36 +59,6 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 			+ "jdk.management.jfr," //
 			+ "jdk.net," //
 			+ "jdk.nio.mapmode," //
-			+ "jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
-			+ "jdk.unsupported.desktop," //
-			+ "jdk.xml.dom";
-
-	private static final String ASSUMED_DEFAULT_MODULES_9_MAC_21 = "java.se," //
-			+ "jdk.accessibility,jdk.attach,jdk.compiler,jdk.dynalink,jdk.httpserver," //
-			+ "jdk.jartool,jdk.javadoc,jdk.jconsole,jdk.jdi," //
-			+ "jdk.jfr," //
-			+ "jdk.jshell,jdk.jsobject,jdk.management," //
-			+ "jdk.management.jfr," //
-			+ "jdk.naming.ldap," //
-			+ "jdk.net," //
-			+ "jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
-			+ "jdk.scripting.nashorn," //
-			+ "jdk.unsupported.desktop," //
-			+ "jdk.xml.dom";
-
-	private static final String ASSUMED_DEFAULT_MODULES_21_MAC = "java.base," //
-			+ "java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging," //
-			+ "java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi," //
-			+ "java.scripting,java.security.jgss,java.security.sasl,java.smartcardio," //
-			+ "java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto," //
-			+ "jdk.accessibility,jdk.attach,jdk.compiler,jdk.dynalink,jdk.httpserver," //
-			+ "jdk.jartool,jdk.javadoc,jdk.jconsole,jdk.jdi," //
-			+ "jdk.jfr," //
-			+ "jdk.jshell,jdk.jsobject,jdk.management," //
-			+ "jdk.management.jfr," //
-			+ "jdk.naming.ldap," //
-			+ "jdk.net," //
-			+ "jdk.scripting.nashorn," //
 			+ "jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
 			+ "jdk.unsupported.desktop," //
 			+ "jdk.xml.dom";
@@ -173,11 +142,6 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 			List<String> defaultModules = getDefaultModules(javaProject);
 			String expectedModules;
 			String moduleList = String.join(",", defaultModules);
-			if (Platform.OS.isMac() && Runtime.version().feature() == 21) {
-				assertEquals(ASSUMED_DEFAULT_MODULES_9_MAC_21, moduleList);
-			} else {
-				assertEquals(ASSUMED_DEFAULT_MODULES_9, moduleList);
-			}
 			assertEquals(ASSUMED_DEFAULT_MODULES_9, moduleList);
 			switch (moduleList) {
 				case ASSUMED_DEFAULT_MODULES_9:
@@ -189,16 +153,10 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 							+ "jdk.net," //
 							+ "jdk.nio.mapmode," //
 							// + "jdk.packager,jdk.packager.services,jdk.plugin.dom,"
-							// + "jdk.scripting.nashorn,"
+							// + "jdk.scripting.nashorn," 
 							+ "jdk.sctp,"
 							+ "jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
 							+ "jdk.unsupported.desktop,jdk.xml.dom";
-					break;
-				case ASSUMED_DEFAULT_MODULES_9_MAC_21:
-					expectedModules = "java.instrument,java.net.http,java.scripting,java.sql.rowset,java.xml.crypto,"
-							+ "jdk.accessibility,jdk.dynalink,jdk.httpserver," + "jdk.jartool,jdk.jconsole,jdk.jshell," + "jdk.management.jfr,"
-							+ "jdk.naming.ldap," + "jdk.net," + "jdk.sctp," + "jdk.security.auth,jdk.security.jgss,jdk.unsupported,"
-							+ "jdk.scripting.nashorn," + "jdk.unsupported.desktop,jdk.xml.dom";
 					break;
 				default:
 					fail("Unknown set of default modules " + moduleList);
@@ -241,12 +199,6 @@ public class ModuleOptionsTests extends AbstractDebugTest {
 						+ "jdk.security.auth,jdk.security.jgss,jdk.unsupported," //
 						+ "jdk.unsupported.desktop," //
 						+ "jdk.xml.dom";
-				break;
-			case ASSUMED_DEFAULT_MODULES_21_MAC:
-				expectedModules = "java.instrument,java.net.http,java.scripting,java.smartcardio,java.sql.rowset,java.xml.crypto,"
-						+ "jdk.accessibility," + "jdk.dynalink," + "jdk.httpserver," + "jdk.jartool,jdk.jconsole,jdk.jshell," + "jdk.jsobject,"
-						+ "jdk.management.jfr," + "jdk.naming.ldap," + "jdk.net," + "jdk.scripting.nashorn," + "jdk.sctp,"
-						+ "jdk.security.auth,jdk.security.jgss,jdk.unsupported," + "jdk.unsupported.desktop," + "jdk.xml.dom";
 				break;
 			default:
 				fail("Unknown set of default modules " + moduleList);


### PR DESCRIPTION
This reverts commit b3f12298cb11952d93f0fde69e58da70826ba352.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
