### PR TITLE
Update Lambda breakpoint message label

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
@@ -474,4 +474,6 @@ public class DebugUIMessages extends NLS {
 
 	public static String ListSameElementsFor2;
 	public static String fExceptionBreakpointMsg;
+
+	protected static String JavaDebugOptionsManager_Lambda_Breakpoint;
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -297,6 +297,7 @@ JDIModelPresentation_no_suspended_threads=[toString() unavailable - no suspended
 
 JavaDebugOptionsManager_Breakpoint___1=Breakpoint:
 JavaDebugOptionsManager_Method_breakpoint___2=Method breakpoint:
+JavaDebugOptionsManager_Lambda_Breakpoint=Lambda Breakpoint:
 JavaDebugOptionsManager_Watchpoint___3=Watchpoint:
 JavaDebugOptionsManager_0=Initialize Java Debug Options
 JavaDebugOptionsManager_exceptionRecurrence_dialogTitle=Repeated exception occurrence

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugOptionsManager.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JavaDebugOptionsManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -878,7 +878,13 @@ public class JavaDebugOptionsManager implements IDebugEventSetListener, IPropert
 					if (breakpoint instanceof IJavaBreakpoint) {
 						String info = fLabelProvider.getText(breakpoint);
 						String type = DebugUIMessages.JavaDebugOptionsManager_Breakpoint___1;
-						if (breakpoint instanceof IJavaMethodBreakpoint || breakpoint instanceof IJavaMethodEntryBreakpoint) {
+						if (breakpoint instanceof IJavaMethodBreakpoint javaMBp) {
+							if (javaMBp.isLambdaBreakpoint()) {
+								type = DebugUIMessages.JavaDebugOptionsManager_Lambda_Breakpoint;
+							} else {
+								type = DebugUIMessages.JavaDebugOptionsManager_Method_breakpoint___2;
+							}
+						} else if (breakpoint instanceof IJavaMethodEntryBreakpoint) {
 							type = DebugUIMessages.JavaDebugOptionsManager_Method_breakpoint___2;
 						} else if (breakpoint instanceof IJavaWatchpoint) {
 							type = DebugUIMessages.JavaDebugOptionsManager_Watchpoint___3;


### PR DESCRIPTION
This commit updates label for lambda breakpoints on annotation hover.

<img width="1084" height="146" alt="image" src="https://github.com/user-attachments/assets/46c2255f-ae99-436f-afae-485ac31990d8" />

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/861

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
