### PR TITLE
Extend DetectVMInstallationsJob to consider JAVA.*_HOME environment-variables

### DIFF
--- a/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
+++ b/org.eclipse.jdt.launching/launching/org/eclipse/jdt/internal/launching/DetectVMInstallationsJob.java
@@ -169,9 +169,9 @@ public class DetectVMInstallationsJob extends Job {
 		if (jdkHome != null) {
 			directories.add(new File(jdkHome));
 		}
-		System.getenv().entrySet().forEach(entry -> {
-			if (entry.getKey().startsWith("JAVA_HOME_")) { //$NON-NLS-1$
-				directories.add(new File(entry.getValue()));
+		System.getenv().forEach((key, value) -> {
+			if (key.startsWith("JAVA_HOME_") || (key.startsWith("JAVA") && key.endsWith("_HOME"))) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				directories.add(new File(value));
 			}
 		});
 		// other common/standard lookup strategies can be added here


### PR DESCRIPTION
## What it does

Extend DetectVMInstallationsJob to consider `JAVA.*_HOME` environment-variables
This matches the behavior of the `maven-toolchains-plugin`:

https://github.com/apache/maven-toolchains-plugin/blob/1f2ca233a1048e32b9efad8c32f9e613ee013ba1/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java#L141-L142

This was discussed in
- https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/843#issuecomment-3928326958

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
