### PR TITLE
Remove single-quote in debug preference

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2024 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -357,7 +357,7 @@ JavaDebugPreferencePage_SuspendOnRecurrencePolicy_Always=Always
 JavaDebugPreferencePage_SuspendOnRecurrencePolicy_Unconfigured=Unconfigured
 JavaDebugPreferencePage_SuspendOnRecurrencePolicy_OnlyOnce=Only once
 JavaDebugPreferencePage_promptWhenDeletingCondidtionalBreakpoint=&Prompt for confirmation when deleting a conditional breakpoint from editor
-JavaDebugPreferencePage_0=See <a>''{0}''</a> for general debug settings.
+JavaDebugPreferencePage_0=See <a>{0}</a> for general debug settings.
 JavaDebugPreferencePage_advancedSourcelookup=Use &advanced source lookup (JRE 1.5 and higher)  
 JavaDebugPreferencePage_listenToThreadNameChanges=L&isten to thread name changes
 JavaDebugPreferencePage_only_include_exported_entries=Onl&y include exported classpath entries when launching


### PR DESCRIPTION
This commit will remove unwanted singlequote used in Run/Debug hyperlink in debug preference

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
