### PR TITLE
Enable multi-status dialog when message exceeds threshold

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.java
@@ -146,6 +146,8 @@ public class DebugUIMessages extends NLS {
     public static String JDIDebugUIPlugin_4;
 	public static String JDIDebugUIPlugin_5;
 
+	public static String JDIDebugUIPlugin_MultiStatusError;
+
 	public static String JDIModelPresentation__No_explicit_return_value__30;
 	public static String JDIModelPresentation__conditional__2;
 	public static String JDIModelPresentation___may_be_out_of_synch__2;
@@ -478,4 +480,8 @@ public class DebugUIMessages extends NLS {
 	public static String fExceptionBreakpointMsg;
 
 	protected static String JavaDebugOptionsManager_Lambda_Breakpoint;
+
+	public static String JDIDebugUIPlugin_MultiStatusWarning;
+
+	public static String JDIDebugUIPlugin_MultiStatusInfo;
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/DebugUIMessages.properties
@@ -90,6 +90,9 @@ JDIDebugUIPlugin_The_target_VM_does_not_support_hot_code_replace_1=The target VM
 JDIDebugUIPlugin_3=Do not show error &when hot code replace is not supported
 JDIDebugUIPlugin_0=Warning
 JDIDebugUIPlugin_5=Ignore errors in current session
+JDIDebugUIPlugin_MultiStatusError=Multiple errors occurred
+JDIDebugUIPlugin_MultiStatusWarning=There are multiple warnings
+JDIDebugUIPlugin_MultiStatusInfo=There are multiple informational messages
 
 JDIModelPresentation__No_explicit_return_value__30=(No explicit return value)
 JDIModelPresentation__conditional__2=[conditional]

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIDebugUIPlugin.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIDebugUIPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -89,6 +90,7 @@ import org.eclipse.jface.preference.PreferenceManager;
 import org.eclipse.jface.preference.PreferenceNode;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.window.Window;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -138,6 +140,8 @@ public class JDIDebugUIPlugin extends AbstractUIPlugin {
 	private IDebugModelPresentation fUtilPresentation;
 
 	private StackFrameCategorizer stackFrameCategorizer;
+
+	private static final int STATUS_LINE_LIMIT = 10;
 
 	/**
 	 * Java Debug UI listeners
@@ -276,19 +280,46 @@ public class JDIDebugUIPlugin extends AbstractUIPlugin {
 			break;
 		}
 	}
+
 	public static void statusDialog(String title, IStatus status) {
 		Shell shell = getActiveWorkbenchShell();
+		String message = status.getMessage();
+		long currentLines = message.lines().limit(STATUS_LINE_LIMIT + 1).count();
+		boolean showInMulti = currentLines > STATUS_LINE_LIMIT;
+		String pluginId = status.getPlugin();
+		if (pluginId == null) {
+			JDIDebugUIPlugin plugin = getDefault();
+			pluginId = (plugin != null && JDIDebugUIPlugin.getUniqueIdentifier() != null) ? JDIDebugUIPlugin.getUniqueIdentifier()
+					: JDIDebugUIPlugin.class.getName();
+		}
+
 		if (shell != null) {
 			switch (status.getSeverity()) {
-			case IStatus.ERROR:
-				ErrorDialog.openError(shell, title, null, status);
-				break;
-			case IStatus.WARNING:
-				MessageDialog.openWarning(shell, title, status.getMessage());
-				break;
-			case IStatus.INFO:
-				MessageDialog.openInformation(shell, title, status.getMessage());
-				break;
+				case IStatus.ERROR:
+					if (showInMulti) {
+						status = new MultiStatus(pluginId, status.getCode(), new IStatus[] {
+								status }, NLS.bind(DebugUIMessages.JDIDebugUIPlugin_MultiStatusError, title.toLowerCase()), null);
+					} else {
+						ErrorDialog.openError(shell, title, null, status);
+					}
+					break;
+				case IStatus.WARNING:
+					if (showInMulti) {
+						status = new MultiStatus(pluginId, status.getCode(), new IStatus[] {
+								status }, NLS.bind(DebugUIMessages.JDIDebugUIPlugin_MultiStatusWarning, title.toLowerCase()), null);
+						ErrorDialog.openError(shell, title, null, status);
+					} else {
+						MessageDialog.openWarning(shell, title, status.getMessage());
+					}
+					break;
+				case IStatus.INFO:
+					if (showInMulti) {
+						status = new MultiStatus(pluginId, status.getCode(), new IStatus[] {
+								status }, NLS.bind(DebugUIMessages.JDIDebugUIPlugin_MultiStatusInfo, title.toLowerCase()), null);
+						ErrorDialog.openError(shell, title, null, status);
+					} else {
+						MessageDialog.openInformation(shell, title, status.getMessage());
+					}
 			}
 		}
 	}


### PR DESCRIPTION
Improve the Status Dialog by enabling a multi-status when the no. status message lines exceeds a predefined line threshold. This enhances readability.

**_Steps to check_**
1. Select an int variable in the variables view
2. Paste a long multiline string in the detail pane 
3. Save it (cmd+s)

**Current**

A huge error dialog will open, but not a scrollable one, so users can't see every messages
<img width="1067" height="8011" alt="image" src="https://github.com/user-attachments/assets/131472bb-875d-4c5e-93e5-6666f8ec690f" />

**With change**
A minimilistic (Multi-status)  dialog will open which lets user to see all errors by scrolling
<img width="943" height="420" alt="image" src="https://github.com/user-attachments/assets/49898593-4476-4ce8-9fa9-4a5b9874eaa0" />

![Scroll](https://github.com/user-attachments/assets/83f7b13e-14c1-4d79-9042-82f07c826837)


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
