### PR TITLE
Avoid ClassCastException when casting to EvaluationResult

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaObjectValueEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/JavaObjectValueEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -167,12 +167,13 @@ public class JavaObjectValueEditor implements IVariableValueEditor {
                 IEvaluationListener listener= new IEvaluationListener() {
                     @Override
                     public void evaluationComplete(IEvaluationResult result) {
-                        var convertedResult = convert((EvaluationResult) result, variable, thread);
-
-                        synchronized (JavaObjectValueEditor.this) {
-                            results[0] = convertedResult;
-                            JavaObjectValueEditor.this.notifyAll();
-                        }
+						if (result instanceof EvaluationResult evalResult) {
+							var convertedResult = convert(evalResult, variable, thread);
+							synchronized (JavaObjectValueEditor.this) {
+								results[0] = convertedResult;
+								JavaObjectValueEditor.this.notifyAll();
+							}
+						}
                     }
                 };
     			synchronized(this) {


### PR DESCRIPTION
Add a type check before casting the evaluation result to EvaluationResult in JavaObjectValueEditor to prevent a potential ClassCastException when other evaluation engines return different result types.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/910

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
