### PR TITLE
Remove java.lang.Thread#stop() reference in javadoc

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/IJavaThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/debug/core/IJavaThread.java
@@ -271,7 +271,6 @@ public interface IJavaThread extends IThread, IFilteredStep {
 	 * @exception DebugException
 	 *                if the request fails
 	 * @since 3.0
-	 * @see java.lang.Thread#stop() // From Java 26 onwards this method is removed
 	 */
 	public void stop(IJavaObject exception) throws DebugException;
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.




Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
FIx Build issues
see https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/906/checks?check_run_id=66721520230


<img width="1700" height="327" alt="image" src="https://github.com/user-attachments/assets/a61c1885-a227-4e3f-9e4e-955cfca476ec" />
## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
