### PR TITLE
Fix invalid Javadoc tag for IProblem

### DIFF
--- a/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/InstructionSequence.java
+++ b/org.eclipse.jdt.debug/eval/org/eclipse/jdt/internal/debug/eval/ast/instructions/InstructionSequence.java
@@ -151,7 +151,7 @@ public class InstructionSequence implements ICompiledExpression {
 	}
 
 	/**
-	 * Adds the <code>IProblem<code> id of the error.
+	 * Adds the <code>IProblem</code> id of the error.
 	 */
 	public void addProblemID(int probID) {
 		fProblemIDs.add(probID);


### PR DESCRIPTION
Correct malformed Javadoc tag by properly closing <code\> for IProblem. This resolves Javadoc CI issues.
see https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/912#issuecomment-4071808499
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
