### PR TITLE
Disable VMDisconnectEventTest.testJDIVMDeath for Java 26

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMDisconnectEventTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMDisconnectEventTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -75,6 +75,9 @@ public class VMDisconnectEventTest extends AbstractJDITest {
 	 * Test that we received the event.
 	 */
 	public void testJDIVMDeath() {
+		if (Runtime.version().feature() == 26) {
+			return;
+		}
 		assertTrue("Should trigger VMDisconnectEvent or VMDeathEvent", fVMDisconnectEvent instanceof VMDeathEvent
 				|| fVMDisconnectEvent instanceof VMDisconnectEvent);
 	}


### PR DESCRIPTION
Disable VMDisconnectEventTest.testJDIVMDeath as it fails consistently on java 26
see https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/781#issuecomment-4081097575

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
