### PR TITLE
Fix Debug Hover showing SuperClass Field's value in Subclass Field

### DIFF
--- a/org.eclipse.jdt.debug.tests/java8/SubClass.java
+++ b/org.eclipse.jdt.debug.tests/java8/SubClass.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 IBM Corporation.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+public class SubClass extends SuperClass {
+    private boolean fInitialized;
+
+    public SubClass() {
+        fInitialized = false;
+        System.out.println("SubClass constructor");
+    }
+
+    public static void main(String[] args) {
+        new SubClass();
+    }
+}

--- a/org.eclipse.jdt.debug.tests/java8/SuperClass.java
+++ b/org.eclipse.jdt.debug.tests/java8/SuperClass.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 IBM Corporation.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+public class SuperClass {
+    private boolean fInitialized = true;
+
+    public SuperClass() {
+        
+    }
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -552,6 +552,8 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 				cfgs.add(createLaunchConfiguration(jp, "GH275"));
 				cfgs.add(createLaunchConfiguration(jp, "LambdaTest"));
 				cfgs.add(createLaunchConfiguration(jp, "InnerClassBug"));
+				cfgs.add(createLaunchConfiguration(jp, "SuperClass"));
+				cfgs.add(createLaunchConfiguration(jp, "SubClass"));
 	    		loaded18 = true;
 	    		waitForBuild();
 	        }

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/DebugHoverTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/ui/DebugHoverTests.java
@@ -1559,4 +1559,39 @@ public class DebugHoverTests extends AbstractDebugUiTests {
 		}
 	}
 
+	public void testResolveSameFieldsInSuperAndSub() throws Exception {
+		sync(() -> TestUtil.waitForJobs(getName(), 1000, 10000, ProcessConsole.class));
+
+		final String typeName = "SubClass";
+		final String expectedMethod = "<init>";
+		final int framesNumber = 2;
+		final int bpLine1 = 18;
+
+		IJavaBreakpoint bp1 = createLineBreakpoint(bpLine1, "", typeName + ".java", typeName);
+		bp1.setSuspendPolicy(IJavaBreakpoint.SUSPEND_THREAD);
+		IFile file = (IFile) bp1.getMarker().getResource();
+		assertEquals(typeName + ".java", file.getName());
+
+		IJavaThread thread = null;
+		try {
+			thread = launchToBreakpoint(typeName);
+			CompilationUnitEditor part = openEditorAndValidateStack(expectedMethod, framesNumber, file, thread);
+
+			JavaDebugHover hover = new JavaDebugHover();
+			hover.setEditor(part);
+			int offset = part.getViewer().getDocument().get().indexOf("fInitialized = ");
+			String variableName = "fInitialized";
+			IRegion region = new Region(offset, variableName.length());
+			String text = selectAndReveal(part, bpLine1, region);
+			assertEquals(variableName, text);
+			IVariable info = (IVariable) sync(() -> hover.getHoverInfo2(part.getViewer(), region));
+			assertNotNull(info);
+			assertEquals(variableName, info.getName());
+			assertEquals("false", info.getValue().getValueString());
+		} finally {
+			terminateAndRemove(thread);
+			removeAllBreakpoints();
+		}
+	}
+
 }

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIObjectValue.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIObjectValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -276,6 +276,17 @@ public class JDIObjectValue extends JDIValue implements IJavaObject {
 					if (declaringTypeSignature.equals(signature)) {
 						field = fieldTmp;
 						break;
+					}
+					List<Field> fieldList = ref.allFields(); // Possible sub class fields with same name as of super class
+					fieldList.remove(fieldTmp);
+					for (Field fieldCurrentTmp : fieldList) {
+						if (name.equals(fieldCurrentTmp.name())) {
+							String signatureCurrent = fieldCurrentTmp.declaringType().signature();
+							if (declaringTypeSignature.equals(signatureCurrent)) {
+								field = fieldCurrentTmp;
+								break main;
+							}
+						}
 					}
 					// check if we are inside local type - Signature.createTypeSignature
 					// can't create proper type name out of source field in JavaDebugHover


### PR DESCRIPTION
This commit adds an additional computation for finding the subclass class field if superclass has same field as of subclass

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/924

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
