### PR TITLE
Fix CME issue on JDIObjectValue

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIObjectValue.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIObjectValue.java
@@ -277,7 +277,7 @@ public class JDIObjectValue extends JDIValue implements IJavaObject {
 						field = fieldTmp;
 						break;
 					}
-					List<Field> fieldList = ref.allFields(); // Possible sub class fields with same name as of super class
+					List<Field> fieldList = new ArrayList<>(ref.allFields()); // Possible sub class fields with same name as of super class
 					fieldList.remove(fieldTmp);
 					for (Field fieldCurrentTmp : fieldList) {
 						if (name.equals(fieldCurrentTmp.name())) {


### PR DESCRIPTION
Avoid modifying list returned by allFields() by creating a defensive copy before removal. This prevents potential concurrent modification issues and unintended side effects on JDI data.

handles : https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/930#discussion_r3063514179
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
