### PR TITLE
Allow overriding JDIThread StepHandler and StepOverHandler

### DIFF
--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -2420,7 +2420,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	/**
 	 * Helper class to perform stepping an a thread.
 	 */
-	abstract class StepHandler implements IJDIEventListener {
+	protected abstract class StepHandler implements IJDIEventListener {
 		/**
 		 * Request for stepping in the underlying VM
 		 */
@@ -3176,7 +3176,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	/**
 	 * Handler for step over requests.
 	 */
-	class StepOverHandler extends StepHandler {
+	protected class StepOverHandler extends StepHandler {
 
 		@Override
 		protected int getStepKind() {


### PR DESCRIPTION
Make package protected `JDIThread.StepHandler` and `JDIThread.StepOverHandler` classes protected for same reason it was done for the three other step handler classes via
https://bugs.eclipse.org/bugs/show_bug.cgi?id=470200 / b6d7767 - allow derived debugger implementations override few Java debugger classes with access to **all** step handler classes.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/936
