### PR TITLE
Retry launching in AbstractDebugTest on BindException

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AbstractDebugTest.java
@@ -19,6 +19,7 @@ package org.eclipse.jdt.debug.tests;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -177,6 +178,7 @@ import junit.framework.TestCase;
 @SuppressWarnings("deprecation")
 public abstract class AbstractDebugTest extends TestCase implements  IEvaluationListener {
 
+	private static final int SOCKET_BIND_ERROR_MAX_RETRIES = 3;
 	private static boolean setupFirstTest = false;
 
 	public static final String MULTI_OUTPUT_PROJECT_NAME = "MultiOutput";
@@ -1490,13 +1492,7 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 	 *             if the event is never received.
 	 */
 	protected Object launchAndWait(ILaunchConfiguration configuration, String mode, DebugEventWaiter waiter, boolean register) throws CoreException {
-		ILaunch launch;
-		try {
-			launch = configuration.launch(mode, new TimeoutMonitor(DEFAULT_TIMEOUT), false, register);
-		} catch (Throwable t) {
-			logProcessConsoleContents();
-			throw t;
-		}
+		ILaunch launch = launchConfig(configuration, mode, register);
 		Object suspendee= waiter.waitForEvent();
 		if (suspendee == null) {
 			StringBuilder buf = new StringBuilder();
@@ -1538,8 +1534,6 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		}
 		return suspendee;
 	}
-
-
 
 	/**
 	 * Launches the type with the given name, and waits for a
@@ -3222,6 +3216,28 @@ public abstract class AbstractDebugTest extends TestCase implements  IEvaluation
 		String detailed = message + " " + vm.getName() + ", location: " + vm.getInstallLocation();
 		IStatus status = new Status(IStatus.INFO, JDIDebugPlugin.getUniqueIdentifier(), detailed, null);
 		JDIDebugPlugin.log(status);
+	}
+
+	private static ILaunch launchConfig(ILaunchConfiguration configuration, String mode, boolean register) throws CoreException {
+		ILaunch launch = null;
+		for (int retry = 1; retry <= SOCKET_BIND_ERROR_MAX_RETRIES; ++retry) {
+			try {
+				launch = configuration.launch(mode, new TimeoutMonitor(DEFAULT_TIMEOUT), false, register);
+				break;
+			} catch (CoreException e) {
+				Throwable cause = e.getStatus().getException();
+				if (retry < SOCKET_BIND_ERROR_MAX_RETRIES && cause instanceof BindException) {
+					// port might be in use between checking for a free port and launching, try a few times
+					DebugPlugin.log(Status.error("Could not bind socket for debugging, retry: " + retry, e));
+				} else {
+					throw e;
+				}
+			} catch (Throwable t) {
+				logProcessConsoleContents();
+				throw t;
+			}
+		}
+		return launch;
 	}
 
 	private static void logProcessConsoleContents() {


### PR DESCRIPTION
Debug tests infrequently run into:
```
java.net.BindException: Address already in use
```
This can occur when the chosen debug port is in use. The port is chosen in `StandardVMDebugger.getCommandLine()`, delegating to `SocketUtil.findFreePort()`:
```
try (ServerSocket socket = new ServerSocket(0)) {
    return socket.getLocalPort();
}
```
Which can result in the socket being in use, at the time of the launch.

This change adds 3 retries to the launch, in case of `BindException`.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/940