### PR TITLE
Stop using Color constructors with Display

### DIFF
--- a/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/TestMessageConsoleActionDelegate.java
+++ b/org.eclipse.jdt.debug.tests/console tests/org/eclipse/jdt/debug/tests/console/TestMessageConsoleActionDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.ColorDialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IActionDelegate2;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -77,7 +76,7 @@ public class TestMessageConsoleActionDelegate implements IActionDelegate2, IWork
 		stream.println("two.... three....");
 		ColorDialog dialog = new ColorDialog(DebugUIPlugin.getShell());
 		dialog.open();
-		Color color = new Color(Display.getCurrent(), dialog.getRGB());
+		Color color = new Color(dialog.getRGB());
 		stream.setColor(color);
 	}
 

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/detailpane/SimpleDetailPane.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/detailpane/SimpleDetailPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2015 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -76,24 +76,24 @@ public class SimpleDetailPane implements IDetailPane {
 	private Color getColor(int typeId){
 		if (typeId == TYPE_PRIVATE){
 			if (colorPrivate == null || colorPrivate.isDisposed()){
-				colorPrivate = new Color(theLabel.getDisplay(),255,0,0);
+				colorPrivate = new Color(255, 0, 0);
 			}
 			return colorPrivate;
 		}
 		if (typeId == TYPE_PROTECTED){
 			if (colorProtected == null || colorProtected.isDisposed()){
-				colorProtected = new Color(theLabel.getDisplay(),0,0,255);
+				colorProtected = new Color(0, 0, 255);
 			}
 			return colorProtected;
 		}
 		if (typeId == TYPE_PUBLIC){
 			if (colorPublic == null || colorPublic.isDisposed()){
-				colorPublic = new Color(theLabel.getDisplay(),0,255,0);
+				colorPublic = new Color(0, 255, 0);
 			}
 			return colorPublic;
 		}
 		if (colorOther == null || colorOther.isDisposed()){
-			colorOther = new Color(theLabel.getDisplay(),0,0,0);
+			colorOther = new Color(0, 0, 0);
 		}
 		return colorOther;
 	}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDISourceViewer.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDISourceViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,6 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 
 /**
@@ -166,15 +165,13 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 		IPreferenceStore store= getPreferenceStore();
 		if (store != null) {
 			StyledText styledText= getTextWidget();
-			Color color= store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT)
-				? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND, styledText.getDisplay());
+			Color color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT) ? null
+					: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND);
 			styledText.setForeground(color);
 			setForegroundColor(color);
 
-			color= store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT)
-				? null
-				: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND, styledText.getDisplay());
+			color = store.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT) ? null
+					: createColor(store, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND);
 			styledText.setBackground(color);
 			setBackgroundColor(color);
 		}
@@ -184,7 +181,7 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 	 * Creates a color from the information stored in the given preference store.
 	 * Returns <code>null</code> if there is no such information available.
 	 */
-	private Color createColor(IPreferenceStore store, String key, Display display) {
+	private Color createColor(IPreferenceStore store, String key) {
 		RGB rgb= null;
 		if (store.contains(key)) {
 			if (store.isDefault(key)) {
@@ -193,7 +190,7 @@ public class JDISourceViewer extends SourceViewer implements IPropertyChangeList
 				rgb= PreferenceConverter.getColor(store, key);
 			}
 			if (rgb != null) {
-				return new Color(display, rgb);
+				return new Color(rgb);
 			}
 		}
 		return null;


### PR DESCRIPTION
Simplifies the code and reduces chances for problems. Contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/pull/3233 .

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
