### PR TITLE
Cleanup: Use instanceof pattern matching

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaJRETab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaJRETab.java
@@ -326,8 +326,7 @@ public class JavaJRETab extends JavaLaunchTab {
 				vm = JavaRuntime.getVMInstall(vmPath);
 			}
 			String environmentId = JavaRuntime.getExecutionEnvironmentId(vmPath);
-			if(vm instanceof AbstractVMInstall) {
-				AbstractVMInstall install = (AbstractVMInstall) vm;
+			if(vm instanceof AbstractVMInstall install) {
 				String vmver = install.getJavaVersion();
 				if(vmver != null) {
 					int val = JavaCore.compareJavaVersions(compliance, vmver);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaLaunchShortcut.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaLaunchShortcut.java
@@ -289,8 +289,7 @@ public abstract class JavaLaunchShortcut implements ILaunchShortcut2 {
 
 	@Override
 	public IResource getLaunchableResource(ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection ss) {
 			if (ss.size() == 1) {
 				Object element = ss.getFirstElement();
 				if (element instanceof IAdaptable) {

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIElementImageDescriptor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIElementImageDescriptor.java
@@ -73,10 +73,9 @@ public class JDIElementImageDescriptor extends CompositeImageDescriptor {
 	 */
 	@Override
 	public boolean equals(Object object) {
-		if (!(object instanceof JDIElementImageDescriptor)) {
+		if (!(object instanceof JDIElementImageDescriptor other)) {
 			return false;
 		}
-		JDIElementImageDescriptor other = (JDIElementImageDescriptor) object;
 		return (fBaseImage.equals(other.fBaseImage) && fFlags == other.fFlags);
 	}
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIImageDescriptor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIImageDescriptor.java
@@ -99,11 +99,10 @@ public class JDIImageDescriptor extends CompositeImageDescriptor {
 	 */
 	@Override
 	public boolean equals(Object object) {
-		if (!(object instanceof JDIImageDescriptor)){
+		if (!(object instanceof JDIImageDescriptor other)){
 			return false;
 		}
 
-		JDIImageDescriptor other= (JDIImageDescriptor)object;
 		return (getBaseImage().equals(other.getBaseImage()) && getFlags() == other.getFlags());
 	}
 

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java
@@ -401,8 +401,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 					if (exName != null) {
 						args = new String[] { thread.getName(), exName };
 					}
-				} else if (breakpoint instanceof IJavaWatchpoint) {
-					IJavaWatchpoint wp = (IJavaWatchpoint)breakpoint;
+				} else if (breakpoint instanceof IJavaWatchpoint wp) {
 					String fieldName = wp.getFieldName();
 					args = new String[] {thread.getName(), fieldName, typeName};
 					if (wp.isAccessSuspend(thread.getDebugTarget())) {
@@ -410,8 +409,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 					} else {
 						key.append("_fieldmodification"); //$NON-NLS-1$
 					}
-				} else if (breakpoint instanceof IJavaMethodBreakpoint) {
-					IJavaMethodBreakpoint me= (IJavaMethodBreakpoint)breakpoint;
+				} else if (breakpoint instanceof IJavaMethodBreakpoint me) {
 					String methodName= me.getMethodName();
 					args = new String[] {thread.getName(), methodName, typeName};
 					if (me.isEntrySuspend(thread.getDebugTarget())) {
@@ -419,8 +417,7 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 					} else {
 						key.append("_methodexit"); //$NON-NLS-1$
 					}
-				} else if (breakpoint instanceof IJavaLineBreakpoint) {
-					IJavaLineBreakpoint jlbp = (IJavaLineBreakpoint)breakpoint;
+				} else if (breakpoint instanceof IJavaLineBreakpoint jlbp) {
 					int lineNumber= jlbp.getLineNumber();
 					if (lineNumber > -1) {
 						args = new String[] {thread.getName(), String.valueOf(lineNumber), typeName};
@@ -1021,9 +1018,8 @@ public class JDIModelPresentation extends LabelProvider implements IDebugModelPr
 	 */
 	private int computeJDIAdornmentFlags(Object element) {
 		try {
-			if (element instanceof IJavaThread) {
+			if (element instanceof IJavaThread javaThread) {
 				int flag= 0;
-				IJavaThread javaThread = ((IJavaThread)element);
 				if (ThreadMonitorManager.getDefault().isInDeadlock(javaThread)) {
 					flag= JDIImageDescriptor.IN_DEADLOCK;
 				}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/LambdaUtils.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/LambdaUtils.java
@@ -98,10 +98,9 @@ public class LambdaUtils extends org.eclipse.jdt.internal.debug.core.model.Lambd
 	}
 
 	private static List<String> getArgumentTypeNames(IJavaElement parent) throws CoreException {
-		if (!(parent instanceof IMethod)) {
+		if (!(parent instanceof IMethod method)) {
 			return null;
 		}
-		IMethod method = (IMethod) parent;
 		IType type = method.getDeclaringType();
 		if (type == null) {
 			return null;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/MemberActionFilter.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/MemberActionFilter.java
@@ -39,8 +39,7 @@ public class MemberActionFilter implements IActionFilter {
 	@Override
 	public boolean testAttribute(Object target, String name, String value) {
 		if (name.equals("MemberActionFilter")) { //$NON-NLS-1$
-			if (target instanceof IMember) {
-				IMember member = (IMember) target;
+			if (target instanceof IMember member) {
 				if (value.equals("isRemote")) { //$NON-NLS-1$
 					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 					if(window != null) {
@@ -95,8 +94,7 @@ public class MemberActionFilter implements IActionFilter {
 					IAdaptable adapt = DebugUITools.getDebugContext();
 					if(adapt != null) {
 						IDebugTarget adapter = adapt.getAdapter(IDebugTarget.class);
-						if(adapter instanceof IJavaDebugTarget) {
-							IJavaDebugTarget dtarget = (IJavaDebugTarget) adapter;
+						if(adapter instanceof IJavaDebugTarget dtarget) {
 							return dtarget.supportsInstanceRetrieval();
 						}
 					}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaExceptionHyperLink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaExceptionHyperLink.java
@@ -67,8 +67,7 @@ public class JavaExceptionHyperLink extends JavaStackTraceHyperlink {
 			IBreakpoint[] breakpoints = DebugPlugin.getDefault().getBreakpointManager().getBreakpoints(JDIDebugModel.getPluginIdentifier());
 			for (int i = 0; i < breakpoints.length; i++) {
 				IBreakpoint breakpoint = breakpoints[i];
-				if (breakpoint instanceof IJavaExceptionBreakpoint) {
-					IJavaExceptionBreakpoint exceptionBreakpoint = (IJavaExceptionBreakpoint) breakpoint;
+				if (breakpoint instanceof IJavaExceptionBreakpoint exceptionBreakpoint) {
 					if (fExceptionName.equals(exceptionBreakpoint.getTypeName())) {
 						// reset enabled setting to true but save original value to reset if user cancels dialog
 						exceptionBreakpoint.getMarker().setAttribute(JavaBreakpointPage.ATTR_ENABLED_SETTING_ON_CANCEL, Boolean.toString(exceptionBreakpoint.isEnabled()));

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsPreferencePage.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/JREsPreferencePage.java
@@ -199,8 +199,7 @@ public class JREsPreferencePage extends PreferencePage implements IWorkbenchPref
 		else {
 			String latest = JavaCore.getAllJavaSourceVersionsSupportedByCompiler().last();
 			String vmver = null;
-			if (vmInstall instanceof AbstractVMInstall) {
-				AbstractVMInstall vm = (AbstractVMInstall) vmInstall;
+			if (vmInstall instanceof AbstractVMInstall vm) {
 				vmver = vm.getJavaVersion();
 			}
 			if (vmver == null) {
@@ -255,8 +254,7 @@ public class JREsPreferencePage extends PreferencePage implements IWorkbenchPref
 	 * @since 3.3
 	 */
 	private boolean supportsCurrentCompliance(IVMInstall vm, String compliance) {
-		if(vm instanceof AbstractVMInstall) {
-			AbstractVMInstall install = (AbstractVMInstall) vm;
+		if(vm instanceof AbstractVMInstall install) {
 			String vmver = install.getJavaVersion();
 			if(vmver == null) {
 				vmver = getVersionFromRealVM(vm);

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryContentProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryContentProvider.java
@@ -117,8 +117,7 @@ public class LibraryContentProvider implements ITreeContentProvider {
 	 */
 	@Override
 	public Object[] getChildren(Object parentElement) {
-		if (parentElement instanceof LibraryStandin) {
-			LibraryStandin standin= (LibraryStandin) parentElement;
+		if (parentElement instanceof LibraryStandin standin) {
 			Object[] children= fChildren.get(standin);
 			if (children == null) {
 				children = new Object[] { new SubElement(standin, SubElement.SOURCE_PATH), new SubElement(standin, SubElement.JAVADOC_URL),

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryLabelProvider.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryLabelProvider.java
@@ -44,8 +44,7 @@ public class LibraryLabelProvider extends LabelProvider {
 	public Image getImage(Object element) {
 		String key = null;
 		IStatus status = Status.OK_STATUS;
-		if (element instanceof LibraryStandin) {
-			LibraryStandin library= (LibraryStandin) element;
+		if (element instanceof LibraryStandin library) {
 			IPath sourcePath= library.getSystemLibrarySourcePath();
 			if (sourcePath != null && !Path.EMPTY.equals(sourcePath)) {
                 key = ISharedImages.IMG_OBJS_EXTERNAL_ARCHIVE_WITH_SOURCE;
@@ -88,8 +87,7 @@ public class LibraryLabelProvider extends LabelProvider {
 	public String getText(Object element) {
 		if (element instanceof LibraryStandin) {
 			return ((LibraryStandin)element).getSystemLibraryPath().toOSString();
-		} else if (element instanceof SubElement) {
-			SubElement subElement= (SubElement) element;
+		} else if (element instanceof SubElement subElement) {
 			StringBuilder text= new StringBuilder();
 			switch (subElement.getType()) {
 			case SubElement.SOURCE_PATH:

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryStandin.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/jres/LibraryStandin.java
@@ -108,8 +108,7 @@ public final class LibraryStandin {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof LibraryStandin) {
-			LibraryStandin lib = (LibraryStandin)obj;
+		if (obj instanceof LibraryStandin lib) {
 			return getSystemLibraryPath().equals(lib.getSystemLibraryPath())
 				&& equals(getSystemLibrarySourcePath(), lib.getSystemLibrarySourcePath())
 				&& equals(getPackageRootPath(), lib.getPackageRootPath())

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/search/LaunchConfigurationQueryParticipant.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/search/LaunchConfigurationQueryParticipant.java
@@ -96,11 +96,9 @@ public class LaunchConfigurationQueryParticipant implements IQueryParticipant {
 		SubMonitor subMon = SubMonitor.convert(monitor, 8);
 		try {
 			Pattern pattern = null;
-			if (query instanceof ElementQuerySpecification) {
-				ElementQuerySpecification elementQuery = (ElementQuerySpecification) query;
+			if (query instanceof ElementQuerySpecification elementQuery) {
 				IJavaElement element = elementQuery.getElement();
-				if(element instanceof IMember) {
-					IMember member = (IMember) element;
+				if(element instanceof IMember member) {
 					IType type = null;
 					if(member.getElementType() == IJavaElement.TYPE) {
 						type = (IType) member;
@@ -121,8 +119,7 @@ public class LaunchConfigurationQueryParticipant implements IQueryParticipant {
 					return;
 				}
 			}
-			if (query instanceof PatternQuerySpecification) {
-				PatternQuerySpecification patternQuery = (PatternQuerySpecification) query;
+			if (query instanceof PatternQuerySpecification patternQuery) {
 				int flags = patternQuery.isCaseSensitive() ? 0
 						: Pattern.CASE_INSENSITIVE;
 				String quotedPattern = quotePattern(patternQuery.getPattern());
@@ -197,8 +194,7 @@ public class LaunchConfigurationQueryParticipant implements IQueryParticipant {
 			IJavaElement element = ((ElementQuerySpecification) query).getElement();
 			return element.getElementType() == IJavaElement.TYPE || element.getElementType() == IJavaElement.METHOD;
 		}
-		if (query instanceof PatternQuerySpecification) {
-			PatternQuerySpecification patternQuery = (PatternQuerySpecification) query;
+		if (query instanceof PatternQuerySpecification patternQuery) {
 			switch (patternQuery.getSearchFor()) {
 				case IJavaSearchConstants.UNKNOWN:
 				case IJavaSearchConstants.TYPE:

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableColumnPresentationFactory.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableColumnPresentationFactory.java
@@ -50,8 +50,7 @@ public class JavaVariableColumnPresentationFactory implements IColumnPresentatio
 	private boolean isApplicable(IPresentationContext context, Object element) {
 		IJavaStackFrame frame = null;
 		if (IDebugUIConstants.ID_VARIABLE_VIEW.equals(context.getId())) {
-			if (element instanceof IAdaptable) {
-				IAdaptable adaptable = (IAdaptable)element;
+			if (element instanceof IAdaptable adaptable) {
 				frame = adaptable.getAdapter(IJavaStackFrame.class);
 			}
 		}

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableEditor.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/variables/JavaVariableEditor.java
@@ -42,8 +42,7 @@ public class JavaVariableEditor extends VariableEditor {
 	 */
 	@Override
 	public CellEditor getCellEditor(IPresentationContext context, String columnId, Object element, Composite parent) {
-		if (element instanceof IJavaVariable) {
-			IJavaVariable var = (IJavaVariable) element;
+		if (element instanceof IJavaVariable var) {
 			if (JavaVariableCellModifier.isBoolean(var)) {
 				return new ComboBoxCellEditor(parent, new String[]{Boolean.toString(true), Boolean.toString(false)}, SWT.READ_ONLY);
 			}


### PR DESCRIPTION
use java 16 instaceof pattern matching by automatic code clean-up in JDT Debug.ui packages.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
