### PR TITLE
Disable "Stop in Main" checkbox in Run configuration

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaMainTab.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/debug/ui/launchConfigurations/JavaMainTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.internal.ui.SWTFactory;
+import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
@@ -105,8 +107,11 @@ public class JavaMainTab extends SharedJavaMainTab {
 		fConsiderInheritedMainButton = SWTFactory.createCheckButton(parent, LauncherMessages.JavaMainTab_22, null, false, 2);
 		fConsiderInheritedMainButton.addSelectionListener(getDefaultListener());
 
-		fStopInMainCheckButton = SWTFactory.createCheckButton(parent, LauncherMessages.JavaMainTab_St_op_in_main_1, null, false, 1);
-		fStopInMainCheckButton.addSelectionListener(getDefaultListener());
+		ILaunchConfigurationDialog dialog = getLaunchConfigurationDialog();
+		if (dialog != null && ILaunchManager.DEBUG_MODE.equals(dialog.getMode())) {
+			fStopInMainCheckButton = SWTFactory.createCheckButton(parent, LauncherMessages.JavaMainTab_Suspend_In_Main, null, false, 1);
+			fStopInMainCheckButton.addSelectionListener(getDefaultListener());
+		}
 	}
 
 	@Override
@@ -231,7 +236,7 @@ public class JavaMainTab extends SharedJavaMainTab {
 		mapResources(config);
 
 		// attribute added in 2.1, so null must be used instead of false for backwards compatibility
-		if (fStopInMainCheckButton.getSelection()) {
+		if (fStopInMainCheckButton != null && fStopInMainCheckButton.getSelection()) {
 			config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, true);
 		}
 		else {
@@ -315,7 +320,9 @@ public class JavaMainTab extends SharedJavaMainTab {
 			stop = config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, false);
 		}
 		catch (CoreException e) {JDIDebugUIPlugin.log(e);}
-		fStopInMainCheckButton.setSelection(stop);
+		if (fStopInMainCheckButton != null) {
+			fStopInMainCheckButton.setSelection(stop);
+		}
 	}
 
 }

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/LauncherMessages.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/LauncherMessages.java
@@ -87,7 +87,7 @@ public class LauncherMessages extends NLS {
 	public static String JavaMainTab_E_xt__jars_6;
 	public static String JavaMainTab_Main_cla_ss__4;
 	public static String JavaMainTab_Main_type_not_specified_16;
-	public static String JavaMainTab_St_op_in_main_1;
+	public static String JavaMainTab_Suspend_In_Main;
 	public static String JavaMainTab_19;
 	public static String JavaMainTab_20;
 	public static String JavaMainTab_21;

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/LauncherMessages.properties
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/launcher/LauncherMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2000, 2022 IBM Corporation and others.
+#  Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -78,7 +78,7 @@ JavaMainTab__Main_19=Main
 JavaMainTab_E_xt__jars_6=Includ&e system libraries when searching for a main class
 JavaMainTab_Main_cla_ss__4=&Main class:
 JavaMainTab_Main_type_not_specified_16=Main type not specified
-JavaMainTab_St_op_in_main_1=St&op in main
+JavaMainTab_Suspend_In_Main=Suspend in main
 JavaMainTab_19=Illegal project name: {0}
 JavaMainTab_20=Project {0} does not exist
 JavaMainTab_21=Project {0} is closed


### PR DESCRIPTION
This PR just disables the "Stop in Main" option in side Run configuration only as it is not relevant in run config and rename the option to "Suspend in Main"

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/934

Before:
<img width="600" height="300" alt="Screenshot 2026-04-23 at 9 49 00 AM" src="https://github.com/user-attachments/assets/5f734abe-9f33-4737-81eb-92e14607a002" />

After:
<img width="600" height="300" alt="Screenshot 2026-04-23 at 9 48 45 AM" src="https://github.com/user-attachments/assets/e042b21c-ae2c-4cc7-b900-001e44c66eea" />


