### PR TITLE
Refactor ObjectComparison to utility class

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/variables/CompareObjectsTest.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/variables/CompareObjectsTest.java
@@ -13,6 +13,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.debug.tests.variables;
 
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.arrayElementsExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareCustomObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareSelectedLists;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareSelectedMaps;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.customObjectValueExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.listElementsExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.mapElementsExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.objectValueExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.setElementsExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.stringCompare;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -26,15 +37,11 @@ import org.eclipse.jdt.debug.core.IJavaThread;
 import org.eclipse.jdt.debug.core.IJavaValue;
 import org.eclipse.jdt.debug.core.IJavaVariable;
 import org.eclipse.jdt.debug.tests.AbstractDebugTest;
-import org.eclipse.jdt.internal.debug.ui.ObjectComparison;
 
 public class CompareObjectsTest extends AbstractDebugTest {
 
-	private ObjectComparison objectComparision;
-
 	public CompareObjectsTest(String name) {
 		super(name);
-		objectComparision = new ObjectComparison();
 	}
 
 	@Override
@@ -68,38 +75,38 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable s9 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[10];
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(s1, objectComparision.objectValueExtraction((IJavaValue) s1.getValue()));
-			result.put(s2, objectComparision.objectValueExtraction((IJavaValue) s2.getValue()));
-			result = objectComparision.stringCompare(result);
+			result.put(s1, objectValueExtraction((IJavaValue) s1.getValue()));
+			result.put(s2, objectValueExtraction((IJavaValue) s2.getValue()));
+			result = stringCompare(result);
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(s1);
 			assertThat(compareResult.get("ImmediateResult"), containsString("Same"));
 			result.clear();
 
-			result.put(s3, objectComparision.objectValueExtraction((IJavaValue) s3.getValue()));
-			result.put(s4, objectComparision.objectValueExtraction((IJavaValue) s4.getValue()));
-			result = objectComparision.stringCompare(result);
+			result.put(s3, objectValueExtraction((IJavaValue) s3.getValue()));
+			result.put(s4, objectValueExtraction((IJavaValue) s4.getValue()));
+			result = stringCompare(result);
 			compareResult = (Map<String, String>) result.get(s3);
 			assertThat(compareResult.get("ImmediateResult"), containsString("Different"));
 			result.clear();
 
-			result.put(s5, objectComparision.objectValueExtraction((IJavaValue) s5.getValue()));
-			result.put(s6, objectComparision.objectValueExtraction((IJavaValue) s6.getValue()));
-			result = objectComparision.stringCompare(result);
+			result.put(s5, objectValueExtraction((IJavaValue) s5.getValue()));
+			result.put(s6, objectValueExtraction((IJavaValue) s6.getValue()));
+			result = stringCompare(result);
 			compareResult = (Map<String, String>) result.get(s5);
 			assertThat(compareResult.get("ImmediateResult"), containsString("Same"));
 			result.clear();
 
-			result.put(s7, objectComparision.objectValueExtraction((IJavaValue) s7.getValue()));
-			result.put(s8, objectComparision.objectValueExtraction((IJavaValue) s8.getValue()));
-			result = objectComparision.stringCompare(result);
+			result.put(s7, objectValueExtraction((IJavaValue) s7.getValue()));
+			result.put(s8, objectValueExtraction((IJavaValue) s8.getValue()));
+			result = stringCompare(result);
 			compareResult = (Map<String, String>) result.get(s8);
 			assertThat(compareResult.get("ImmediateResult"), containsString("Same"));
 			result.clear();
 
-			result.put(s1, objectComparision.objectValueExtraction((IJavaValue) s1.getValue()));
-			result.put(s9, objectComparision.objectValueExtraction((IJavaValue) s9.getValue()));
-			result = objectComparision.stringCompare(result);
+			result.put(s1, objectValueExtraction((IJavaValue) s1.getValue()));
+			result.put(s9, objectValueExtraction((IJavaValue) s9.getValue()));
+			result = stringCompare(result);
 			compareResult = (Map<String, String>) result.get(s9);
 			assertThat(compareResult.get("ImmediateResult"), containsString("Different"));
 			result.clear();
@@ -137,38 +144,38 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable linkedList = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[11];
 
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(s1, objectComparision.listElementsExtraction((IJavaObject) s1.getValue()));
-			result.put(s2, objectComparision.listElementsExtraction((IJavaObject) s2.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Lists");
+			result.put(s1, listElementsExtraction((IJavaObject) s1.getValue()));
+			result.put(s2, listElementsExtraction((IJavaObject) s2.getValue()));
+			result = compareSelectedLists(result, "Lists");
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(s1);
 			String resultValue = compareResult.get("ImmediateResult");
 			assertEquals("Lists contain same elements as in s2, but in different order", resultValue);
 			result.clear();
 
-			result.put(s3, objectComparision.listElementsExtraction((IJavaObject) s3.getValue()));
-			result.put(s4, objectComparision.listElementsExtraction((IJavaObject) s4.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Lists");
+			result.put(s3, listElementsExtraction((IJavaObject) s3.getValue()));
+			result.put(s4, listElementsExtraction((IJavaObject) s4.getValue()));
+			result = compareSelectedLists(result, "Lists");
 			compareResult = (Map<String, String>) result.get(s3);
 			Object o = compareResult.get("Values");
 			resultValue = o.toString();
 			assertEquals("Element is actually missing - [apple1]", "[apple1]",resultValue);
 			result.clear();
 
-			result.put(s5, objectComparision.listElementsExtraction((IJavaObject) s5.getValue()));
-			result.put(s6, objectComparision.listElementsExtraction((IJavaObject) s6.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Lists");
+			result.put(s5, listElementsExtraction((IJavaObject) s5.getValue()));
+			result.put(s6, listElementsExtraction((IJavaObject) s6.getValue()));
+			result = compareSelectedLists(result, "Lists");
 			compareResult = (Map<String, String>) result.get(s6);
 			o = compareResult.get("Values");
 			resultValue = o.toString();
 			assertEquals("Element is actually missing - [22]","[22]" ,resultValue );
 			result.clear();
 
-			result.put(stack, objectComparision.listElementsExtraction((IJavaObject) stack.getValue()));
-			result.put(arrayList, objectComparision.listElementsExtraction((IJavaObject) arrayList.getValue()));
-			result.put(vector, objectComparision.listElementsExtraction((IJavaObject) vector.getValue()));
-			result.put(linkedList, objectComparision.listElementsExtraction((IJavaObject) linkedList.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Lists");
+			result.put(stack, listElementsExtraction((IJavaObject) stack.getValue()));
+			result.put(arrayList, listElementsExtraction((IJavaObject) arrayList.getValue()));
+			result.put(vector, listElementsExtraction((IJavaObject) vector.getValue()));
+			result.put(linkedList, listElementsExtraction((IJavaObject) linkedList.getValue()));
+			result = compareSelectedLists(result, "Lists");
 			compareResult = (Map<String, String>) result.get(stack);
 			o = compareResult.get("ImmediateResult");
 			resultValue = o.toString();
@@ -209,9 +216,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable map1 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[2];
 			IJavaVariable map2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[3];
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(map1, objectComparision.mapElementsExtraction(map1));
-			result.put(map2, objectComparision.mapElementsExtraction(map2));
-			result = objectComparision.compareSelectedMaps(result);
+			result.put(map1, mapElementsExtraction(map1));
+			result.put(map2, mapElementsExtraction(map2));
+			result = compareSelectedMaps(result);
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(map1);
 			Object o = compareResult.get("valSameInfo");
@@ -224,9 +231,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable map3 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[4];
 			IJavaVariable map4 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[5];
-			result.put(map3, objectComparision.mapElementsExtraction(map3));
-			result.put(map4, objectComparision.mapElementsExtraction(map4));
-			result = objectComparision.compareSelectedMaps(result);
+			result.put(map3, mapElementsExtraction(map3));
+			result.put(map4, mapElementsExtraction(map4));
+			result = compareSelectedMaps(result);
 			compareResult = (Map<String, String>) result.get(map3);
 			o = compareResult.get("valSameInfo");
 			resultValue = o.toString();
@@ -238,9 +245,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable map5 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[6];
 			IJavaVariable map6 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[7];
-			result.put(map5, objectComparision.mapElementsExtraction(map5));
-			result.put(map6, objectComparision.mapElementsExtraction(map6));
-			result = objectComparision.compareSelectedMaps(result);
+			result.put(map5, mapElementsExtraction(map5));
+			result.put(map6, mapElementsExtraction(map6));
+			result = compareSelectedMaps(result);
 			compareResult = (Map<String, String>) result.get(map6);
 			o = compareResult.get("MapValues");
 			resultValue = o.toString();
@@ -252,9 +259,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable map7 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[8];
 			IJavaVariable map8 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[9];
-			result.put(map7, objectComparision.mapElementsExtraction(map7));
-			result.put(map8, objectComparision.mapElementsExtraction(map8));
-			result = objectComparision.compareSelectedMaps(result);
+			result.put(map7, mapElementsExtraction(map7));
+			result.put(map8, mapElementsExtraction(map8));
+			result = compareSelectedMaps(result);
 			compareResult = (Map<String, String>) result.get(map7);
 			o = compareResult.get("MapValues");
 			resultValue = o.toString();
@@ -264,15 +271,15 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			assertEquals("[key2]", resultKey);
 			result.clear();
 
-			result.put(map1, objectComparision.mapElementsExtraction(map1));
-			result.put(map2, objectComparision.mapElementsExtraction(map2));
-			result.put(map3, objectComparision.mapElementsExtraction(map3));
-			result.put(map4, objectComparision.mapElementsExtraction(map4));
-			result.put(map5, objectComparision.mapElementsExtraction(map5));
-			result.put(map6, objectComparision.mapElementsExtraction(map6));
-			result.put(map7, objectComparision.mapElementsExtraction(map7));
-			result.put(map8, objectComparision.mapElementsExtraction(map8));
-			result = objectComparision.compareSelectedMaps(result);
+			result.put(map1, mapElementsExtraction(map1));
+			result.put(map2, mapElementsExtraction(map2));
+			result.put(map3, mapElementsExtraction(map3));
+			result.put(map4, mapElementsExtraction(map4));
+			result.put(map5, mapElementsExtraction(map5));
+			result.put(map6, mapElementsExtraction(map6));
+			result.put(map7, mapElementsExtraction(map7));
+			result.put(map8, mapElementsExtraction(map8));
+			result = compareSelectedMaps(result);
 			compareResult = (Map<String, String>) result.get(map7);
 			o = compareResult.get("MultiMapValues");
 			resultValue = o.toString();
@@ -311,9 +318,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable s2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[3];
 
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(s1, objectComparision.setElementsExtraction((IJavaObject) s1.getValue()));
-			result.put(s2, objectComparision.setElementsExtraction((IJavaObject) s2.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Sets");
+			result.put(s1, setElementsExtraction((IJavaObject) s1.getValue()));
+			result.put(s2, setElementsExtraction((IJavaObject) s2.getValue()));
+			result = compareSelectedLists(result, "Sets");
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(s1);
 			Object o = compareResult.get("Values");
@@ -323,9 +330,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable s3 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[4];
 			IJavaVariable s4 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[5];
-			result.put(s3, objectComparision.setElementsExtraction((IJavaObject) s3.getValue()));
-			result.put(s4, objectComparision.setElementsExtraction((IJavaObject) s4.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Sets");
+			result.put(s3, setElementsExtraction((IJavaObject) s3.getValue()));
+			result.put(s4, setElementsExtraction((IJavaObject) s4.getValue()));
+			result = compareSelectedLists(result, "Sets");
 			compareResult = (Map<String, String>) result.get(s3);
 			o = compareResult.get("ImmediateResult");
 			resultValue = o.toString();
@@ -334,9 +341,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable linkedHashS1 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[6];
 			IJavaVariable linkedHashS2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[7];
-			result.put(linkedHashS1, objectComparision.setElementsExtraction((IJavaObject) linkedHashS1.getValue()));
-			result.put(linkedHashS2, objectComparision.setElementsExtraction((IJavaObject) linkedHashS2.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Sets");
+			result.put(linkedHashS1, setElementsExtraction((IJavaObject) linkedHashS1.getValue()));
+			result.put(linkedHashS2, setElementsExtraction((IJavaObject) linkedHashS2.getValue()));
+			result = compareSelectedLists(result, "Sets");
 			compareResult = (Map<String, String>) result.get(linkedHashS2);
 			o = compareResult.get("Values");
 			resultValue = o.toString();
@@ -345,24 +352,24 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable copyWr1 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[8];
 			IJavaVariable copyWr2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[9];
-			result.put(copyWr1, objectComparision.setElementsExtraction((IJavaObject) copyWr1.getValue()));
-			result.put(copyWr2, objectComparision.setElementsExtraction((IJavaObject) copyWr2.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Sets");
+			result.put(copyWr1, setElementsExtraction((IJavaObject) copyWr1.getValue()));
+			result.put(copyWr2, setElementsExtraction((IJavaObject) copyWr2.getValue()));
+			result = compareSelectedLists(result, "Sets");
 			compareResult = (Map<String, String>) result.get(copyWr1);
 			o = compareResult.get("ImmediateResult");
 			resultValue = o.toString();
 			assertEquals("Sets same as of xx2", resultValue);
 			result.clear();
 
-			result.put(s1, objectComparision.setElementsExtraction((IJavaObject) s1.getValue()));
-			result.put(s2, objectComparision.setElementsExtraction((IJavaObject) s2.getValue()));
-			result.put(linkedHashS1, objectComparision.setElementsExtraction((IJavaObject) linkedHashS1.getValue()));
-			result.put(linkedHashS2, objectComparision.setElementsExtraction((IJavaObject) linkedHashS2.getValue()));
-			result.put(copyWr1, objectComparision.setElementsExtraction((IJavaObject) copyWr1.getValue()));
-			result.put(copyWr2, objectComparision.setElementsExtraction((IJavaObject) copyWr2.getValue()));
-			result.put(s3, objectComparision.setElementsExtraction((IJavaObject) s3.getValue()));
-			result.put(s4, objectComparision.setElementsExtraction((IJavaObject) s4.getValue()));
-			result = objectComparision.compareSelectedLists(result, "Sets");
+			result.put(s1, setElementsExtraction((IJavaObject) s1.getValue()));
+			result.put(s2, setElementsExtraction((IJavaObject) s2.getValue()));
+			result.put(linkedHashS1, setElementsExtraction((IJavaObject) linkedHashS1.getValue()));
+			result.put(linkedHashS2, setElementsExtraction((IJavaObject) linkedHashS2.getValue()));
+			result.put(copyWr1, setElementsExtraction((IJavaObject) copyWr1.getValue()));
+			result.put(copyWr2, setElementsExtraction((IJavaObject) copyWr2.getValue()));
+			result.put(s3, setElementsExtraction((IJavaObject) s3.getValue()));
+			result.put(s4, setElementsExtraction((IJavaObject) s4.getValue()));
+			result = compareSelectedLists(result, "Sets");
 			compareResult = (Map<String, String>) result.get(copyWr1);
 			o = compareResult.get("MultiValues");
 			resultValue = o.toString();
@@ -392,9 +399,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable s2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[3];
 
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(s1, objectComparision.arrayElementsExtraction(s1));
-			result.put(s2, objectComparision.arrayElementsExtraction(s2));
-			result = objectComparision.compareSelectedLists(result, "Arrays");
+			result.put(s1, arrayElementsExtraction(s1));
+			result.put(s2, arrayElementsExtraction(s2));
+			result = compareSelectedLists(result, "Arrays");
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(s1);
 			Object o = compareResult.get("ImmediateResult");
@@ -404,20 +411,20 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable s3 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[4];
 			IJavaVariable s4 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[5];
-			result.put(s3, objectComparision.arrayElementsExtraction(s3));
-			result.put(s4, objectComparision.arrayElementsExtraction(s4));
-			result = objectComparision.compareSelectedLists(result, "Arrays");
+			result.put(s3, arrayElementsExtraction(s3));
+			result.put(s4, arrayElementsExtraction(s4));
+			result = compareSelectedLists(result, "Arrays");
 			compareResult = (Map<String, String>) result.get(s4);
 			o = compareResult.get("Values");
 			resultValue = o.toString();
 			assertEquals("[1]", resultValue);
 			result.clear();
 
-			result.put(s1, objectComparision.arrayElementsExtraction(s1));
-			result.put(s2, objectComparision.arrayElementsExtraction(s2));
-			result.put(s3, objectComparision.arrayElementsExtraction(s3));
-			result.put(s4, objectComparision.arrayElementsExtraction(s4));
-			result = objectComparision.compareSelectedLists(result, "Arrays");
+			result.put(s1, arrayElementsExtraction(s1));
+			result.put(s2, arrayElementsExtraction(s2));
+			result.put(s3, arrayElementsExtraction(s3));
+			result.put(s4, arrayElementsExtraction(s4));
+			result = compareSelectedLists(result, "Arrays");
 			compareResult = (Map<String, String>) result.get(s3);
 			o = compareResult.get("MultiValues");
 			resultValue = o.toString();
@@ -447,9 +454,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable wrap2 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[6];
 
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(wrap1, objectComparision.objectValueExtraction((IJavaValue) wrap1.getValue()));
-			result.put(wrap2, objectComparision.objectValueExtraction((IJavaValue) wrap2.getValue()));
-			result = objectComparision.compareObjects(result);
+			result.put(wrap1, objectValueExtraction((IJavaValue) wrap1.getValue()));
+			result.put(wrap2, objectValueExtraction((IJavaValue) wrap2.getValue()));
+			result = compareObjects(result);
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(wrap1);
 			Object o = compareResult.get("ImmediateResult");
@@ -459,9 +466,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 
 			IJavaVariable wrap3 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[7];
 			IJavaVariable wrap4 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[8];
-			result.put(wrap3, objectComparision.objectValueExtraction((IJavaValue) wrap3.getValue()));
-			result.put(wrap4, objectComparision.objectValueExtraction((IJavaValue) wrap4.getValue()));
-			result = objectComparision.compareObjects(result);
+			result.put(wrap3, objectValueExtraction((IJavaValue) wrap3.getValue()));
+			result.put(wrap4, objectValueExtraction((IJavaValue) wrap4.getValue()));
+			result = compareObjects(result);
 			compareResult = (Map<String, String>) result.get(wrap4);
 			o = compareResult.get("ImmediateResult");
 			resultValue = o.toString();
@@ -491,9 +498,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			IJavaVariable wrap3 = (IJavaVariable) mainThread.getTopStackFrame().getVariables()[4];
 
 			Map<IJavaVariable, Object> result = new HashMap<>();
-			result.put(wrap1, objectComparision.customObjectValueExtraction((IJavaObject) wrap1.getValue()));
-			result.put(wrap2, objectComparision.customObjectValueExtraction((IJavaObject) wrap2.getValue()));
-			result = objectComparision.compareCustomObjects(result);
+			result.put(wrap1, customObjectValueExtraction((IJavaObject) wrap1.getValue()));
+			result.put(wrap2, customObjectValueExtraction((IJavaObject) wrap2.getValue()));
+			result = compareCustomObjects(result);
 			Map<String, String> compareResult = new HashMap<>();
 			compareResult = (Map<String, String>) result.get(wrap1);
 			Object o = compareResult.get("fields");
@@ -505,9 +512,9 @@ public class CompareObjectsTest extends AbstractDebugTest {
 			assertEquals("{custom=Different in [a1]}", resultValue);
 			result.clear();
 
-			result.put(wrap1, objectComparision.customObjectValueExtraction((IJavaObject) wrap1.getValue()));
-			result.put(wrap3, objectComparision.customObjectValueExtraction((IJavaObject) wrap3.getValue()));
-			result = objectComparision.compareCustomObjects(result);
+			result.put(wrap1, customObjectValueExtraction((IJavaObject) wrap1.getValue()));
+			result.put(wrap3, customObjectValueExtraction((IJavaObject) wrap3.getValue()));
+			result = compareCustomObjects(result);
 			compareResult = (Map<String, String>) result.get(wrap1);
 			o = compareResult.get("fields");
 			resultValue = o.toString();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ObjectComparison.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/ObjectComparison.java
@@ -35,10 +35,10 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.osgi.util.NLS;
 
 /**
- * Class to provides methods to extract and compare Java Collections, Java Types and Custom Types
+ * Helper class to provides methods to extract and compare Java Collections, Java Types and Custom Types
  *
  */
-public class ObjectComparison {
+public final class ObjectComparison {
 	public static final String IMMEDIATE_RESULT_KEY = "ImmediateResult"; //$NON-NLS-1$
 	public static final String KEYSET_1 = "keySet"; //$NON-NLS-1$
 	public static final String VALUESET_1 = "valueSet"; //$NON-NLS-1$
@@ -48,6 +48,8 @@ public class ObjectComparison {
 	public static final String OBJECT_TYPE = "Type"; //$NON-NLS-1$
 	public static final String OBJECT_VALUES = "Values"; //$NON-NLS-1$
 
+	private ObjectComparison() {
+	}
 	/**
 	 * Extracts the actual value as string representation of the given object
 	 *
@@ -58,7 +60,7 @@ public class ObjectComparison {
 	 *         presented in variable view
 	 */
 	@SuppressWarnings("nls")
-	public String objectValueExtraction(IJavaValue value) throws DebugException {
+	public static String objectValueExtraction(IJavaValue value) throws DebugException {
 		String refType1 = value.getReferenceTypeName();
 		List<String> interfaceCheck = getInterfaces(refType1);
 		if (interfaceCheck.contains("java.lang.CharSequence")) {
@@ -86,7 +88,7 @@ public class ObjectComparison {
 	 * @return Returns string content
 	 */
 	@SuppressWarnings("nls")
-	private String stringValueExtraction(IJavaObject value) throws DebugException {
+	private static String stringValueExtraction(IJavaObject value) throws DebugException {
 		IJavaThread thread = getSuspendedThread(value);
 		IJavaValue stringVal = value.sendMessage("toString", "()Ljava/lang/String;", null, thread, false);
 		return stringVal.getValueString();
@@ -100,7 +102,7 @@ public class ObjectComparison {
 	 * @return Returns a Map containing selected IJavaVariable and its extracted Set contents
 	 * @throws DebugException
 	 */
-	public Map<IJavaVariable, Object> setExtraction(List<IStructuredSelection> selections) throws DebugException {
+	public static Map<IJavaVariable, Object> setExtraction(List<IStructuredSelection> selections) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -122,7 +124,7 @@ public class ObjectComparison {
 	 * @return Returns a List of Set contents
 	 */
 	@SuppressWarnings("nls")
-	public List<String> setElementsExtraction(IJavaObject javaObject1) throws DebugException {
+	public static List<String> setElementsExtraction(IJavaObject javaObject1) throws DebugException {
 		List<String> contents = new ArrayList<>();
 		IJavaThread thread = getSuspendedThread(javaObject1);
 		IJavaValue toArray = javaObject1.sendMessage("toArray", "()[Ljava/lang/Object;", null, thread, false);
@@ -141,7 +143,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of comparison result for given IJavaVariable keys
 	 */
 	@SuppressWarnings({ "unchecked", "nls" })
-	public Map<IJavaVariable, Object> compareCustomObjects(Map<IJavaVariable, Object> compareResults) throws DebugException {
+	public static Map<IJavaVariable, Object> compareCustomObjects(Map<IJavaVariable, Object> compareResults) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			Map<String, Object> properties = new HashMap<>();
@@ -220,7 +222,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return returns a Map of comparison result details
 	 */
-	public Map<IJavaVariable, Object> compareObjects(Map<IJavaVariable, Object> compareResults) throws DebugException {
+	public static Map<IJavaVariable, Object> compareObjects(Map<IJavaVariable, Object> compareResults) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			String val1 = entry1.getValue().toString();
@@ -265,7 +267,7 @@ public class ObjectComparison {
 	 * @throws Exception
 	 * @return Returns a Map of IJavaVariable and field value pair
 	 */
-	public Map<IJavaVariable, Object> extractCustomObjects(List<IStructuredSelection> selections) throws Exception {
+	public static Map<IJavaVariable, Object> extractCustomObjects(List<IStructuredSelection> selections) throws Exception {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -290,7 +292,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of IJavaVariable and references
 	 * @throws DebugException
 	 */
-	public Map<IJavaVariable, Object> customObjectsReferencesExtraction(List<IStructuredSelection> selections) throws DebugException {
+	public static Map<IJavaVariable, Object> customObjectsReferencesExtraction(List<IStructuredSelection> selections) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -310,7 +312,7 @@ public class ObjectComparison {
 	 * @return Return <code>True</code> if all objects are of same reference. <code>False</code> if any one of the objects are from different
 	 *         reference
 	 */
-	public boolean objectsRefCheck(Map<IJavaVariable, Object> compareResults) {
+	public static boolean objectsRefCheck(Map<IJavaVariable, Object> compareResults) {
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			String val1 = entry1.getValue().toString();
 			IJavaVariable key1 = entry1.getKey();
@@ -335,7 +337,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return Returns a Map of IJavaVariable and field value pair
 	 */
-	public Map<String, String> customObjectValueExtraction(IJavaObject javaObject1) throws DebugException {
+	public static Map<String, String> customObjectValueExtraction(IJavaObject javaObject1) throws DebugException {
 		Map<String, String> contents = new HashMap<>();
 		for (IVariable ob : javaObject1.getVariables()) {
 			String content;
@@ -357,7 +359,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of IJavaVariable and field value pair
 	 * @throws DebugException
 	 */
-	public Map<IJavaVariable, Object> extractOtherObjects(List<IStructuredSelection> selections) throws DebugException {
+	public static Map<IJavaVariable, Object> extractOtherObjects(List<IStructuredSelection> selections) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -378,7 +380,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of IJavaVariable and array values
 	 * @throws DebugException
 	 */
-	public Map<IJavaVariable, Object> arrayExtraction(List<IStructuredSelection> selections) throws DebugException {
+	public static Map<IJavaVariable, Object> arrayExtraction(List<IStructuredSelection> selections) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -397,7 +399,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return Returns a List of array elements
 	 */
-	public List<String> arrayElementsExtraction(IJavaVariable selectedObject1) throws DebugException {
+	public static List<String> arrayElementsExtraction(IJavaVariable selectedObject1) throws DebugException {
 		List<String> arrayElements1 = new ArrayList<>();
 		if (selectedObject1.getValue() instanceof IJavaValue javaVal1) {
 			for (IVariable jv : javaVal1.getVariables()) {
@@ -418,7 +420,7 @@ public class ObjectComparison {
 	 * @return returns <code>true</code> if elements of all list1 elements are present in list2 .<code>false</code> if any element of list1 is missing
 	 *         from list2
 	 */
-	public <T> boolean listContentsCheck(List<T> l1, List<T> l2) {
+	public static <T> boolean listContentsCheck(List<T> l1, List<T> l2) {
 		for (T t : l1) {
 			if (!l2.contains(t)) {
 				return false;
@@ -435,7 +437,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return Returns a Map of comparison result for given IJavaVariable
 	 */
-	public Map<IJavaVariable, Object> stringCompare(Map<IJavaVariable, Object> compareResults) throws DebugException {
+	public static Map<IJavaVariable, Object> stringCompare(Map<IJavaVariable, Object> compareResults) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			String val1 = (String) entry1.getValue();
@@ -482,7 +484,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of comparison result for given IJavaVariable
 	 */
 	@SuppressWarnings({ "unchecked", "nls" })
-	public Map<IJavaVariable, Object> compareSelectedLists(Map<IJavaVariable, Object> compareResults, String interfaceType) throws DebugException {
+	public static Map<IJavaVariable, Object> compareSelectedLists(Map<IJavaVariable, Object> compareResults, String interfaceType) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			List<String> listV1 = (List<String>) entry1.getValue();
@@ -548,7 +550,7 @@ public class ObjectComparison {
 	 * @return Returns a Map of comparison result for given IJavaVariable
 	 */
 	@SuppressWarnings({ "nls", "unchecked" })
-	public Map<IJavaVariable, Object> compareSelectedMaps(Map<IJavaVariable, Object> compareResults) throws DebugException {
+	public static Map<IJavaVariable, Object> compareSelectedMaps(Map<IJavaVariable, Object> compareResults) throws DebugException {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Map.Entry<IJavaVariable, Object> entry1 : compareResults.entrySet()) {
 			Map<String, Object> current = (Map<String, Object>) entry1.getValue();
@@ -639,7 +641,7 @@ public class ObjectComparison {
 	 * @throws Exception
 	 * @return Returns a Map of IJavaVariable and its Iterable contents
 	 */
-	public Map<IJavaVariable, Object> iterableExtraction(List<IStructuredSelection> selections) throws Exception {
+	public static Map<IJavaVariable, Object> iterableExtraction(List<IStructuredSelection> selections) throws Exception {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -661,7 +663,7 @@ public class ObjectComparison {
 	 * @return Returns actual List of selected Iterable object
 	 */
 	@SuppressWarnings("nls")
-	public List<String> iterableElementsExtraction(IJavaObject javaObject1) throws DebugException {
+	public static List<String> iterableElementsExtraction(IJavaObject javaObject1) throws DebugException {
 		List<String> contents = new ArrayList<>();
 		IJavaThread thread = getSuspendedThread(javaObject1);
 		IJavaObject iterator = (IJavaObject) javaObject1.sendMessage("iterator", "()Ljava/util/Iterator;", null, thread, false);
@@ -685,7 +687,7 @@ public class ObjectComparison {
 	 * @throws Exception
 	 * @return Returns a Map of IJavaVariable and its List contents
 	 */
-	public Map<IJavaVariable, Object> listExtraction(List<IStructuredSelection> selections) throws Exception {
+	public static Map<IJavaVariable, Object> listExtraction(List<IStructuredSelection> selections) throws Exception {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -707,7 +709,7 @@ public class ObjectComparison {
 	 * @return Returns actual List of selected List object
 	 */
 	@SuppressWarnings("nls")
-	public List<String> listElementsExtraction(IJavaObject javaObject1) throws DebugException {
+	public static List<String> listElementsExtraction(IJavaObject javaObject1) throws DebugException {
 		List<String> contents = new ArrayList<>();
 		IJavaThread thread = getSuspendedThread(javaObject1);
 		IJavaValue toArray = javaObject1.sendMessage("toArray", "()[Ljava/lang/Object;", null, thread, false);
@@ -725,7 +727,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return Returns actual List
 	 */
-	public Map<IJavaVariable, Object> mapExtraction(List<IStructuredSelection> selections) throws Exception {
+	public static Map<IJavaVariable, Object> mapExtraction(List<IStructuredSelection> selections) throws Exception {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -744,7 +746,7 @@ public class ObjectComparison {
 	 * @throws DebugException
 	 * @return Returns Map of IJavaVariable and string contents
 	 */
-	public Map<IJavaVariable, Object> stringExtraction(List<IStructuredSelection> selections) throws Exception {
+	public static Map<IJavaVariable, Object> stringExtraction(List<IStructuredSelection> selections) throws Exception {
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		for (Object selection : selections) {
 			if (selection instanceof IJavaVariable selectedObject) {
@@ -766,7 +768,7 @@ public class ObjectComparison {
 	 * @return returns a Map of comparison result details
 	 */
 	@SuppressWarnings("nls")
-	public Map<String, Object> mapElementsExtraction(IJavaVariable selectedObject1) throws DebugException {
+	public static Map<String, Object> mapElementsExtraction(IJavaVariable selectedObject1) throws DebugException {
 		if (selectedObject1.getValue() instanceof IJavaObject javaObject1) {
 			IJavaThread thread = getSuspendedThread(javaObject1);
 			Map<String, Object> result = new HashMap<>();
@@ -863,7 +865,7 @@ public class ObjectComparison {
 	 *            IJavaValue object
 	 * @return returns a suspended IJavaThread object
 	 */
-	private IJavaThread getSuspendedThread(IJavaValue value) throws DebugException {
+	private static IJavaThread getSuspendedThread(IJavaValue value) throws DebugException {
 		IJavaThread thread = (IJavaThread) value.getDebugTarget().getThreads()[0];
 		if (!thread.isSuspended()) {
 			JDIStackFrame frame = (JDIStackFrame) DebugUITools.getDebugContext();

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/CompareObjectsAction.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/actions/CompareObjectsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,23 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.ui.actions;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.arrayExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.checkInterfaces;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareCustomObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareSelectedLists;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.compareSelectedMaps;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.customObjectsReferencesExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.extractCustomObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.extractOtherObjects;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.iterableExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.listExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.mapExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.objectsRefCheck;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.setExtraction;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.stringCompare;
+import static org.eclipse.jdt.internal.debug.ui.ObjectComparison.stringExtraction;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,7 +99,6 @@ public class CompareObjectsAction extends ObjectActionDelegate implements IWorkb
 	 */
 	@SuppressWarnings("nls")
 	protected void compareSelectedObjects(List<IStructuredSelection> selections) {
-		ObjectComparison obcp = new ObjectComparison();
 		Map<IJavaVariable, Object> result = new HashMap<>();
 		try {
 			Set<String> valueSet = selectionTypeChecker(selections);
@@ -92,56 +108,56 @@ public class CompareObjectsAction extends ObjectActionDelegate implements IWorkb
 			}
 			String temp = (String) valueSet.toArray()[0];
 			if (temp.equals("Lists")) {
-				result = obcp.listExtraction(selections);
-				result = obcp.compareSelectedLists(result, temp);
+				result = listExtraction(selections);
+				result = compareSelectedLists(result, temp);
 				if (selections.size() == 2) {
 					displayListResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Sets")) {
-				result = obcp.setExtraction(selections);
-				result = obcp.compareSelectedLists(result, temp);
+				result = setExtraction(selections);
+				result = compareSelectedLists(result, temp);
 				if (selections.size() == 2) {
 					displayListResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Queues") || temp.equals("Deques")) {
-				result = obcp.listExtraction(selections);
-				result = obcp.compareSelectedLists(result, temp);
+				result = listExtraction(selections);
+				result = compareSelectedLists(result, temp);
 				if (selections.size() == 2) {
 					displayListResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Maps")) {
-				result = obcp.mapExtraction(selections);
-				result = obcp.compareSelectedMaps(result);
+				result = mapExtraction(selections);
+				result = compareSelectedMaps(result);
 				if (selections.size() == 2) {
 					displayMapResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Iterables")) {
-				result = obcp.iterableExtraction(selections);
-				result = obcp.compareSelectedLists(result, temp);
+				result = iterableExtraction(selections);
+				result = compareSelectedLists(result, temp);
 				if (selections.size() == 2) {
 					displayListResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Arrays")) {
-				result = obcp.arrayExtraction(selections);
-				result = obcp.compareSelectedLists(result, temp);
+				result = arrayExtraction(selections);
+				result = compareSelectedLists(result, temp);
 				if (selections.size() == 2) {
 					displayListResultsInDialogBox(result);
 					return;
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("CharSequences")) {
-				result = obcp.stringExtraction(selections);
-				result = obcp.stringCompare(result);
+				result = stringExtraction(selections);
+				result = stringCompare(result);
 				if (selections.size() == 2) {
 					String type = temp.substring(temp.lastIndexOf('.') + 1);
 					displayComparisonResults(result, type);
@@ -149,8 +165,8 @@ public class CompareObjectsAction extends ObjectActionDelegate implements IWorkb
 				}
 				displayInDiffView(result, temp);
 			} else if (temp.equals("Wrappers")) {
-				result = obcp.extractOtherObjects(selections);
-				result = obcp.compareObjects(result);
+				result = extractOtherObjects(selections);
+				result = compareObjects(result);
 				if (selections.size() == 2) {
 					String type = temp.substring(temp.lastIndexOf('.') + 1);
 					displayComparisonResults(result, type);
@@ -158,13 +174,13 @@ public class CompareObjectsAction extends ObjectActionDelegate implements IWorkb
 				}
 				displayInDiffView(result, temp);
 			} else {
-				result = obcp.customObjectsReferencesExtraction(selections);
-				if (obcp.objectsRefCheck(result)) {
+				result = customObjectsReferencesExtraction(selections);
+				if (objectsRefCheck(result)) {
 					displayComparisonResults();
 					return;
 				}
-				result = obcp.extractCustomObjects(selections);
-				result = obcp.compareCustomObjects(result);
+				result = extractCustomObjects(selections);
+				result = compareCustomObjects(result);
 				displayInDiffViewForComplex(result);
 			}
 
@@ -191,7 +207,7 @@ public class CompareObjectsAction extends ObjectActionDelegate implements IWorkb
 		if (declarationReferenceType.endsWith("[]")) {
 			return "Arrays";
 		}
-		String interfaceType = ObjectComparison.checkInterfaces(valueReferenceType);
+		String interfaceType = checkInterfaces(valueReferenceType);
 		return interfaceType;
 	}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

Convert ObjectComparison to a static utility class by hiding the constructor and making all methods static.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
