### PR TITLE
Improve null handling in ConsoleLineTracker

### DIFF
--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/ConsoleLineTracker.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/ConsoleLineTracker.java
@@ -64,7 +64,7 @@ public class ConsoleLineTracker implements IConsoleLineTrackerExtension {
 	 * @return the document backingthis console
 	 */
 	public static IDocument getDocument() {
-		return fConsole.getDocument();
+		return fConsole != null ? fConsole.getDocument() : null;
 	}
 
 	/**


### PR DESCRIPTION
`ConsoleLineTracker.getDocument()` is polled from tests, waiting for a non-null value. If `ConsoleLineTracker.fConsole` is not yet set, the polling can throw a NPE. This change adds a null check, to avoid the NPE.

See: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/559