### PR TITLE
Consider "RMI Runtime" thread group as a user group

### DIFF
--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.26.0.qualifier
+Bundle-Version: 3.26.100.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -114,6 +114,12 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	private static final String MAIN_THREAD_GROUP = "main"; //$NON-NLS-1$
 
 	/**
+	 * Constant for the name of the {@code RMI Runtime} thread group. See internal JDK method {@code sun.rmi.runtime.RuntimeUtil.newUserThread()},
+	 * which uses: {@code sun.rmi.runtime.RuntimeUtil.userThreadGroup}
+	 */
+	private static final String RMI_RUNTIME_THREAD_GROUP = "RMI Runtime"; //$NON-NLS-1$
+
+	/**
 	 * @since 3.5
 	 */
 	public static final int RESUME_QUIET = 500;
@@ -565,7 +571,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 				// #targetRequestFailed will throw an exception
 				return;
 			}
-			if (tgn != null && tgn.equals(MAIN_THREAD_GROUP)) {
+			if (MAIN_THREAD_GROUP.equals(tgn) || RMI_RUNTIME_THREAD_GROUP.equals(tgn)) {
 				fIsSystemThread = false;
 				break;
 			}


### PR DESCRIPTION
LSP4J calls are serviced by the "RMI Runtime" thread group. In JDK code, this group is considered a user thread group, as it can run user code (such as LSP4J calls from clients).

This change adjusts `JDIThread` to consider the "RMI Runtime" thread group as a user thread group. This makes it possible to debug LSP4J code without turning on the system threads Debug view filter. Which in turn avoids running into Debug view updating mechanism bugs related to using filters.

See: https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/971
