### PR TITLE
Increment Line Number in Stacktrace Ambiguous Result

### DIFF
--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTraceHyperlink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -279,7 +279,7 @@ public class JavaStackTraceHyperlink implements IHyperlink {
 			}
 		}
 		if (methodSignature == null) {
-			return openClipboard(matches, line, typeName);
+			return openClipboard(matches, ++line, typeName);
 		}
 		methodSignature = methodSignature.replace(" ", ""); //$NON-NLS-1$//$NON-NLS-2$ ;
 		String methodNameExtracted = methodSignature.substring(0, methodSignature.indexOf('('));


### PR DESCRIPTION
This commit increments line number when Stacktrace has ambiguous result with no method signature.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/973


With fix : 
<img width="1080" height="608" alt="Untitledz" src="https://github.com/user-attachments/assets/25a7e8c2-92a9-43c5-8ceb-99294634de23" />



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
