### PR TITLE
Do not activate org.eclipse.jdt.ui.javaEditorScope from JavaStackTracePageParticipant

### DIFF
--- a/org.eclipse.jdt.debug.ui/plugin.properties
+++ b/org.eclipse.jdt.debug.ui/plugin.properties
@@ -267,6 +267,9 @@ javaLikeExtensions.description=Regular expression matching registered Java-like 
 Context.javaDebugging.name= Debugging Java
 Context.javaDebugging.description= Debugging Java programs
 
+Context.javaConsoleScope.name= In Java Stack Trace Console
+Context.javaConsoleScope.description= Editing Java stack traces
+
 newWizardCategoryName=Java Run/Debug
 NewJavaScrapbookPage.label= Scrapbook Page
 NewJavaScrapbookPage.description=Create a Java scrapbook page file

--- a/org.eclipse.jdt.debug.ui/plugin.xml
+++ b/org.eclipse.jdt.debug.ui/plugin.xml
@@ -3395,6 +3395,20 @@ M4 = Platform-specific fourth key
             id="org.eclipse.jdt.debug.ui.debugging"
             parentId="org.eclipse.debug.ui.debugging">
       </context>
+      <context
+            name="%Context.javaConsoleScope.name"
+            description="%Context.javaConsoleScope.description"
+            id="org.eclipse.jdt.debug.ui.javaConsoleScope"
+            parentId="org.eclipse.ui.contexts.window">
+      </context>
+   </extension>
+   <extension
+         point="org.eclipse.ui.bindings">
+      <key
+            sequence="M1+M2+F"
+            contextId="org.eclipse.jdt.debug.ui.javaConsoleScope"
+            commandId="org.eclipse.jdt.ui.edit.text.java.format"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
    </extension>
    <extension
          point="org.eclipse.debug.ui.debugModelContextBindings">

--- a/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTracePageParticipant.java
+++ b/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/console/JavaStackTracePageParticipant.java
@@ -35,6 +35,14 @@ import org.eclipse.ui.part.IPageBookViewPage;
  */
 public class JavaStackTracePageParticipant implements IConsolePageParticipant {
 
+	/**
+	 * Dedicated context activated while a Java stack trace console page is showing, used only to enable the Format command's key binding (see
+	 * jdt.debug.ui's plugin.xml). This is intentionally <b>not</b> the shared "org.eclipse.jdt.ui.javaEditorScope"/"org.eclipse.ui.textEditorScope"
+	 * context: activating those would also make unrelated generic text/java editor key bindings (e.g. the zoom in/out commands) take priority over
+	 * this console's own key bindings while it is showing.
+	 */
+    private static final String JAVA_CONSOLE_SCOPE = "org.eclipse.jdt.debug.ui.javaConsoleScope"; //$NON-NLS-1$
+
     private CloseConsoleAction fCloseAction;
     private FormatStackTraceActionDelegate fFormatAction;
     private IHandlerActivation fHandlerActivation;
@@ -88,8 +96,13 @@ public class JavaStackTracePageParticipant implements IConsolePageParticipant {
 
         fHandlerActivation = handlerService.activateHandler("org.eclipse.jdt.ui.edit.text.java.format", formatHandler); //$NON-NLS-1$
 
+        // Activate our own dedicated context (rather than the shared java/text
+        // editor scope) so that the Format command's Ctrl+Shift+F key binding
+        // works here, without dragging in unrelated generic editor key bindings
+        // (e.g. zoom in/out) that would otherwise take priority over this
+        // console's own key bindings while it is showing.
         IContextService contextService = workbench.getAdapter(IContextService.class);
-        fContextActivation = contextService.activateContext("org.eclipse.jdt.ui.javaEditorScope"); //$NON-NLS-1$
+        fContextActivation = contextService.activateContext(JAVA_CONSOLE_SCOPE);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
This will mask the ConsoleView context when JavaStackTraceConsolePage is active in ConsoleView.

see https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/977