### PR TITLE
Clean up breakpoints after marker loss

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Carsten Hammer - cleanup after failed test VM startup
  *******************************************************************************/
 package org.eclipse.debug.jdi.tests;
 
@@ -24,9 +25,11 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.debug.jdi.tests.program.MainClass;
 import org.eclipse.jdi.Bootstrap;
+import org.eclipse.jdi.TimeoutException;
 import org.eclipse.jdi.internal.VirtualMachineImpl;
 
 import com.sun.jdi.AbsentInformationException;
@@ -562,7 +565,7 @@ public abstract class AbstractJDITest extends TestCase {
 	 * NOTE: This assumes that the VM can watch field access.
 	 */
 	protected AccessWatchpointRequest getStaticAccessWatchpointRequest() {
-		// Get the static field
+		// Get the field
 		Field field = getField("fString");
 
 		// Create an access watchpoint for this field
@@ -671,8 +674,13 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Launches the target VM and connects to VM.
 	 */
 	protected void launchTargetAndConnectToVM() {
-		launchTarget();
-		connectToVM();
+		try {
+			launchTarget();
+			connectToVM();
+		} catch (RuntimeException | Error failure) {
+			cleanupAfterFailedStartup(failure);
+			throw failure;
+		}
 	}
 
 	protected boolean vmIsRunning() {
@@ -912,9 +920,15 @@ public abstract class AbstractJDITest extends TestCase {
 		startConsoleReaders();
 
 
-		// Contact the VM (try at least 10 times for 5 seconds)
+		// Bound each attach as well as the retry loop. A zero connector timeout
+		// waits forever if a peer accepts the socket but does not complete JDWP.
+		long timeoutNanos = TimeUnit.SECONDS.toNanos(5);
+		Throwable connectionFailure = null;
 		long n0 = System.nanoTime();
 		for (int i = 0; i < 10000; i++) {
+			if (Thread.currentThread().isInterrupted()) {
+				throw new Error("Interrupted while connecting to the VM", new InterruptedException());
+			}
 			try {
 				VirtualMachineManager manager = Bootstrap.virtualMachineManager();
 				List<AttachingConnector> connectors = manager.attachingConnectors();
@@ -925,6 +939,8 @@ public abstract class AbstractJDITest extends TestCase {
 				Map<String, Argument> args = connector.defaultArguments();
 				args.get("port").setValue(String.valueOf(fBackEndPort));
 				args.get("hostname").setValue("localhost");
+				long remainingMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(timeoutNanos - (System.nanoTime() - n0)));
+				args.get("timeout").setValue(Long.toString(remainingMillis));
 
 				fVM = connector.attach(args);
 				if (fVMTraceFlags != com.sun.jdi.VirtualMachine.TRACE_NONE) {
@@ -933,9 +949,10 @@ public abstract class AbstractJDITest extends TestCase {
 				break;
 			} catch (IllegalConnectorArgumentsException e) {
 				e.printStackTrace();
-			} catch (IOException e) {
+			} catch (IOException | TimeoutException e) {
+				connectionFailure = e;
 				long n1 = System.nanoTime();
-				if (i > 10 && n1 - n0 > 5_000_000_000L) {
+				if (n1 - n0 >= timeoutNanos) {
 					e.printStackTrace();
 					System.out.println("Could not contact the VM at localhost" + ":" + fBackEndPort + " after " + (n1 - n0) / 1_000_000L + "ms");
 					break;
@@ -943,6 +960,8 @@ public abstract class AbstractJDITest extends TestCase {
 				try {
 					Thread.sleep(10);
 				} catch (InterruptedException interrupted) {
+					Thread.currentThread().interrupt();
+					throw new Error("Interrupted while connecting to the VM", interrupted);
 				}
 			}
 		}
@@ -963,14 +982,35 @@ public abstract class AbstractJDITest extends TestCase {
 				} catch (IOException e) {
 				}
 
-				// Shut it down
-				killVM();
 			}
-			throw new Error("Could not contact the VM");
+			Error failure = new Error("Could not contact the VM", connectionFailure);
+			// Retain pre-cleanup state in the test failure even when console output
+			// from the target process is missing from the CI test report.
+			failure.addSuppressed(new IllegalStateException("JDI startup at localhost:" + fBackEndPort
+					+ "; target " + describeProcess(fLaunchedVM) + "; proxy " + describeProcess(fLaunchedProxy)
+					+ "; runtime=" + Runtime.version() + "; vendor=" + System.getProperty("java.vendor")));
+			throw failure;
 		}
 		long n1 = System.nanoTime(); // for example after ~ 110ms
 		System.out.println("Connected to localhost" + ":" + fBackEndPort + " after " + (n1 - n0) / 1_000_000L + "ms");
 		startEventReader();
+	}
+
+	private static String describeProcess(Process process) {
+		if (process == null) {
+			return "not started";
+		}
+		String pid;
+		try {
+			pid = Long.toString(process.pid());
+		} catch (UnsupportedOperationException e) {
+			pid = "unavailable";
+		}
+		try {
+			return "pid=" + pid + ", alive=false, exitCode=" + process.exitValue();
+		} catch (IllegalThreadStateException e) {
+			return "pid=" + pid + ", alive=true";
+		}
 	}
 	/**
 	 * Initializes the fields that are used by this test only.
@@ -1158,7 +1198,23 @@ public abstract class AbstractJDITest extends TestCase {
 	 */
 	protected void launchTargetAndStartProgram() {
 		launchTargetAndConnectToVM();
-		startProgram();
+		try {
+			startProgram();
+		} catch (RuntimeException | Error failure) {
+			cleanupAfterFailedStartup(failure);
+			throw failure;
+		}
+	}
+
+	private void cleanupAfterFailedStartup(Throwable failure) {
+		// JUnit does not call tearDown() when setUp() fails.
+		try {
+			shutDownTarget();
+		} catch (RuntimeException | Error cleanupFailure) {
+			if (cleanupFailure != failure) {
+				failure.addSuppressed(cleanupFailure);
+			}
+		}
 	}
 	/**
 	 * Init tests
@@ -1201,29 +1257,57 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Shut down the target.
 	 */
 	public void shutDownTarget() {
-		stopReaders();
-		if (fVM != null) {
+		boolean hadTarget = fVM != null || fLaunchedVM != null || fLaunchedProxy != null;
+		Throwable failure = null;
+		try {
+			stopReaders();
+			if (fVM != null) {
+				try {
+					fVM.exit(0);
+				} catch (VMDisconnectedException e) {
+				}
+			}
+		} catch (RuntimeException | Error e) {
+			failure = e;
+			throw e;
+		} finally {
 			try {
-				fVM.exit(0);
-			} catch (VMDisconnectedException e) {
+				killVM();
+			} catch (RuntimeException | Error cleanupFailure) {
+				if (failure == null) {
+					throw cleanupFailure;
+				}
+				if (failure != cleanupFailure) {
+					failure.addSuppressed(cleanupFailure);
+				}
+			} finally {
+				fVM = null;
+				// Keep a handle to a process whose termination failed.
+				if (fLaunchedVM != null && !fLaunchedVM.isAlive()) {
+					fLaunchedVM = null;
+				}
+				if (fLaunchedProxy != null && !fLaunchedProxy.isAlive()) {
+					fLaunchedProxy = null;
+				}
+				fEventReader = null;
+				fConsoleReader = null;
+				fConsoleErrorReader = null;
+				fProxyReader = null;
+				fProxyErrorReader = null;
+				if (hadTarget) {
+					selectNextPort();
+				}
 			}
 		}
+	}
 
-		fVM = null;
-		fLaunchedVM = null;
-
-		// We want subsequent connections to use different ports, unless a
-		// VM exec sting is given.
+	private static void selectNextPort() {
+		// Preserve the port embedded in a user-supplied VM command.
 		if (fVmCmd == null) {
-			ServerSocket socket;
-			try {
-				socket = new ServerSocket(0);
-				int availablePort = socket.getLocalPort();
-				socket.close(); //Available but always initialized
-				fBackEndPort = availablePort;
+			try (ServerSocket socket = new ServerSocket(0)) {
+				fBackEndPort = socket.getLocalPort();
 			} catch (IOException e) {
-				fBackEndPort +=2;
-
+				fBackEndPort += 2;
 			}
 		}
 	}
@@ -1317,15 +1401,12 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Stops the event reader.
 	 */
 	private void stopEventReader() {
-		fEventReader.stop();
+		if (fEventReader != null) {
+			fEventReader.stop();
+		}
 	}
 	protected void killVM() {
-		if (fLaunchedVM != null) {
-			fLaunchedVM.destroy();
-		}
-		if (fLaunchedProxy != null) {
-			fLaunchedProxy.destroy();
-		}
+		TestProcessCleanup.terminate(fLaunchedVM, fLaunchedProxy);
 	}
 	/**
 	 * Starts the target program.

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2022 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,8 @@ public class AutomatedSuite extends TestSuite {
 	public AutomatedSuite() {
 		AbstractJDITest.parseArgs(new String[] {});
 
+		addTest(new TestSuite(VMConnectionTimeoutTest.class));
+		addTest(new TestSuite(VMStartupCleanupTest.class));
 		addTest(new TestSuite(AccessibleTest.class));
 		addTest(new TestSuite(ArrayReferenceTest.class));
 		addTest(new TestSuite(ArrayTypeTest.class));

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.util.concurrent.TimeUnit;
+
+/** Bounded termination of processes owned by a JDI test. */
+final class TestProcessCleanup {
+	private static final long EXIT_TIMEOUT_MILLIS = 5000;
+
+	private TestProcessCleanup() {
+	}
+
+	static void terminate(Process... processes) {
+		terminate(EXIT_TIMEOUT_MILLIS, processes);
+	}
+
+	static void terminate(long timeoutMillis, Process... processes) {
+		if (timeoutMillis <= 0) {
+			throw new IllegalArgumentException("Process exit timeout must be positive");
+		}
+		Throwable failure = null;
+		for (Process process : processes) {
+			try {
+				terminate(process, timeoutMillis);
+			} catch (RuntimeException | Error e) {
+				if (failure == null) {
+					failure = e;
+				} else if (failure != e) {
+					failure.addSuppressed(e);
+				}
+			}
+		}
+		if (failure instanceof RuntimeException e) {
+			throw e;
+		}
+		if (failure instanceof Error e) {
+			throw e;
+		}
+	}
+
+	private static void terminate(Process process, long timeoutMillis) {
+		if (process == null || !process.isAlive()) {
+			return;
+		}
+		// Cleanup must still run when startup was interrupted. Restore the flag below.
+		boolean interrupted = Thread.interrupted();
+		try {
+			process.destroy();
+			if (!interrupted) {
+				try {
+					if (process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+						return;
+					}
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+			process.destroyForcibly();
+			long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+			while (process.isAlive()) {
+				long remaining = deadline - System.nanoTime();
+				if (remaining <= 0) {
+					throw terminationFailure(process);
+				}
+				try {
+					if (!process.waitFor(remaining, TimeUnit.NANOSECONDS) && process.isAlive()) {
+						throw terminationFailure(process);
+					}
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+		} finally {
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+
+	private static IllegalStateException terminationFailure(Process process) {
+		return new IllegalStateException("Test process " + process.pid() + " did not terminate after destroyForcibly()");
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMConnectionTimeoutTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMConnectionTimeoutTest.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import junit.framework.TestCase;
+
+/** Tests the deadline and subsequent cleanup with the real JDI connector. */
+public class VMConnectionTimeoutTest extends TestCase {
+
+	public void testPeerThatDoesNotCompleteHandshakeCannotBlockStartup() throws Exception {
+		assertSilentPeerIsBounded(false);
+	}
+
+	public void testHandshakeTimeoutReachesCleanupAndRetainsDiagnostics() throws Exception {
+		assertSilentPeerIsBounded(true);
+	}
+
+	private void assertSilentPeerIsBounded(boolean throughStartup) throws Exception {
+		int previousPort = AbstractJDITest.fBackEndPort;
+		ConnectionProbe probe = new ConnectionProbe();
+		FutureTask<Void> attempt = new FutureTask<>(() -> {
+			if (throughStartup) {
+				probe.launchTargetAndConnectToVM();
+			} else {
+				probe.connectToVM();
+			}
+			return null;
+		});
+		Thread connecting = new Thread(attempt, "JDI startup timeout test");
+		connecting.setDaemon(true);
+		try (ServerSocket listener = new ServerSocket(0)) {
+			listener.setSoTimeout(10000);
+			AbstractJDITest.fBackEndPort = listener.getLocalPort();
+			connecting.start();
+			try (Socket peer = listener.accept()) {
+				peer.setSoTimeout(10000);
+				assertEquals("JDWP-Handshake", new String(peer.getInputStream().readNBytes(14), StandardCharsets.US_ASCII));
+				// Keep the connection open without answering its JDWP handshake.
+				try {
+					attempt.get(10, TimeUnit.SECONDS);
+					fail("A peer without a JDWP handshake must not be accepted as a VM");
+				} catch (ExecutionException expected) {
+					Throwable failure = expected.getCause();
+					assertTrue("Startup must report its ordinary connection failure: " + failure, failure instanceof Error);
+					assertEquals("Could not contact the VM", failure.getMessage());
+					assertTrue("Retain the transport timeout as the cause", failure.getCause() instanceof org.eclipse.jdi.TimeoutException);
+					assertTrue("Record the process state before cleanup, not after destroying it",
+							Arrays.stream(failure.getSuppressed()).anyMatch(detail -> detail.getMessage() != null
+									&& detail.getMessage().contains("pid=42, alive=true")
+									&& detail.getMessage().contains("localhost:" + listener.getLocalPort())));
+					if (throughStartup) {
+						assertFalse("Cleanup must terminate the owned process", probe.process.isAlive());
+						assertNull("Cleanup must clear the target handle", probe.fLaunchedVM);
+						assertNull(probe.fConsoleReader);
+						assertNull(probe.fConsoleErrorReader);
+					}
+				} catch (TimeoutException expected) {
+					fail("The connector blocked past the startup deadline on a silent peer");
+				}
+			}
+		} finally {
+			// Closing the peer releases even the unfixed implementation.
+			try {
+				connecting.join(10000);
+				assertFalse("Startup thread did not terminate after the peer closed", connecting.isAlive());
+			} finally {
+				probe.stopConsoleTestReaders();
+				probe.process.destroy();
+				AbstractJDITest.fBackEndPort = previousPort;
+			}
+		}
+	}
+
+	private static final class ConnectionProbe extends AbstractJDITest {
+		final Process process = new StreamOnlyProcess();
+
+		ConnectionProbe() {
+			fLaunchedVM = process;
+		}
+
+		@Override
+		protected void launchTarget() {
+			// Only the process is substituted; attach uses the real transport.
+		}
+
+		@Override
+		public void localSetUp() {
+			// No target program is needed for a transport-level startup failure.
+		}
+
+		void stopConsoleTestReaders() {
+			if (fConsoleReader != null) {
+				fConsoleReader.stop();
+			}
+			if (fConsoleErrorReader != null) {
+				fConsoleErrorReader.stop();
+			}
+		}
+	}
+
+	private static final class StreamOnlyProcess extends Process {
+		private volatile boolean alive = true;
+
+		@Override
+		public OutputStream getOutputStream() {
+			return OutputStream.nullOutputStream();
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public int waitFor() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int exitValue() {
+			if (alive) {
+				throw new IllegalThreadStateException();
+			}
+			return 0;
+		}
+
+		@Override
+		public long pid() {
+			return 42;
+		}
+
+		@Override
+		public void destroy() {
+			alive = false;
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
@@ -1,0 +1,448 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.jdi.VirtualMachine;
+
+import junit.framework.TestCase;
+
+/** Tests failure paths without relying on a slow or overloaded debug VM. */
+public class VMStartupCleanupTest extends TestCase {
+	private int previousPort;
+	private String previousCommand;
+
+	@Override
+	protected void setUp() {
+		previousPort = AbstractJDITest.fBackEndPort;
+		previousCommand = AbstractJDITest.fVmCmd;
+		AbstractJDITest.fVmCmd = null;
+	}
+
+	@Override
+	protected void tearDown() {
+		AbstractJDITest.fBackEndPort = previousPort;
+		AbstractJDITest.fVmCmd = previousCommand;
+	}
+
+	public void testFailedAttachCleansProcessesWithoutEventReader() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.nextProxy = proxy;
+		fixture.attachFailure = new Error("attach failed");
+		AbstractJDITest.fBackEndPort = 0;
+
+		assertStartupFailure(fixture, fixture.attachFailure);
+
+		assertFalse(vm.isAlive());
+		assertFalse(proxy.isAlive());
+		assertCleared(fixture);
+		assertTrue(AbstractJDITest.fBackEndPort > 0);
+	}
+
+	public void testLaunchFailureCleansAlreadyStartedProxy() {
+		Fixture fixture = new Fixture();
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextProxy = proxy;
+		fixture.launchFailure = new Error("VM launch failed");
+
+		assertStartupFailure(fixture, fixture.launchFailure);
+
+		assertFalse(proxy.isAlive());
+		assertCleared(fixture);
+	}
+
+	public void testProgramStartupFailureCleansVMAndReaders() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.programFailure = new IllegalStateException("program did not become ready");
+		AbstractReader reader = new AbstractReader("cleanup test reader") {
+			@Override
+			protected void readerLoop() {
+			}
+		};
+		fixture.fConsoleReader = reader;
+		fixture.fConsoleErrorReader = reader;
+		fixture.fProxyReader = reader;
+		fixture.fProxyErrorReader = reader;
+
+		assertStartupFailure(fixture, fixture.programFailure);
+
+		assertTrue(reader.fIsStopping);
+		assertFalse(vm.isAlive());
+		assertCleared(fixture);
+	}
+
+	public void testCleanupFailureDoesNotReplaceStartupFailure() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		vm.refuseExit = true;
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.nextProxy = proxy;
+		fixture.attachFailure = new Error("original attach failure");
+
+		assertStartupFailure(fixture, fixture.attachFailure);
+
+		assertEquals(1, fixture.attachFailure.getSuppressed().length);
+		assertTrue(fixture.attachFailure.getSuppressed()[0] instanceof IllegalStateException);
+		assertFalse(proxy.isAlive());
+		assertSame(vm, fixture.fLaunchedVM);
+		vm.alive = false;
+		fixture.shutDownTarget();
+		assertCleared(fixture);
+	}
+
+	public void testShutdownIsIdempotent() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.fLaunchedVM = vm;
+		fixture.shutDownTarget();
+		int port = AbstractJDITest.fBackEndPort;
+		fixture.shutDownTarget();
+		assertEquals(List.of("destroy", "wait"), vm.calls);
+		assertEquals(port, AbstractJDITest.fBackEndPort);
+		assertCleared(fixture);
+	}
+
+	public void testCustomVMCommandKeepsPort() {
+		AbstractJDITest.fVmCmd = "user supplied command";
+		Fixture fixture = new Fixture();
+		fixture.fLaunchedVM = new FakeProcess();
+		fixture.shutDownTarget();
+		assertEquals(previousPort, AbstractJDITest.fBackEndPort);
+		assertCleared(fixture);
+	}
+
+	public void testNextStartupDoesNotReuseFailedVM() {
+		Fixture fixture = new Fixture();
+		FakeProcess first = new FakeProcess();
+		fixture.nextVM = first;
+		fixture.attachFailure = new Error("first attach failed");
+		assertStartupFailure(fixture, fixture.attachFailure);
+		assertCleared(fixture);
+
+		FakeProcess second = new FakeProcess();
+		fixture.nextVM = second;
+		fixture.attachFailure = null;
+		try {
+			fixture.launchTargetAndConnectToVM();
+			assertFalse(first.isAlive());
+			assertTrue(second.isAlive());
+			assertSame(second, fixture.fLaunchedVM);
+			assertNotNull(fixture.fVM);
+		} finally {
+			fixture.shutDownTarget();
+		}
+		assertCleared(fixture);
+	}
+
+	public void testInterruptedAttachCleansVMAndPreservesInterrupt() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.useRealConnect = true;
+		Thread.currentThread().interrupt();
+		try {
+			try {
+				fixture.launchTargetAndConnectToVM();
+				fail("Interrupted startup should fail");
+			} catch (Error failure) {
+				assertTrue(failure.getCause() instanceof InterruptedException);
+			}
+			assertTrue(Thread.currentThread().isInterrupted());
+			assertFalse(vm.isAlive());
+			assertCleared(fixture);
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testGracefulTerminationWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		TestProcessCleanup.terminate(10000, process);
+		assertEquals(List.of("destroy", "wait"), process.calls);
+		assertFalse(process.isAlive());
+	}
+
+	public void testForcedTerminationAlsoWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		process.forceNeeded = true;
+		TestProcessCleanup.terminate(10000, process);
+		assertEquals(List.of("destroy", "wait", "force", "wait"), process.calls);
+		assertFalse(process.isAlive());
+	}
+
+	public void testInterruptedWaitStillTerminatesProcess() {
+		FakeProcess process = new FakeProcess();
+		process.interruptWait = true;
+		try {
+			TestProcessCleanup.terminate(10000, process);
+			assertEquals(List.of("destroy", "wait", "force", "wait"), process.calls);
+			assertFalse(process.isAlive());
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testAlreadyInterruptedCleanupStillWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		Thread.currentThread().interrupt();
+		try {
+			TestProcessCleanup.terminate(10000, process);
+			assertEquals(List.of("destroy", "force", "wait"), process.calls);
+			assertFalse(process.isAlive());
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testAlreadyExitedAndMissingProcessesAreIgnored() {
+		FakeProcess process = new FakeProcess();
+		process.alive = false;
+		TestProcessCleanup.terminate(10000, null, process);
+		assertTrue(process.calls.isEmpty());
+	}
+
+	public void testAllProcessesAreAttemptedAndFailuresPreserved() {
+		FakeProcess first = new FakeProcess();
+		FakeProcess second = new FakeProcess();
+		FakeProcess third = new FakeProcess();
+		first.refuseExit = true;
+		second.refuseExit = true;
+		try {
+			TestProcessCleanup.terminate(10000, first, second, third);
+			fail("Unterminated processes must be reported");
+		} catch (IllegalStateException failure) {
+			assertTrue(failure.getMessage().contains("42"));
+			assertEquals(1, failure.getSuppressed().length);
+		}
+		assertEquals(List.of("destroy", "wait", "force", "wait"), first.calls);
+		assertEquals(first.calls, second.calls);
+		assertFalse(third.isAlive());
+	}
+
+	public void testFailedStartupTerminatesRealJavaProcess() throws Exception {
+		Path directory = Files.createTempDirectory("jdi-startup-cleanup");
+		Path ready = directory.resolve("ready");
+		Process process = null;
+		try {
+			String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+			process = new ProcessBuilder(java, "-cp", AbstractJDITest.fClassPath,
+					WaitingProcess.class.getName(), ready.toString())
+					.redirectError(ProcessBuilder.Redirect.INHERIT).start();
+			long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(AbstractJDITest.TIMEOUT);
+			while (!Files.exists(ready) && process.isAlive() && System.nanoTime() < deadline) {
+				Thread.sleep(10);
+			}
+			assertTrue("Child JVM did not become ready", Files.exists(ready));
+			assertTrue("Child JVM exited before cleanup", process.isAlive());
+			Fixture fixture = new Fixture();
+			fixture.nextVM = process;
+			fixture.attachFailure = new Error("injected attach failure");
+			assertStartupFailure(fixture, fixture.attachFailure);
+			assertFalse("Failed startup left its JVM alive", process.isAlive());
+			assertCleared(fixture);
+		} finally {
+			try {
+				if (process != null) {
+					process.destroyForcibly();
+					assertTrue("Could not clean up child JVM", process.waitFor(5, TimeUnit.SECONDS));
+				}
+			} finally {
+				Files.deleteIfExists(ready);
+				Files.deleteIfExists(directory);
+			}
+		}
+	}
+
+	private static void assertStartupFailure(Fixture fixture, Throwable expected) {
+		try {
+			fixture.runBare();
+			fail("Startup should fail");
+		} catch (Throwable actual) {
+			assertSame(expected, actual);
+		}
+		assertFalse("Test body must not run after failed setUp", fixture.testRan);
+		assertFalse("JUnit must not be relied on to clean up failed setUp", fixture.tornDown);
+	}
+
+	private static void assertCleared(Fixture fixture) {
+		assertNull(fixture.fVM);
+		assertNull(fixture.fLaunchedVM);
+		assertNull(fixture.fLaunchedProxy);
+		assertNull(fixture.fEventReader);
+		assertNull(fixture.fConsoleReader);
+		assertNull(fixture.fConsoleErrorReader);
+		assertNull(fixture.fProxyReader);
+		assertNull(fixture.fProxyErrorReader);
+	}
+
+	private static class Fixture extends AbstractJDITest {
+		Process nextVM;
+		Process nextProxy;
+		Error launchFailure;
+		Error attachFailure;
+		RuntimeException programFailure;
+		boolean useRealConnect;
+		boolean testRan;
+		boolean tornDown;
+
+		@Override
+		protected void launchTarget() {
+			fLaunchedProxy = nextProxy;
+			if (launchFailure != null) {
+				throw launchFailure;
+			}
+			fLaunchedVM = nextVM;
+		}
+
+		@Override
+		protected void connectToVM() {
+			if (useRealConnect) {
+				super.connectToVM();
+				return;
+			}
+			if (attachFailure != null) {
+				throw attachFailure;
+			}
+			fVM = (VirtualMachine) Proxy.newProxyInstance(VirtualMachine.class.getClassLoader(),
+					new Class<?>[] { VirtualMachine.class }, (proxy, method, args) -> {
+						if (method.getName().equals("exit")) {
+							return null;
+						}
+						throw new AssertionError("Unexpected VM call: " + method.getName());
+					});
+			fEventReader = new EventReader("cleanup test event reader", null);
+		}
+
+		@Override
+		protected void startProgram() {
+			if (programFailure != null) {
+				throw programFailure;
+			}
+		}
+
+		@Override
+		public void localSetUp() {
+		}
+
+		@Override
+		protected void runTest() {
+			testRan = true;
+		}
+
+		@Override
+		protected void tearDown() {
+			tornDown = true;
+			shutDownTarget();
+		}
+	}
+
+	private static class FakeProcess extends Process {
+		final List<String> calls = new ArrayList<>();
+		boolean alive = true;
+		boolean forceNeeded;
+		boolean forced;
+		boolean refuseExit;
+		boolean interruptWait;
+
+		@Override
+		public boolean isAlive() {
+			return alive;
+		}
+
+		@Override
+		public long pid() {
+			return 42;
+		}
+
+		@Override
+		public void destroy() {
+			calls.add("destroy");
+		}
+
+		@Override
+		public Process destroyForcibly() {
+			calls.add("force");
+			forced = true;
+			return this;
+		}
+
+		@Override
+		public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+			assertTrue("Wait must be bounded and positive", timeout > 0);
+			calls.add("wait");
+			if (interruptWait) {
+				interruptWait = false;
+				throw new InterruptedException();
+			}
+			if (refuseExit || (forceNeeded && !forced)) {
+				return false;
+			}
+			alive = false;
+			return true;
+		}
+
+		@Override
+		public int waitFor() {
+			throw new AssertionError("Unbounded waitFor must not be used");
+		}
+
+		@Override
+		public int exitValue() {
+			if (alive) {
+				throw new IllegalThreadStateException();
+			}
+			return 0;
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public OutputStream getOutputStream() {
+			return OutputStream.nullOutputStream();
+		}
+	}
+
+	/** A real subprocess that cannot exit normally before cleanup is requested. */
+	public static class WaitingProcess {
+		public static void main(String[] args) throws Exception {
+			Files.writeString(Path.of(args[0]), "ready");
+			new CountDownLatch(1).await();
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.debug.test.stepping.StepIntoSelectionWithGenerics;
 import org.eclipse.jdt.debug.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.debug.tests.breakpoints.BreakpointListenerTests;
 import org.eclipse.jdt.debug.tests.breakpoints.BreakpointLocationVerificationTests;
+import org.eclipse.jdt.debug.tests.breakpoints.BreakpointRemovalTests;
 import org.eclipse.jdt.debug.tests.breakpoints.BreakpointWorkingSetTests;
 import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsInJava8Tests;
 import org.eclipse.jdt.debug.tests.breakpoints.ConditionalBreakpointsTests;
@@ -409,6 +410,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(TargetPatternBreakpointTests.class));
 		addTest(new TestSuite(BreakpointListenerTests.class));
 		addTest(new TestSuite(JavaBreakpointListenerTests.class));
+		addTest(new TestSuite(BreakpointRemovalTests.class));
 		addTest(new TestSuite(MiscBreakpointsTests.class));
 		addTest(new TestSuite(ThreadNameChangeTests.class));
 		addTest(new TestSuite(BreakpointLocationVerificationTests.class));

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/BreakpointRemovalTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/breakpoints/BreakpointRemovalTests.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.breakpoints;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.debug.core.model.IBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaBreakpointListener;
+import org.eclipse.jdt.debug.core.IJavaClassPrepareBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
+import org.eclipse.jdt.debug.core.IJavaThread;
+import org.eclipse.jdt.debug.testplugin.EvalualtionBreakpointListener;
+import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget;
+
+/**
+ * Tests cleanup of Java breakpoints whose marker has been deleted or detached.
+ */
+public class BreakpointRemovalTests extends AbstractDebugTest {
+
+	private static final String NO_ASSOCIATED_MARKER = "Breakpoint does not have an associated marker"; //$NON-NLS-1$
+	private static final String DELETED_MARKER = "Breakpoint marker does not exist"; //$NON-NLS-1$
+	private static final String TEST_LISTENER = "org.eclipse.jdt.debug.tests.evalListener"; //$NON-NLS-1$
+
+	public BreakpointRemovalTests(String name) {
+		super(name);
+	}
+
+	/**
+	 * Tests the complete marker-deletion lifecycle while a debug target is
+	 * suspended at the deleted breakpoint.
+	 */
+	public void testMarkerDeletionCleansTargetAndAllowsReplacementBreakpoint() throws Exception {
+		String typeName = "HitCountLooper"; //$NON-NLS-1$
+		int loopLine = 19;
+		IJavaLineBreakpoint breakpoint = createLineBreakpoint(loopLine, typeName);
+		breakpoint.addBreakpointListener(TEST_LISTENER);
+		EvalualtionBreakpointListener.reset();
+		EvalualtionBreakpointListener.VOTE = IJavaBreakpointListener.SUSPEND;
+
+		List<IStatus> markerErrors = Collections.synchronizedList(new ArrayList<>());
+		ILogListener logListener = (status, plugin) -> {
+			if (containsMarkerError(status)) {
+				markerErrors.add(status);
+			}
+		};
+		IJavaThread thread = null;
+		boolean logListenerRegistered = false;
+		try {
+			thread = launchToLineBreakpoint(typeName, breakpoint);
+			assertNotNull("Breakpoint was not hit", thread); //$NON-NLS-1$
+			JDIDebugTarget target = (JDIDebugTarget) thread.getDebugTarget();
+			assertTrue("Breakpoint should be tracked by the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+			assertTrue("Breakpoint should be current in the suspended thread", containsByIdentity(thread.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+
+			Platform.addLogListener(logListener);
+			logListenerRegistered = true;
+			IWorkspaceRunnable runnable = monitor -> {
+				breakpoint.getMarker().delete();
+				get14Project().getProject().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
+			};
+			ResourcesPlugin.getWorkspace().run(runnable, null);
+
+			waitForRemovalNotification();
+			assertTrue("Breakpoint removal listener was not notified", EvalualtionBreakpointListener.REMOVED); //$NON-NLS-1$
+			waitForCleanup(target, thread, breakpoint);
+			assertFalse("Deleted breakpoint remained in the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+			assertFalse("Deleted breakpoint remained current in the suspended thread", containsByIdentity(thread.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+			assertTrue("Unexpected marker error while deleting breakpoint: " + markerErrors, markerErrors.isEmpty()); //$NON-NLS-1$
+
+			IJavaLineBreakpoint replacement = createLineBreakpoint(loopLine, typeName);
+			assertTrue("Replacement breakpoint was not installed in the debug target", containsByIdentity(target.getBreakpoints(), replacement)); //$NON-NLS-1$
+			thread = resumeToLineBreakpoint(thread, replacement);
+			assertNotNull("Replacement breakpoint was not hit", thread); //$NON-NLS-1$
+			assertTrue("Replacement breakpoint should be current in the suspended thread", containsByIdentity(thread.getBreakpoints(), replacement)); //$NON-NLS-1$
+			assertFalse("Deleted breakpoint became current again", containsByIdentity(thread.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+		} finally {
+			if (logListenerRegistered) {
+				Platform.removeLogListener(logListener);
+			}
+			terminateAndRemove(thread);
+			removeAllBreakpoints();
+		}
+	}
+
+	/**
+	 * Tests target-side cleanup when a removal notification carries a line
+	 * breakpoint whose marker association has already been cleared.
+	 */
+	public void testLineBreakpointRemovalAfterMarkerIsDetached() throws Exception {
+		String typeName = "HitCountLooper"; //$NON-NLS-1$
+		IJavaLineBreakpoint breakpoint = createLineBreakpoint(17, typeName);
+		breakpoint.addBreakpointListener(TEST_LISTENER);
+		EvalualtionBreakpointListener.reset();
+
+		IJavaThread thread = null;
+		IMarker marker = null;
+		try {
+			thread = launchToLineBreakpoint(typeName, breakpoint);
+			assertNotNull("Breakpoint was not hit", thread); //$NON-NLS-1$
+			JDIDebugTarget target = (JDIDebugTarget) thread.getDebugTarget();
+			assertTrue("Breakpoint should be tracked by the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+			assertTrue("Breakpoint should be current in the suspended thread", containsByIdentity(thread.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+
+			marker = detachMarker(breakpoint);
+			target.breakpointRemoved(breakpoint, null);
+
+			assertTrue("Breakpoint removal listener was not notified", EvalualtionBreakpointListener.REMOVED); //$NON-NLS-1$
+			assertFalse("Breakpoint without marker remained in the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+			assertFalse("Breakpoint without marker remained current in the suspended thread", containsByIdentity(thread.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+		} finally {
+			restoreMarker(breakpoint, marker);
+			terminateAndRemove(thread);
+			removeAllBreakpoints();
+		}
+	}
+
+	/**
+	 * Tests the class-prepare-specific request cleanup when the breakpoint marker
+	 * association has already been cleared.
+	 */
+	public void testClassPrepareBreakpointRemovalAfterMarkerIsDetached() throws Exception {
+		String typeName = "HitCountLooper"; //$NON-NLS-1$
+		IJavaClassPrepareBreakpoint breakpoint = createClassPrepareBreakpoint("DropTests"); //$NON-NLS-1$
+		breakpoint.addBreakpointListener(TEST_LISTENER);
+		IJavaLineBreakpoint launchBreakpoint = createLineBreakpoint(17, typeName);
+		EvalualtionBreakpointListener.reset();
+
+		IJavaThread thread = null;
+		IMarker marker = null;
+		try {
+			thread = launchToLineBreakpoint(typeName, launchBreakpoint);
+			assertNotNull("Launch breakpoint was not hit", thread); //$NON-NLS-1$
+			JDIDebugTarget target = (JDIDebugTarget) thread.getDebugTarget();
+			assertTrue("Class prepare breakpoint should be tracked by the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+
+			marker = detachMarker(breakpoint);
+			target.breakpointRemoved(breakpoint, null);
+
+			assertTrue("Breakpoint removal listener was not notified", EvalualtionBreakpointListener.REMOVED); //$NON-NLS-1$
+			assertFalse("Class prepare breakpoint without marker remained in the debug target", containsByIdentity(target.getBreakpoints(), breakpoint)); //$NON-NLS-1$
+		} finally {
+			restoreMarker(breakpoint, marker);
+			terminateAndRemove(thread);
+			removeAllBreakpoints();
+		}
+	}
+
+	private IMarker detachMarker(IJavaBreakpoint breakpoint) {
+		IMarker marker = breakpoint.getMarker();
+		try {
+			breakpoint.setMarker(null);
+		} catch (CoreException e) {
+			// Configuring the breakpoint cannot complete after the marker was detached.
+		}
+		assertNull("Breakpoint marker should be detached", breakpoint.getMarker()); //$NON-NLS-1$
+		return marker;
+	}
+
+	private static void restoreMarker(IJavaBreakpoint breakpoint, IMarker marker) throws CoreException {
+		if (breakpoint.getMarker() == null && marker != null) {
+			breakpoint.setMarker(marker);
+		}
+	}
+
+	private static void waitForRemovalNotification() throws InterruptedException {
+		long timeout = System.currentTimeMillis() + DEFAULT_TIMEOUT;
+		synchronized (EvalualtionBreakpointListener.REMOVE_LOCK) {
+			while (!EvalualtionBreakpointListener.REMOVED) {
+				long remaining = timeout - System.currentTimeMillis();
+				if (remaining <= 0) {
+					return;
+				}
+				EvalualtionBreakpointListener.REMOVE_LOCK.wait(remaining);
+			}
+		}
+	}
+
+	private static void waitForCleanup(JDIDebugTarget target, IJavaThread thread, IBreakpoint breakpoint) throws InterruptedException {
+		long timeout = System.currentTimeMillis() + DEFAULT_TIMEOUT;
+		while (containsByIdentity(target.getBreakpoints(), breakpoint) || containsByIdentity(thread.getBreakpoints(), breakpoint)) {
+			if (System.currentTimeMillis() >= timeout) {
+				return;
+			}
+			Thread.sleep(10);
+		}
+	}
+
+	private static boolean containsByIdentity(IBreakpoint[] breakpoints, IBreakpoint expected) {
+		for (IBreakpoint breakpoint : breakpoints) {
+			if (breakpoint == expected) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean containsByIdentity(List<IBreakpoint> breakpoints, IBreakpoint expected) {
+		synchronized (breakpoints) {
+			for (IBreakpoint breakpoint : breakpoints) {
+				if (breakpoint == expected) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean containsMarkerError(IStatus status) {
+		if (containsMarkerError(status.getMessage())) {
+			return true;
+		}
+		for (Throwable exception = status.getException(); exception != null; exception = exception.getCause()) {
+			if (containsMarkerError(exception.getMessage())) {
+				return true;
+			}
+		}
+		for (IStatus child : status.getChildren()) {
+			if (containsMarkerError(child)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean containsMarkerError(String message) {
+		return message != null && (message.contains(NO_ASSOCIATED_MARKER) || message.contains(DELETED_MARKER));
+	}
+}

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.26.100.qualifier
+Bundle-Version: 3.26.200.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaBreakpoint.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaBreakpoint.java
@@ -286,7 +286,7 @@ public abstract class JavaBreakpoint extends Breakpoint implements IJavaBreakpoi
 		// deletion.
 		// Don't try updating the marker (decrementing the install count) if
 		// it no longer exists.
-		if (!(request instanceof ClassPrepareRequest) && getMarker().exists()) {
+		if (!(request instanceof ClassPrepareRequest) && markerExists()) {
 			decrementInstallCount();
 		}
 	}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaClassPrepareBreakpoint.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/breakpoints/JavaClassPrepareBreakpoint.java
@@ -146,7 +146,7 @@ public class JavaClassPrepareBreakpoint extends JavaBreakpoint implements
 		// deletion.
 		// Don't try updating the marker (decrementing the install count) if
 		// it no longer exists.
-		if (getMarker().exists()) {
+		if (markerExists()) {
 			decrementInstallCount();
 		}
 	}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIDebugTarget.java
@@ -1629,17 +1629,30 @@ public class JDIDebugTarget extends JDIDebugElement implements
 		if (!isAvailable()) {
 			return;
 		}
-		if (supportsBreakpoint(breakpoint)) {
+		// A removal notification can arrive after the marker is no longer
+		// available. Use the target's installed state instead of marker data.
+		boolean installed = false;
+		synchronized (fBreakpoints) {
+			for (IBreakpoint installedBreakpoint : fBreakpoints) {
+				if (installedBreakpoint == breakpoint) {
+					installed = true;
+					break;
+				}
+			}
+		}
+		if (installed) {
 			try {
 				((JavaBreakpoint) breakpoint).removeFromTarget(this);
-				getBreakpoints().remove(breakpoint);
-				Iterator<JDIThread> threads = getThreadIterator();
-				while (threads.hasNext()) {
-					threads.next()
-							.removeCurrentBreakpoint(breakpoint);
-				}
 			} catch (CoreException e) {
 				logError(e);
+			} finally {
+				synchronized (fBreakpoints) {
+					fBreakpoints.removeIf(installedBreakpoint -> installedBreakpoint == breakpoint);
+				}
+				Iterator<JDIThread> threads = getThreadIterator();
+				while (threads.hasNext()) {
+					threads.next().removeCurrentBreakpoint(breakpoint);
+				}
 			}
 		}
 	}

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/model/JDIThread.java
@@ -476,7 +476,7 @@ public class JDIThread extends JDIDebugElement implements IJavaThread {
 	 */
 	protected void removeCurrentBreakpoint(IBreakpoint bp) {
 		synchronized (breakpointAcessLock) {
-			fCurrentBreakpoints.remove(bp);
+			fCurrentBreakpoints.removeIf(breakpoint -> breakpoint == bp);
 		}
 	}
 


### PR DESCRIPTION
## What it does

Addresses marker-loss cleanup scenarios described in
[#55](https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/55).

The issue collects the following historical reports:

- [Bug 576200 — Stale Breakpoint Confusion](https://bugs.eclipse.org/bugs/show_bug.cgi?id=576200)
- [Bug 354784 — DebugException: Breakpoint does not have an associated marker](https://bugs.eclipse.org/bugs/show_bug.cgi?id=354784)

This change makes breakpoint removal tolerate a deleted marker or a
missing marker association, so that an already tracked breakpoint does
not remain referenced by the debug target or its threads merely because
marker-dependent operations fail.

### Why the removal path needs to change

Previously, `JDIDebugTarget.breakpointRemoved(...)` re-evaluated
`supportsBreakpoint(...)` during removal. Request deregistration also
called `getMarker().exists()` without handling a missing marker, and
collection removal could invoke marker-dependent breakpoint equality.

These checks are problematic during removal: a breakpoint that was
previously accepted and tracked by the target must still be removable
after its marker has disappeared. Its current marker state is no longer
a reliable basis for deciding whether the target needs to clean it up.

The breakpoint-specific changes therefore:

- Identify tracked breakpoints by object identity instead of
  re-evaluating marker-backed support during removal.
- Guard install-count updates with `markerExists()` in both
  `JavaBreakpoint` and `JavaClassPrepareBreakpoint`.
- Remove target and thread references in a `finally` block, so a
  `CoreException` during request cleanup does not prevent this reference
  cleanup.
- Remove current thread breakpoints by object identity instead of
  invoking marker-dependent equality.

The exception-safe cleanup guarantee concerns target and thread
references. This change does not introduce a general recovery mechanism
for arbitrary failures while deleting JDI requests.

The historical reports provide the context for this work. The regression
tests cover the specific scenarios described below; this PR does not
claim to resolve every failure mode collected under #55.

## Dependency on #992 and review scope

**Please review and merge
[#992](https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/992) first.**

The current branch includes the JDI test-infrastructure snapshot
`df207cea34032ef36ac3a9d2073aa0cf8dcd5e2f` from #992 through merge commit
`b33666436ec20c8888fe87b01af16cbd32605864`.

Consequently, the current diff against `master` contains both the
breakpoint-removal changes and additional changes under
`org.eclipse.jdt.debug.jdi.tests`. The infrastructure work is a separate
change, included as a separately reviewable CI prerequisite rather than
as part of the breakpoint-removal implementation. The imported snapshot
is not necessarily the latest revision of #992.

### Rationale and impact of the included infrastructure changes

The JDI test harness starts VM/proxy processes and reader threads during
test setup. A startup failure can occur before normal teardown is
available; in particular, JUnit does not invoke `tearDown()` when
`setUp()` fails. The infrastructure change adds cleanup at the startup
entry points so that such failures do not simply leave owned processes
and reader state behind.

The included changes cover cleanup after launch, attach or program
startup failure; null-safe handling when the event reader has not yet
been created; bounded waits for normal and forced process termination;
and preservation of the original startup failure when cleanup also
fails. Interruption is preserved, and proxy cleanup is attempted even
when VM cleanup fails.

The included snapshot also passes a bounded timeout to the JDI
connector. A retry-loop deadline alone cannot bound an individual attach
attempt when a peer accepts the socket but does not complete the JDWP
handshake. Connection failures retain diagnostic information about the
process state before cleanup.

These are shared test-harness behavior changes, not just additional
tests for the breakpoint fix. They affect startup failure handling and
shutdown across the JDI test suite, including bounded waiting and
possible forced termination of owned processes. They do not change
product-side debugger connection timeouts. Their independent rationale,
regression coverage and review belong in #992.

This does **not** establish that the earlier connection-refused CI
failures were caused by a silent JDWP peer, or that the infrastructure
change explains every earlier test failure.

Before merging this PR, integrate #992, update this branch to the
resulting upstream state, and verify that the remaining diff contains
only the breakpoint-specific changes, their regression tests and the
required bundle-version increment. The infrastructure changes should
not be squashed into the breakpoint fix.

## How to test

Run `BreakpointRemovalTests` as a JUnit Plug-in Test. The class is also
included in `org.eclipse.jdt.debug.tests.AutomatedSuite`.

### Marker deletion and replacement breakpoint

`testMarkerDeletionCleansTargetAndAllowsReplacementBreakpoint`

Launches `HitCountLooper` and suspends at line 19 inside its loop.
Deletes the breakpoint marker through the workspace, checks the removal
notification and target/thread reference cleanup, and checks that no
missing-marker or deleted-marker error was logged during removal.

It then creates a replacement breakpoint at the same line and verifies
that the replacement is hit after resuming.

### Line breakpoint with a detached marker

`testLineBreakpointRemovalAfterMarkerIsDetached`

Suspends at a line breakpoint, deliberately clears its marker
association, and invokes the target's removal callback. Checks the
removal notification and removal from target and thread state.

### Class-prepare breakpoint with a detached marker

`testClassPrepareBreakpointRemovalAfterMarkerIsDetached`

Keeps a class-prepare breakpoint for `DropTests` tracked while
`HitCountLooper` is suspended at an independent line breakpoint.
Deliberately clears the class-prepare breakpoint's marker association
and invokes the removal callback. Checks the removal notification and
removal from target state.

The detached-marker tests exercise explicitly constructed error states.
No separate fault-injection test for a `CoreException` during request
cleanup is included.

The infrastructure regression tests, `VMStartupCleanupTest` and
`VMConnectionTimeoutTest`, are included in the JDI `AutomatedSuite` and
belong to the separate review of #992.

### CI status

For combined-branch commit
`b33666436ec20c8888fe87b01af16cbd32605864`, GitHub reports the
`continuous-integration/jenkins/pr-head` check as successful:

[Jenkins PR-990, build 26](https://ci.eclipse.org/jdt/job/eclipse.jdt.debug-github/job/PR-990/26/display/redirect)

This records the reported CI status for that specific revision. CI must
be rerun after updating the branch to the final merged version of #992.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)