### PR TITLE
Ensure JDI test VM cleanup after failed startup

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -25,9 +25,11 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.debug.jdi.tests.program.MainClass;
 import org.eclipse.jdi.Bootstrap;
+import org.eclipse.jdi.TimeoutException;
 import org.eclipse.jdi.internal.VirtualMachineImpl;
 
 import com.sun.jdi.AbsentInformationException;
@@ -918,7 +920,10 @@ public abstract class AbstractJDITest extends TestCase {
 		startConsoleReaders();
 
 
-		// Contact the VM (try at least 10 times for 5 seconds)
+		// Bound each attach as well as the retry loop. A zero connector timeout
+		// waits forever if a peer accepts the socket but does not complete JDWP.
+		long timeoutNanos = TimeUnit.SECONDS.toNanos(5);
+		Throwable connectionFailure = null;
 		long n0 = System.nanoTime();
 		for (int i = 0; i < 10000; i++) {
 			if (Thread.currentThread().isInterrupted()) {
@@ -934,6 +939,8 @@ public abstract class AbstractJDITest extends TestCase {
 				Map<String, Argument> args = connector.defaultArguments();
 				args.get("port").setValue(String.valueOf(fBackEndPort));
 				args.get("hostname").setValue("localhost");
+				long remainingMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(timeoutNanos - (System.nanoTime() - n0)));
+				args.get("timeout").setValue(Long.toString(remainingMillis));
 
 				fVM = connector.attach(args);
 				if (fVMTraceFlags != com.sun.jdi.VirtualMachine.TRACE_NONE) {
@@ -942,9 +949,10 @@ public abstract class AbstractJDITest extends TestCase {
 				break;
 			} catch (IllegalConnectorArgumentsException e) {
 				e.printStackTrace();
-			} catch (IOException e) {
+			} catch (IOException | TimeoutException e) {
+				connectionFailure = e;
 				long n1 = System.nanoTime();
-				if (i > 10 && n1 - n0 > 5_000_000_000L) {
+				if (n1 - n0 >= timeoutNanos) {
 					e.printStackTrace();
 					System.out.println("Could not contact the VM at localhost" + ":" + fBackEndPort + " after " + (n1 - n0) / 1_000_000L + "ms");
 					break;
@@ -975,11 +983,34 @@ public abstract class AbstractJDITest extends TestCase {
 				}
 
 			}
-			throw new Error("Could not contact the VM");
+			Error failure = new Error("Could not contact the VM", connectionFailure);
+			// Retain pre-cleanup state in the test failure even when console output
+			// from the target process is missing from the CI test report.
+			failure.addSuppressed(new IllegalStateException("JDI startup at localhost:" + fBackEndPort
+					+ "; target " + describeProcess(fLaunchedVM) + "; proxy " + describeProcess(fLaunchedProxy)
+					+ "; runtime=" + Runtime.version() + "; vendor=" + System.getProperty("java.vendor")));
+			throw failure;
 		}
 		long n1 = System.nanoTime(); // for example after ~ 110ms
 		System.out.println("Connected to localhost" + ":" + fBackEndPort + " after " + (n1 - n0) / 1_000_000L + "ms");
 		startEventReader();
+	}
+
+	private static String describeProcess(Process process) {
+		if (process == null) {
+			return "not started";
+		}
+		String pid;
+		try {
+			pid = Long.toString(process.pid());
+		} catch (UnsupportedOperationException e) {
+			pid = "unavailable";
+		}
+		try {
+			return "pid=" + pid + ", alive=false, exitCode=" + process.exitValue();
+		} catch (IllegalThreadStateException e) {
+			return "pid=" + pid + ", alive=true";
+		}
 	}
 	/**
 	 * Initializes the fields that are used by this test only.

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AbstractJDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Carsten Hammer - cleanup after failed test VM startup
  *******************************************************************************/
 package org.eclipse.debug.jdi.tests;
 
@@ -562,7 +563,7 @@ public abstract class AbstractJDITest extends TestCase {
 	 * NOTE: This assumes that the VM can watch field access.
 	 */
 	protected AccessWatchpointRequest getStaticAccessWatchpointRequest() {
-		// Get the static field
+		// Get the field
 		Field field = getField("fString");
 
 		// Create an access watchpoint for this field
@@ -671,8 +672,13 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Launches the target VM and connects to VM.
 	 */
 	protected void launchTargetAndConnectToVM() {
-		launchTarget();
-		connectToVM();
+		try {
+			launchTarget();
+			connectToVM();
+		} catch (RuntimeException | Error failure) {
+			cleanupAfterFailedStartup(failure);
+			throw failure;
+		}
 	}
 
 	protected boolean vmIsRunning() {
@@ -915,6 +921,9 @@ public abstract class AbstractJDITest extends TestCase {
 		// Contact the VM (try at least 10 times for 5 seconds)
 		long n0 = System.nanoTime();
 		for (int i = 0; i < 10000; i++) {
+			if (Thread.currentThread().isInterrupted()) {
+				throw new Error("Interrupted while connecting to the VM", new InterruptedException());
+			}
 			try {
 				VirtualMachineManager manager = Bootstrap.virtualMachineManager();
 				List<AttachingConnector> connectors = manager.attachingConnectors();
@@ -943,6 +952,8 @@ public abstract class AbstractJDITest extends TestCase {
 				try {
 					Thread.sleep(10);
 				} catch (InterruptedException interrupted) {
+					Thread.currentThread().interrupt();
+					throw new Error("Interrupted while connecting to the VM", interrupted);
 				}
 			}
 		}
@@ -963,8 +974,6 @@ public abstract class AbstractJDITest extends TestCase {
 				} catch (IOException e) {
 				}
 
-				// Shut it down
-				killVM();
 			}
 			throw new Error("Could not contact the VM");
 		}
@@ -1158,7 +1167,23 @@ public abstract class AbstractJDITest extends TestCase {
 	 */
 	protected void launchTargetAndStartProgram() {
 		launchTargetAndConnectToVM();
-		startProgram();
+		try {
+			startProgram();
+		} catch (RuntimeException | Error failure) {
+			cleanupAfterFailedStartup(failure);
+			throw failure;
+		}
+	}
+
+	private void cleanupAfterFailedStartup(Throwable failure) {
+		// JUnit does not call tearDown() when setUp() fails.
+		try {
+			shutDownTarget();
+		} catch (RuntimeException | Error cleanupFailure) {
+			if (cleanupFailure != failure) {
+				failure.addSuppressed(cleanupFailure);
+			}
+		}
 	}
 	/**
 	 * Init tests
@@ -1201,29 +1226,57 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Shut down the target.
 	 */
 	public void shutDownTarget() {
-		stopReaders();
-		if (fVM != null) {
+		boolean hadTarget = fVM != null || fLaunchedVM != null || fLaunchedProxy != null;
+		Throwable failure = null;
+		try {
+			stopReaders();
+			if (fVM != null) {
+				try {
+					fVM.exit(0);
+				} catch (VMDisconnectedException e) {
+				}
+			}
+		} catch (RuntimeException | Error e) {
+			failure = e;
+			throw e;
+		} finally {
 			try {
-				fVM.exit(0);
-			} catch (VMDisconnectedException e) {
+				killVM();
+			} catch (RuntimeException | Error cleanupFailure) {
+				if (failure == null) {
+					throw cleanupFailure;
+				}
+				if (failure != cleanupFailure) {
+					failure.addSuppressed(cleanupFailure);
+				}
+			} finally {
+				fVM = null;
+				// Keep a handle to a process whose termination failed.
+				if (fLaunchedVM != null && !fLaunchedVM.isAlive()) {
+					fLaunchedVM = null;
+				}
+				if (fLaunchedProxy != null && !fLaunchedProxy.isAlive()) {
+					fLaunchedProxy = null;
+				}
+				fEventReader = null;
+				fConsoleReader = null;
+				fConsoleErrorReader = null;
+				fProxyReader = null;
+				fProxyErrorReader = null;
+				if (hadTarget) {
+					selectNextPort();
+				}
 			}
 		}
+	}
 
-		fVM = null;
-		fLaunchedVM = null;
-
-		// We want subsequent connections to use different ports, unless a
-		// VM exec sting is given.
+	private static void selectNextPort() {
+		// Preserve the port embedded in a user-supplied VM command.
 		if (fVmCmd == null) {
-			ServerSocket socket;
-			try {
-				socket = new ServerSocket(0);
-				int availablePort = socket.getLocalPort();
-				socket.close(); //Available but always initialized
-				fBackEndPort = availablePort;
+			try (ServerSocket socket = new ServerSocket(0)) {
+				fBackEndPort = socket.getLocalPort();
 			} catch (IOException e) {
-				fBackEndPort +=2;
-
+				fBackEndPort += 2;
 			}
 		}
 	}
@@ -1317,15 +1370,12 @@ public abstract class AbstractJDITest extends TestCase {
 	 * Stops the event reader.
 	 */
 	private void stopEventReader() {
-		fEventReader.stop();
+		if (fEventReader != null) {
+			fEventReader.stop();
+		}
 	}
 	protected void killVM() {
-		if (fLaunchedVM != null) {
-			fLaunchedVM.destroy();
-		}
-		if (fLaunchedProxy != null) {
-			fLaunchedProxy.destroy();
-		}
+		TestProcessCleanup.terminate(fLaunchedVM, fLaunchedProxy);
 	}
 	/**
 	 * Starts the target program.

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2022 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class AutomatedSuite extends TestSuite {
 	public AutomatedSuite() {
 		AbstractJDITest.parseArgs(new String[] {});
 
+		addTest(new TestSuite(VMStartupCleanupTest.class));
 		addTest(new TestSuite(AccessibleTest.class));
 		addTest(new TestSuite(ArrayReferenceTest.class));
 		addTest(new TestSuite(ArrayTypeTest.class));

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/AutomatedSuite.java
@@ -32,6 +32,7 @@ public class AutomatedSuite extends TestSuite {
 	public AutomatedSuite() {
 		AbstractJDITest.parseArgs(new String[] {});
 
+		addTest(new TestSuite(VMConnectionTimeoutTest.class));
 		addTest(new TestSuite(VMStartupCleanupTest.class));
 		addTest(new TestSuite(AccessibleTest.class));
 		addTest(new TestSuite(ArrayReferenceTest.class));

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.util.concurrent.TimeUnit;
+
+/** Bounded termination of processes owned by a JDI test. */
+final class TestProcessCleanup {
+	private static final long EXIT_TIMEOUT_MILLIS = 5000;
+
+	private TestProcessCleanup() {
+	}
+
+	static void terminate(Process... processes) {
+		terminate(EXIT_TIMEOUT_MILLIS, processes);
+	}
+
+	static void terminate(long timeoutMillis, Process... processes) {
+		if (timeoutMillis <= 0) {
+			throw new IllegalArgumentException("Process exit timeout must be positive");
+		}
+		Throwable failure = null;
+		for (Process process : processes) {
+			try {
+				terminate(process, timeoutMillis);
+			} catch (RuntimeException | Error e) {
+				if (failure == null) {
+					failure = e;
+				} else if (failure != e) {
+					failure.addSuppressed(e);
+				}
+			}
+		}
+		if (failure instanceof RuntimeException e) {
+			throw e;
+		}
+		if (failure instanceof Error e) {
+			throw e;
+		}
+	}
+
+	private static void terminate(Process process, long timeoutMillis) {
+		if (process == null || !process.isAlive()) {
+			return;
+		}
+		// Cleanup must still run when startup was interrupted. Restore the flag below.
+		boolean interrupted = Thread.interrupted();
+		try {
+			process.destroy();
+			if (!interrupted) {
+				try {
+					if (process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+						return;
+					}
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+			process.destroyForcibly();
+			long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+			while (process.isAlive()) {
+				long remaining = deadline - System.nanoTime();
+				if (remaining <= 0) {
+					throw terminationFailure(process);
+				}
+				try {
+					if (!process.waitFor(remaining, TimeUnit.NANOSECONDS) && process.isAlive()) {
+						throw terminationFailure(process);
+					}
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+		} finally {
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+
+	private static IllegalStateException terminationFailure(Process process) {
+		return new IllegalStateException("Test process " + process.pid() + " did not terminate after destroyForcibly()");
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
@@ -89,7 +89,12 @@ final class TestProcessCleanup {
 		}
 	}
 
-	private static IllegalStateException terminationFailure(Process process) {
-		return new IllegalStateException("Test process " + process.pid() + " did not terminate after destroyForcibly()");
+private static IllegalStateException terminationFailure(Process process) {
+	String pid;
+	try {
+		pid = Long.toString(process.pid());
+	} catch (UnsupportedOperationException e) {
+		pid = "unavailable";
 	}
+	return new IllegalStateException("Test process " + pid + " did not terminate after destroyForcibly()");
 }

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/TestProcessCleanup.java
@@ -89,12 +89,13 @@ final class TestProcessCleanup {
 		}
 	}
 
-private static IllegalStateException terminationFailure(Process process) {
-	String pid;
-	try {
-		pid = Long.toString(process.pid());
-	} catch (UnsupportedOperationException e) {
-		pid = "unavailable";
+	private static IllegalStateException terminationFailure(Process process) {
+		String pid;
+		try {
+			pid = Long.toString(process.pid());
+		} catch (UnsupportedOperationException e) {
+			pid = "unavailable";
+		}
+		return new IllegalStateException("Test process " + pid + " did not terminate after destroyForcibly()");
 	}
-	return new IllegalStateException("Test process " + pid + " did not terminate after destroyForcibly()");
 }

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMConnectionTimeoutTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMConnectionTimeoutTest.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import junit.framework.TestCase;
+
+/** Tests the deadline and subsequent cleanup with the real JDI connector. */
+public class VMConnectionTimeoutTest extends TestCase {
+
+	public void testPeerThatDoesNotCompleteHandshakeCannotBlockStartup() throws Exception {
+		assertSilentPeerIsBounded(false);
+	}
+
+	public void testHandshakeTimeoutReachesCleanupAndRetainsDiagnostics() throws Exception {
+		assertSilentPeerIsBounded(true);
+	}
+
+	private void assertSilentPeerIsBounded(boolean throughStartup) throws Exception {
+		int previousPort = AbstractJDITest.fBackEndPort;
+		ConnectionProbe probe = new ConnectionProbe();
+		FutureTask<Void> attempt = new FutureTask<>(() -> {
+			if (throughStartup) {
+				probe.launchTargetAndConnectToVM();
+			} else {
+				probe.connectToVM();
+			}
+			return null;
+		});
+		Thread connecting = new Thread(attempt, "JDI startup timeout test");
+		connecting.setDaemon(true);
+		try (ServerSocket listener = new ServerSocket(0)) {
+			listener.setSoTimeout(10000);
+			AbstractJDITest.fBackEndPort = listener.getLocalPort();
+			connecting.start();
+			try (Socket peer = listener.accept()) {
+				peer.setSoTimeout(10000);
+				assertEquals("JDWP-Handshake", new String(peer.getInputStream().readNBytes(14), StandardCharsets.US_ASCII));
+				// Keep the connection open without answering its JDWP handshake.
+				try {
+					attempt.get(10, TimeUnit.SECONDS);
+					fail("A peer without a JDWP handshake must not be accepted as a VM");
+				} catch (ExecutionException expected) {
+					Throwable failure = expected.getCause();
+					assertTrue("Startup must report its ordinary connection failure: " + failure, failure instanceof Error);
+					assertEquals("Could not contact the VM", failure.getMessage());
+					assertTrue("Retain the transport timeout as the cause", failure.getCause() instanceof org.eclipse.jdi.TimeoutException);
+					assertTrue("Record the process state before cleanup, not after destroying it",
+							Arrays.stream(failure.getSuppressed()).anyMatch(detail -> detail.getMessage() != null
+									&& detail.getMessage().contains("pid=42, alive=true")
+									&& detail.getMessage().contains("localhost:" + listener.getLocalPort())));
+					if (throughStartup) {
+						assertFalse("Cleanup must terminate the owned process", probe.process.isAlive());
+						assertNull("Cleanup must clear the target handle", probe.fLaunchedVM);
+						assertNull(probe.fConsoleReader);
+						assertNull(probe.fConsoleErrorReader);
+					}
+				} catch (TimeoutException expected) {
+					fail("The connector blocked past the startup deadline on a silent peer");
+				}
+			}
+		} finally {
+			// Closing the peer releases even the unfixed implementation.
+			try {
+				connecting.join(10000);
+				assertFalse("Startup thread did not terminate after the peer closed", connecting.isAlive());
+			} finally {
+				probe.stopConsoleTestReaders();
+				probe.process.destroy();
+				AbstractJDITest.fBackEndPort = previousPort;
+			}
+		}
+	}
+
+	private static final class ConnectionProbe extends AbstractJDITest {
+		final Process process = new StreamOnlyProcess();
+
+		ConnectionProbe() {
+			fLaunchedVM = process;
+		}
+
+		@Override
+		protected void launchTarget() {
+			// Only the process is substituted; attach uses the real transport.
+		}
+
+		@Override
+		public void localSetUp() {
+			// No target program is needed for a transport-level startup failure.
+		}
+
+		void stopConsoleTestReaders() {
+			if (fConsoleReader != null) {
+				fConsoleReader.stop();
+			}
+			if (fConsoleErrorReader != null) {
+				fConsoleErrorReader.stop();
+			}
+		}
+	}
+
+	private static final class StreamOnlyProcess extends Process {
+		private volatile boolean alive = true;
+
+		@Override
+		public OutputStream getOutputStream() {
+			return OutputStream.nullOutputStream();
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public int waitFor() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int exitValue() {
+			if (alive) {
+				throw new IllegalThreadStateException();
+			}
+			return 0;
+		}
+
+		@Override
+		public long pid() {
+			return 42;
+		}
+
+		@Override
+		public void destroy() {
+			alive = false;
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
@@ -1,0 +1,448 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.jdi.tests;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.jdi.VirtualMachine;
+
+import junit.framework.TestCase;
+
+/** Tests failure paths without relying on a slow or overloaded debug VM. */
+public class VMStartupCleanupTest extends TestCase {
+	private int previousPort;
+	private String previousCommand;
+
+	@Override
+	protected void setUp() {
+		previousPort = AbstractJDITest.fBackEndPort;
+		previousCommand = AbstractJDITest.fVmCmd;
+		AbstractJDITest.fVmCmd = null;
+	}
+
+	@Override
+	protected void tearDown() {
+		AbstractJDITest.fBackEndPort = previousPort;
+		AbstractJDITest.fVmCmd = previousCommand;
+	}
+
+	public void testFailedAttachCleansProcessesWithoutEventReader() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.nextProxy = proxy;
+		fixture.attachFailure = new Error("attach failed");
+		AbstractJDITest.fBackEndPort = 0;
+
+		assertStartupFailure(fixture, fixture.attachFailure);
+
+		assertFalse(vm.isAlive());
+		assertFalse(proxy.isAlive());
+		assertCleared(fixture);
+		assertTrue(AbstractJDITest.fBackEndPort > 0);
+	}
+
+	public void testLaunchFailureCleansAlreadyStartedProxy() {
+		Fixture fixture = new Fixture();
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextProxy = proxy;
+		fixture.launchFailure = new Error("VM launch failed");
+
+		assertStartupFailure(fixture, fixture.launchFailure);
+
+		assertFalse(proxy.isAlive());
+		assertCleared(fixture);
+	}
+
+	public void testProgramStartupFailureCleansVMAndReaders() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.programFailure = new IllegalStateException("program did not become ready");
+		AbstractReader reader = new AbstractReader("cleanup test reader") {
+			@Override
+			protected void readerLoop() {
+			}
+		};
+		fixture.fConsoleReader = reader;
+		fixture.fConsoleErrorReader = reader;
+		fixture.fProxyReader = reader;
+		fixture.fProxyErrorReader = reader;
+
+		assertStartupFailure(fixture, fixture.programFailure);
+
+		assertTrue(reader.fIsStopping);
+		assertFalse(vm.isAlive());
+		assertCleared(fixture);
+	}
+
+	public void testCleanupFailureDoesNotReplaceStartupFailure() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		vm.refuseExit = true;
+		FakeProcess proxy = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.nextProxy = proxy;
+		fixture.attachFailure = new Error("original attach failure");
+
+		assertStartupFailure(fixture, fixture.attachFailure);
+
+		assertEquals(1, fixture.attachFailure.getSuppressed().length);
+		assertTrue(fixture.attachFailure.getSuppressed()[0] instanceof IllegalStateException);
+		assertFalse(proxy.isAlive());
+		assertSame(vm, fixture.fLaunchedVM);
+		vm.alive = false;
+		fixture.shutDownTarget();
+		assertCleared(fixture);
+	}
+
+	public void testShutdownIsIdempotent() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.fLaunchedVM = vm;
+		fixture.shutDownTarget();
+		int port = AbstractJDITest.fBackEndPort;
+		fixture.shutDownTarget();
+		assertEquals(List.of("destroy", "wait"), vm.calls);
+		assertEquals(port, AbstractJDITest.fBackEndPort);
+		assertCleared(fixture);
+	}
+
+	public void testCustomVMCommandKeepsPort() {
+		AbstractJDITest.fVmCmd = "user supplied command";
+		Fixture fixture = new Fixture();
+		fixture.fLaunchedVM = new FakeProcess();
+		fixture.shutDownTarget();
+		assertEquals(previousPort, AbstractJDITest.fBackEndPort);
+		assertCleared(fixture);
+	}
+
+	public void testNextStartupDoesNotReuseFailedVM() {
+		Fixture fixture = new Fixture();
+		FakeProcess first = new FakeProcess();
+		fixture.nextVM = first;
+		fixture.attachFailure = new Error("first attach failed");
+		assertStartupFailure(fixture, fixture.attachFailure);
+		assertCleared(fixture);
+
+		FakeProcess second = new FakeProcess();
+		fixture.nextVM = second;
+		fixture.attachFailure = null;
+		try {
+			fixture.launchTargetAndConnectToVM();
+			assertFalse(first.isAlive());
+			assertTrue(second.isAlive());
+			assertSame(second, fixture.fLaunchedVM);
+			assertNotNull(fixture.fVM);
+		} finally {
+			fixture.shutDownTarget();
+		}
+		assertCleared(fixture);
+	}
+
+	public void testInterruptedAttachCleansVMAndPreservesInterrupt() {
+		Fixture fixture = new Fixture();
+		FakeProcess vm = new FakeProcess();
+		fixture.nextVM = vm;
+		fixture.useRealConnect = true;
+		Thread.currentThread().interrupt();
+		try {
+			try {
+				fixture.launchTargetAndConnectToVM();
+				fail("Interrupted startup should fail");
+			} catch (Error failure) {
+				assertTrue(failure.getCause() instanceof InterruptedException);
+			}
+			assertTrue(Thread.currentThread().isInterrupted());
+			assertFalse(vm.isAlive());
+			assertCleared(fixture);
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testGracefulTerminationWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		TestProcessCleanup.terminate(10000, process);
+		assertEquals(List.of("destroy", "wait"), process.calls);
+		assertFalse(process.isAlive());
+	}
+
+	public void testForcedTerminationAlsoWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		process.forceNeeded = true;
+		TestProcessCleanup.terminate(10000, process);
+		assertEquals(List.of("destroy", "wait", "force", "wait"), process.calls);
+		assertFalse(process.isAlive());
+	}
+
+	public void testInterruptedWaitStillTerminatesProcess() {
+		FakeProcess process = new FakeProcess();
+		process.interruptWait = true;
+		try {
+			TestProcessCleanup.terminate(10000, process);
+			assertEquals(List.of("destroy", "wait", "force", "wait"), process.calls);
+			assertFalse(process.isAlive());
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testAlreadyInterruptedCleanupStillWaitsForExit() {
+		FakeProcess process = new FakeProcess();
+		Thread.currentThread().interrupt();
+		try {
+			TestProcessCleanup.terminate(10000, process);
+			assertEquals(List.of("destroy", "force", "wait"), process.calls);
+			assertFalse(process.isAlive());
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	public void testAlreadyExitedAndMissingProcessesAreIgnored() {
+		FakeProcess process = new FakeProcess();
+		process.alive = false;
+		TestProcessCleanup.terminate(10000, null, process);
+		assertTrue(process.calls.isEmpty());
+	}
+
+	public void testAllProcessesAreAttemptedAndFailuresPreserved() {
+		FakeProcess first = new FakeProcess();
+		FakeProcess second = new FakeProcess();
+		FakeProcess third = new FakeProcess();
+		first.refuseExit = true;
+		second.refuseExit = true;
+		try {
+			TestProcessCleanup.terminate(10000, first, second, third);
+			fail("Unterminated processes must be reported");
+		} catch (IllegalStateException failure) {
+			assertTrue(failure.getMessage().contains("42"));
+			assertEquals(1, failure.getSuppressed().length);
+		}
+		assertEquals(List.of("destroy", "wait", "force", "wait"), first.calls);
+		assertEquals(first.calls, second.calls);
+		assertFalse(third.isAlive());
+	}
+
+	public void testFailedStartupTerminatesRealJavaProcess() throws Exception {
+		Path directory = Files.createTempDirectory("jdi-startup-cleanup");
+		Path ready = directory.resolve("ready");
+		Process process = null;
+		try {
+			String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+			process = new ProcessBuilder(java, "-cp", AbstractJDITest.fClassPath,
+					WaitingProcess.class.getName(), ready.toString())
+					.redirectError(ProcessBuilder.Redirect.INHERIT).start();
+			long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(AbstractJDITest.TIMEOUT);
+			while (!Files.exists(ready) && process.isAlive() && System.nanoTime() < deadline) {
+				Thread.sleep(10);
+			}
+			assertTrue("Child JVM did not become ready", Files.exists(ready));
+			assertTrue("Child JVM exited before cleanup", process.isAlive());
+			Fixture fixture = new Fixture();
+			fixture.nextVM = process;
+			fixture.attachFailure = new Error("injected attach failure");
+			assertStartupFailure(fixture, fixture.attachFailure);
+			assertFalse("Failed startup left its JVM alive", process.isAlive());
+			assertCleared(fixture);
+		} finally {
+			try {
+				if (process != null) {
+					process.destroyForcibly();
+					assertTrue("Could not clean up child JVM", process.waitFor(5, TimeUnit.SECONDS));
+				}
+			} finally {
+				Files.deleteIfExists(ready);
+				Files.deleteIfExists(directory);
+			}
+		}
+	}
+
+	private static void assertStartupFailure(Fixture fixture, Throwable expected) {
+		try {
+			fixture.runBare();
+			fail("Startup should fail");
+		} catch (Throwable actual) {
+			assertSame(expected, actual);
+		}
+		assertFalse("Test body must not run after failed setUp", fixture.testRan);
+		assertFalse("JUnit must not be relied on to clean up failed setUp", fixture.tornDown);
+	}
+
+	private static void assertCleared(Fixture fixture) {
+		assertNull(fixture.fVM);
+		assertNull(fixture.fLaunchedVM);
+		assertNull(fixture.fLaunchedProxy);
+		assertNull(fixture.fEventReader);
+		assertNull(fixture.fConsoleReader);
+		assertNull(fixture.fConsoleErrorReader);
+		assertNull(fixture.fProxyReader);
+		assertNull(fixture.fProxyErrorReader);
+	}
+
+	private static class Fixture extends AbstractJDITest {
+		Process nextVM;
+		Process nextProxy;
+		Error launchFailure;
+		Error attachFailure;
+		RuntimeException programFailure;
+		boolean useRealConnect;
+		boolean testRan;
+		boolean tornDown;
+
+		@Override
+		protected void launchTarget() {
+			fLaunchedProxy = nextProxy;
+			if (launchFailure != null) {
+				throw launchFailure;
+			}
+			fLaunchedVM = nextVM;
+		}
+
+		@Override
+		protected void connectToVM() {
+			if (useRealConnect) {
+				super.connectToVM();
+				return;
+			}
+			if (attachFailure != null) {
+				throw attachFailure;
+			}
+			fVM = (VirtualMachine) Proxy.newProxyInstance(VirtualMachine.class.getClassLoader(),
+					new Class<?>[] { VirtualMachine.class }, (proxy, method, args) -> {
+						if (method.getName().equals("exit")) {
+							return null;
+						}
+						throw new AssertionError("Unexpected VM call: " + method.getName());
+					});
+			fEventReader = new EventReader("cleanup test event reader", null);
+		}
+
+		@Override
+		protected void startProgram() {
+			if (programFailure != null) {
+				throw programFailure;
+			}
+		}
+
+		@Override
+		public void localSetUp() {
+		}
+
+		@Override
+		protected void runTest() {
+			testRan = true;
+		}
+
+		@Override
+		protected void tearDown() {
+			tornDown = true;
+			shutDownTarget();
+		}
+	}
+
+	private static class FakeProcess extends Process {
+		final List<String> calls = new ArrayList<>();
+		boolean alive = true;
+		boolean forceNeeded;
+		boolean forced;
+		boolean refuseExit;
+		boolean interruptWait;
+
+		@Override
+		public boolean isAlive() {
+			return alive;
+		}
+
+		@Override
+		public long pid() {
+			return 42;
+		}
+
+		@Override
+		public void destroy() {
+			calls.add("destroy");
+		}
+
+		@Override
+		public Process destroyForcibly() {
+			calls.add("force");
+			forced = true;
+			return this;
+		}
+
+		@Override
+		public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+			assertTrue("Wait must be bounded and positive", timeout > 0);
+			calls.add("wait");
+			if (interruptWait) {
+				interruptWait = false;
+				throw new InterruptedException();
+			}
+			if (refuseExit || (forceNeeded && !forced)) {
+				return false;
+			}
+			alive = false;
+			return true;
+		}
+
+		@Override
+		public int waitFor() {
+			throw new AssertionError("Unbounded waitFor must not be used");
+		}
+
+		@Override
+		public int exitValue() {
+			if (alive) {
+				throw new IllegalThreadStateException();
+			}
+			return 0;
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return InputStream.nullInputStream();
+		}
+
+		@Override
+		public OutputStream getOutputStream() {
+			return OutputStream.nullOutputStream();
+		}
+	}
+
+	/** A real subprocess that cannot exit normally before cleanup is requested. */
+	public static class WaitingProcess {
+		public static void main(String[] args) throws Exception {
+			Files.writeString(Path.of(args[0]), "ready");
+			new CountDownLatch(1).await();
+		}
+	}
+}

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
@@ -152,7 +152,6 @@ public class VMStartupCleanupTest extends TestCase {
 		Fixture fixture = new Fixture();
 		FakeProcess first = new FakeProcess();
 		fixture.nextVM = first;
-		fixture.attachFailure = null;
 		fixture.attachFailure = new Error("first attach failed");
 		assertStartupFailure(fixture, fixture.attachFailure);
 		assertCleared(fixture);

--- a/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
+++ b/org.eclipse.jdt.debug.jdi.tests/tests/org/eclipse/debug/jdi/tests/VMStartupCleanupTest.java
@@ -97,9 +97,18 @@ public class VMStartupCleanupTest extends TestCase {
 	}
 
 	public void testCleanupFailureDoesNotReplaceStartupFailure() {
+		assertCleanupFailureDoesNotReplaceStartupFailure(false);
+	}
+
+	public void testCleanupFailureWithoutPidDoesNotReplaceStartupFailure() {
+		assertCleanupFailureDoesNotReplaceStartupFailure(true);
+	}
+
+	private void assertCleanupFailureDoesNotReplaceStartupFailure(boolean pidUnavailable) {
 		Fixture fixture = new Fixture();
 		FakeProcess vm = new FakeProcess();
 		vm.refuseExit = true;
+		vm.pidUnavailable = pidUnavailable;
 		FakeProcess proxy = new FakeProcess();
 		fixture.nextVM = vm;
 		fixture.nextProxy = proxy;
@@ -109,6 +118,8 @@ public class VMStartupCleanupTest extends TestCase {
 
 		assertEquals(1, fixture.attachFailure.getSuppressed().length);
 		assertTrue(fixture.attachFailure.getSuppressed()[0] instanceof IllegalStateException);
+		assertEquals("Test process " + (pidUnavailable ? "unavailable" : "42")
+				+ " did not terminate after destroyForcibly()", fixture.attachFailure.getSuppressed()[0].getMessage());
 		assertFalse(proxy.isAlive());
 		assertSame(vm, fixture.fLaunchedVM);
 		vm.alive = false;
@@ -141,6 +152,7 @@ public class VMStartupCleanupTest extends TestCase {
 		Fixture fixture = new Fixture();
 		FakeProcess first = new FakeProcess();
 		fixture.nextVM = first;
+		fixture.attachFailure = null;
 		fixture.attachFailure = new Error("first attach failed");
 		assertStartupFailure(fixture, fixture.attachFailure);
 		assertCleared(fixture);
@@ -230,21 +242,54 @@ public class VMStartupCleanupTest extends TestCase {
 	}
 
 	public void testAllProcessesAreAttemptedAndFailuresPreserved() {
+		assertAllProcessesAreAttemptedAndFailuresPreserved(false);
+	}
+
+	public void testAllProcessesWithoutPidAreAttemptedAndFailuresPreserved() {
+		assertAllProcessesAreAttemptedAndFailuresPreserved(true);
+	}
+
+	private void assertAllProcessesAreAttemptedAndFailuresPreserved(boolean pidUnavailable) {
 		FakeProcess first = new FakeProcess();
 		FakeProcess second = new FakeProcess();
 		FakeProcess third = new FakeProcess();
 		first.refuseExit = true;
 		second.refuseExit = true;
+		first.pidUnavailable = pidUnavailable;
+		second.pidUnavailable = pidUnavailable;
 		try {
 			TestProcessCleanup.terminate(10000, first, second, third);
 			fail("Unterminated processes must be reported");
 		} catch (IllegalStateException failure) {
-			assertTrue(failure.getMessage().contains("42"));
+			String expectedMessage = "Test process " + (pidUnavailable ? "unavailable" : "42")
+					+ " did not terminate after destroyForcibly()";
+			assertEquals(expectedMessage, failure.getMessage());
 			assertEquals(1, failure.getSuppressed().length);
+			assertTrue(failure.getSuppressed()[0] instanceof IllegalStateException);
+			assertEquals(expectedMessage, failure.getSuppressed()[0].getMessage());
 		}
 		assertEquals(List.of("destroy", "wait", "force", "wait"), first.calls);
 		assertEquals(first.calls, second.calls);
 		assertFalse(third.isAlive());
+	}
+
+	public void testInterruptedTerminationFailureWithoutPidPreservesInterrupt() {
+		FakeProcess process = new FakeProcess();
+		process.pidUnavailable = true;
+		process.refuseExit = true;
+		process.interruptWait = true;
+		try {
+			try {
+				TestProcessCleanup.terminate(10000, process);
+				fail("Unterminated process must be reported even without a PID");
+			} catch (IllegalStateException failure) {
+				assertEquals("Test process unavailable did not terminate after destroyForcibly()", failure.getMessage());
+			}
+			assertEquals(List.of("destroy", "wait", "force", "wait"), process.calls);
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
 	}
 
 	public void testFailedStartupTerminatesRealJavaProcess() throws Exception {
@@ -371,6 +416,7 @@ public class VMStartupCleanupTest extends TestCase {
 		boolean forced;
 		boolean refuseExit;
 		boolean interruptWait;
+		boolean pidUnavailable;
 
 		@Override
 		public boolean isAlive() {
@@ -379,7 +425,7 @@ public class VMStartupCleanupTest extends TestCase {
 
 		@Override
 		public long pid() {
-			return 42;
+			return pidUnavailable ? super.pid() : 42;
 		}
 
 		@Override


### PR DESCRIPTION
## What it does

Make the shared JDI test harness clean up owned VM/proxy processes after
failed launch, attach or program startup, and prevent a stalled JDWP
handshake from blocking the attach operation indefinitely.

The changes are confined to `org.eclipse.jdt.debug.jdi.tests`. They
affect the test harness, not product-side debugger connection settings
or breakpoint behavior.

Related: [#990](https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/990).
This infrastructure change is reviewed separately from the
breakpoint-removal fix.

## Why the shared infrastructure needs to change

### Failed startup can bypass normal teardown

The harness can create processes and readers before VM startup has
completed. With the JUnit `TestCase` lifecycle used here, an exception
from `setUp()` prevents `tearDown()` from running: `setUp()` is called
before the `try/finally` that invokes teardown.

See [JUnit's `TestCase.runBare()` implementation](https://junit.org/junit4/xref/junit/framework/TestCase.html#137).

Consequently, cleanup cannot rely exclusively on normal test teardown.
It must also run when the startup operation itself fails.

The existing shutdown path additionally assumes that the event reader
has already been created. That assumption does not hold when attaching
to the VM fails. Process destruction also previously returned without
waiting for process termination, so requesting cleanup did not establish
that the owned process had actually exited.

The cleanup belongs at the shared startup entry points rather than in
individual tests. This covers both the usual launch-and-start path and
callers of `launchTargetAndConnectToVM()`, including `VirtualMachineTest`,
without duplicating failure handling across test classes.

### A retry deadline does not bound a blocked attach call

The existing connection loop checks elapsed time between failed attach
attempts, but does not supply a timeout to the connector. A peer that
accepts the socket without completing the JDWP handshake can therefore
keep an individual attach attempt blocked, preventing both the retry
check and startup cleanup from being reached.

Cleanup alone cannot address that case. The connector call also needs
a finite timeout.

These are specific lifecycle and timeout defects. This PR does not
claim that they explain every earlier CI startup failure, or that
earlier connection-refused failures had the same cause as the
deliberately simulated silent-peer scenario.

## Implementation

### Exception-safe startup and shutdown

`launchTargetAndConnectToVM()` and `launchTargetAndStartProgram()` invoke
cleanup when their launch, attach or program-start operations throw a
`RuntimeException` or `Error`. The original failure is rethrown, and a
cleanup failure is attached as a suppressed exception rather than
replacing it.

Shutdown tolerates an absent event reader and attempts owned-process
cleanup in a `finally` block, including when stopping readers or
requesting VM exit throws.

After cleanup, VM and reader references are cleared. Handles to
processes that are still alive are retained rather than discarded.
Repeated shutdown after successful cleanup does not terminate the
processes again or select another port.

The existing automatic port-selection mechanism is reused after
cleanup when target state was present. A user-supplied VM command keeps
its configured port.

### Bounded process termination

The package-private `TestProcessCleanup` helper centralizes termination
of processes owned by the test harness.

For each live process, it requests normal termination and waits up to
five seconds. If necessary, it requests forced termination and waits
with a separate five-second deadline. Missing or already exited
processes are ignored.

Interruption does not abandon cleanup: the helper attempts forced
termination and restores the interrupt flag afterward. A failure for
one process does not prevent attempts to terminate the remaining
processes; additional failures are retained as suppressed exceptions.

A process that remains alive after forced termination produces an
`IllegalStateException`. Diagnostic formatting tolerates
`Process.pid()` throwing `UnsupportedOperationException`, reporting
the PID as unavailable without masking the intended cleanup failure.

Keeping this logic in a small helper allows the termination sequence,
failure aggregation and interrupt handling to be tested using process
test doubles, without depending on an overloaded or unresponsive JVM.

### Attach timeout and diagnostic retention

The connection loop passes its remaining nominal five-second budget
to the connector instead of leaving the connector timeout unbounded.
Transport timeouts participate in the connection-failure handling.
Interruption detected before an attach attempt or during the retry
sleep aborts startup while preserving the interrupt flag.

When connection attempts fail, the reported error retains the last
connection failure as its cause. Additional diagnostics record the
port, VM/proxy process state and test-runtime information before
cleanup changes that state.

## Behavioral impact and boundaries

This is a shared test-harness behavior change, not merely additional
regression tests.

The attach policy is stricter than before: an attempt that previously
blocked beyond the nominal retry budget can now fail with a timeout.
A slow test VM that previously connected only after exceeding that
budget may therefore fail sooner.

Normal test shutdown also changes. Owned-process termination is now
attempted after the VM exit request, and shutdown may wait for process
exit or escalate to forced termination instead of returning immediately.
Failure to terminate an owned process is reported rather than silently
ignored.

The process timeouts apply separately to each termination phase and
each process. They are not a single five-second deadline for the whole
shutdown operation, nor does this PR establish an end-to-end deadline
for every startup or shutdown action.

Reader shutdown continues to use the existing reader stop mechanism.
This change adds null-safe invocation and reference cleanup; it does
not introduce reader-thread joins or redesign reader synchronization.

The startup cleanup covers the launch, attach and program-start paths
described above. It is not a general recovery mechanism for arbitrary
failures in every test-specific setup hook.

No product code, test exclusions or existing test assertions are
changed.

## How to test

Run `org.eclipse.debug.jdi.tests.AutomatedSuite` using the repository's
existing JDI test configuration. Both new test classes are registered
in that suite, which also performs the shared harness initialization.

The current change adds 20 regression tests.

### `VMStartupCleanupTest` — 18 tests

The lifecycle tests inject failures during launch, attach and program
startup. They exercise the JUnit `runBare()` path and verify that
cleanup occurs even though the fixture's normal `tearDown()` is not
called after failed setup.

Coverage includes cleanup before the event reader exists, reader stop
requests and reference clearing, preservation of the original startup
failure, automatic/custom port handling, repeated shutdown, and a
subsequent startup after successful cleanup.

Process test doubles cover normal and forced termination, bounded
waits, interruption before or during cleanup, missing/already exited
processes, continued cleanup after another process fails, and
diagnostics when a PID is unavailable.

A separate test starts a real Java subprocess, waits until it signals
readiness, injects an attach failure, and verifies that startup cleanup
terminates the subprocess. This supplements the deterministic
test-double coverage with an actual process-lifecycle check.

### `VMConnectionTimeoutTest` — 2 tests

These tests use the real JDI connector and a local socket peer that
accepts the connection and reads the JDWP handshake without replying.

They verify that the connection attempt fails within the test's
bounded wait, retains the transport timeout and pre-cleanup diagnostics,
and reaches owned-process cleanup when invoked through the startup
entry point.

The socket peer is deliberately constructed to reproduce the stalled
handshake condition. These tests do not depend on reproducing an
intermittent CI failure.

### CI status

For commit `bbf02c17a90b2a23563bde8d02be9574201343a0`, GitHub reports
`continuous-integration/jenkins/pr-head` as successful:

[Jenkins PR-992, build 6](https://ci.eclipse.org/jdt/job/eclipse.jdt.debug-github/job/PR-992/6/display/redirect)

This records the reported CI status for that revision. It does not
establish that all historical startup failures share one cause or that
every platform-specific process-termination behavior has been tested.

## Relationship to #990

This PR does not depend on the breakpoint-removal implementation in
[#990](https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/990) and
contains no breakpoint-specific changes.

The intended integration order is to review and merge this
infrastructure change first, then update #990 to the resulting upstream
state. This keeps the shared test-harness behavior changes separately
reviewable and out of the final breakpoint-specific diff.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)