### PR TITLE
Use IFile.getContents() API to retrieve class data in HCR manager

### DIFF
--- a/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug.tests/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.debug.test.stepping,
  org.eclipse.jdt.debug.testplugin,
  org.eclipse.jdt.debug.testplugin.detailpane,
+ org.eclipse.jdt.debug.testplugin.efs,
  org.eclipse.jdt.debug.testplugin.launching,
  org.eclipse.jdt.debug.tests,
  org.eclipse.jdt.debug.tests.breakpoints,

--- a/org.eclipse.jdt.debug.tests/plugin.xml
+++ b/org.eclipse.jdt.debug.tests/plugin.xml
@@ -494,4 +494,13 @@
          </description>
       </perspective>
    </extension>
+   <extension
+         point="org.eclipse.core.filesystem.filesystems">
+      <filesystem
+            scheme="jdtdebugtestfs">
+         <run
+               class="org.eclipse.jdt.debug.testplugin.efs.WrapperFileSystem">
+         </run>
+      </filesystem>
+   </extension>
 </plugin>

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/efs/WrapperFileStore.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/efs/WrapperFileStore.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.debug.testplugin.efs;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.provider.FileStore;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * A file store which delegates all operations to a store of the local file system.
+ * <p>
+ * Note that {@link #toLocalFile(int, IProgressMonitor)} is intentionally <b>not</b> overridden: the default implementation returns <code>null</code>
+ * if no caching is requested, which is what makes resources stored in the {@link WrapperFileSystem} "non local".
+ * </p>
+ */
+public class WrapperFileStore extends FileStore {
+
+	private final IFileStore baseStore;
+
+	public WrapperFileStore(IFileStore baseStore) {
+		this.baseStore = baseStore;
+	}
+
+	@Override
+	public String[] childNames(int options, IProgressMonitor monitor) throws CoreException {
+		return baseStore.childNames(options, monitor);
+	}
+
+	@Override
+	public IFileInfo fetchInfo(int options, IProgressMonitor monitor) throws CoreException {
+		return baseStore.fetchInfo(options, monitor);
+	}
+
+	@Override
+	public IFileStore getChild(String name) {
+		return new WrapperFileStore(baseStore.getChild(name));
+	}
+
+	@Override
+	public String getName() {
+		return baseStore.getName();
+	}
+
+	@Override
+	public IFileStore getParent() {
+		IFileStore parent = baseStore.getParent();
+		return parent == null ? null : new WrapperFileStore(parent);
+	}
+
+	@Override
+	public InputStream openInputStream(int options, IProgressMonitor monitor) throws CoreException {
+		return baseStore.openInputStream(options, monitor);
+	}
+
+	@Override
+	public OutputStream openOutputStream(int options, IProgressMonitor monitor) throws CoreException {
+		return baseStore.openOutputStream(options, monitor);
+	}
+
+	@Override
+	public IFileStore mkdir(int options, IProgressMonitor monitor) throws CoreException {
+		return new WrapperFileStore(baseStore.mkdir(options, monitor));
+	}
+
+	@Override
+	public void delete(int options, IProgressMonitor monitor) throws CoreException {
+		baseStore.delete(options, monitor);
+	}
+
+	@Override
+	public void putInfo(IFileInfo info, int options, IProgressMonitor monitor) throws CoreException {
+		baseStore.putInfo(info, options, monitor);
+	}
+
+	@Override
+	public URI toURI() {
+		return WrapperFileSystem.toWrapperURI(baseStore.toURI());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof WrapperFileStore)) {
+			return false;
+		}
+		return baseStore.equals(((WrapperFileStore) obj).baseStore);
+	}
+
+	@Override
+	public int hashCode() {
+		return baseStore.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return toURI().toString();
+	}
+}

--- a/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/efs/WrapperFileSystem.java
+++ b/org.eclipse.jdt.debug.tests/test plugin/org/eclipse/jdt/debug/testplugin/efs/WrapperFileSystem.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.debug.testplugin.efs;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.provider.FileSystem;
+
+/**
+ * A simple {@link org.eclipse.core.filesystem.IFileSystem} which delegates all operations to the local file system, but which uses an own (non
+ * <code>file</code>) URI scheme.
+ * <p>
+ * Resources stored in this file system are fully functional from the resources API point of view, but they are <b>not</b> located in the local file
+ * system, hence {@link org.eclipse.core.resources.IResource#getLocation()} returns <code>null</code> for them.
+ * </p>
+ */
+public class WrapperFileSystem extends FileSystem {
+
+	/**
+	 * The URI scheme of this file system.
+	 */
+	public static final String SCHEME = "jdtdebugtestfs"; //$NON-NLS-1$
+
+	/**
+	 * Converts the given local (<code>file</code>) URI into an URI of this file system.
+	 *
+	 * @param localUri
+	 *            an URI with the <code>file</code> scheme
+	 * @return the corresponding URI in this file system
+	 */
+	public static URI toWrapperURI(URI localUri) {
+		return convertScheme(localUri, SCHEME);
+	}
+
+	/**
+	 * Converts the given URI of this file system into a local (<code>file</code>) URI.
+	 *
+	 * @param wrapperUri
+	 *            an URI with the {@link #SCHEME} scheme
+	 * @return the corresponding URI in the local file system
+	 */
+	public static URI toLocalURI(URI wrapperUri) {
+		return convertScheme(wrapperUri, EFS.SCHEME_FILE);
+	}
+
+	private static URI convertScheme(URI uri, String scheme) {
+		try {
+			return new URI(scheme, uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Unable to convert " + uri + " to scheme " + scheme, e); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	@Override
+	public IFileStore getStore(URI uri) {
+		return new WrapperFileStore(EFS.getLocalFileSystem().getStore(toLocalURI(uri)));
+	}
+
+	@Override
+	public boolean canDelete() {
+		return true;
+	}
+
+	@Override
+	public boolean canWrite() {
+		return true;
+	}
+
+	@Override
+	public int attributes() {
+		return EFS.getLocalFileSystem().attributes();
+	}
+
+	@Override
+	public boolean isCaseSensitive() {
+		return EFS.getLocalFileSystem().isCaseSensitive();
+	}
+}

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/AutomatedSuite.java
@@ -77,6 +77,7 @@ import org.eclipse.jdt.debug.tests.core.EnvironmentTests;
 import org.eclipse.jdt.debug.tests.core.EventDispatcherTest;
 import org.eclipse.jdt.debug.tests.core.EventSetTests;
 import org.eclipse.jdt.debug.tests.core.ExecutionEnvironmentTests;
+import org.eclipse.jdt.debug.tests.core.HcrChangedClassFilesTests;
 import org.eclipse.jdt.debug.tests.core.HcrTests;
 import org.eclipse.jdt.debug.tests.core.InstanceFilterTests;
 import org.eclipse.jdt.debug.tests.core.InstanceVariableTests;
@@ -339,6 +340,7 @@ public class AutomatedSuite extends DebugSuite {
 		addTest(new TestSuite(RefreshStateTests.class));
 
 	// HCR tests are last - they modify resources
+		addTest(new TestSuite(HcrChangedClassFilesTests.class));
 		addTest(new TestSuite(HcrTests.class));
 
 	// Layout tests

--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/HcrChangedClassFilesTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/HcrChangedClassFilesTests.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.debug.tests.core;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.debug.testplugin.efs.WrapperFileSystem;
+import org.eclipse.jdt.debug.tests.AbstractDebugTest;
+import org.eclipse.jdt.internal.debug.core.hcr.JavaHotCodeReplaceManager;
+
+/**
+ * Tests the detection of changed class files done by the
+ * <code>JavaHotCodeReplaceManager.ChangedClassFilesVisitor</code>, which is the first (and mandatory) step of every hot code replace attempt.
+ * <p>
+ * The visitor has to be able to read the byte code of every changed class file resource, no matter if the resource is stored in the local file system
+ * or in an arbitrary (EFS based) file system, see {@link #testChangedClassFilesInNonLocalProject()}.
+ * </p>
+ */
+public class HcrChangedClassFilesTests extends AbstractDebugTest {
+
+	/**
+	 * Type used to produce the "original" content of the class file under test.
+	 */
+	static class ClassOne {
+		@Override
+		public String toString() {
+			return "One";
+		}
+	}
+
+	/**
+	 * Type used to produce the "changed" content of the class file under test.
+	 */
+	static class ClassTwo {
+		@Override
+		public String toString() {
+			return "Two";
+		}
+	}
+
+	/**
+	 * Collects the class files detected by the HCR manager for all POST_BUILD events it receives.
+	 */
+	static class ChangedClassFilesCollector implements IResourceChangeListener {
+
+		final List<IResource> resources = Collections.synchronizedList(new ArrayList<>());
+		final List<String> names = Collections.synchronizedList(new ArrayList<>());
+		final AtomicInteger events = new AtomicInteger();
+		volatile Exception error;
+
+		@Override
+		public void resourceChanged(IResourceChangeEvent event) {
+			events.incrementAndGet();
+			try {
+				Object visitor = getChangedClassFiles(event);
+				if (visitor == null) {
+					return;
+				}
+				resources.addAll(this.<IResource> invoke(visitor, "getChangedClassFiles"));
+				names.addAll(this.<String> invoke(visitor, "getQualifiedNamesList"));
+			} catch (Exception e) {
+				if (error == null) {
+					error = e;
+				}
+			}
+		}
+
+		/**
+		 * Calls the (protected) <code>JavaHotCodeReplaceManager#getChangedClassFiles(IResourceChangeEvent)</code>, which computes the class files to
+		 * be replaced. Note that the returned visitor type is not accessible, so its (public) methods have to be called reflectively too.
+		 */
+		private static Object getChangedClassFiles(IResourceChangeEvent event) throws Exception {
+			Method method = JavaHotCodeReplaceManager.class.getDeclaredMethod("getChangedClassFiles", IResourceChangeEvent.class);
+			method.setAccessible(true);
+			return method.invoke(JavaHotCodeReplaceManager.getDefault(), event);
+		}
+
+		@SuppressWarnings("unchecked")
+		private <T> List<T> invoke(Object visitor, String methodName) throws Exception {
+			Method method = visitor.getClass().getDeclaredMethod(methodName);
+			method.setAccessible(true);
+			List<T> result = (List<T>) method.invoke(visitor);
+			return result == null ? Collections.<T> emptyList() : result;
+		}
+	}
+
+	private IProject project;
+	private File projectLocation;
+
+	public HcrChangedClassFilesTests(String name) {
+		super(name);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		try {
+			if (project != null && project.exists()) {
+				project.delete(true, true, null);
+			}
+			if (projectLocation != null) {
+				delete(projectLocation);
+			}
+		} finally {
+			project = null;
+			projectLocation = null;
+			super.tearDown();
+		}
+	}
+
+	/**
+	 * A changed class file of a project stored in the local file system must be detected.
+	 */
+	public void testChangedClassFilesInLocalProject() throws Exception {
+		doTestChangedClassFileDetected(false);
+	}
+
+	/**
+	 * A changed class file of a project which is <b>not</b> stored in the local file system must be detected as well: such resources have no local
+	 * location, so the byte code has to be read via the resources API.
+	 */
+	public void testChangedClassFilesInNonLocalProject() throws Exception {
+		doTestChangedClassFileDetected(true);
+	}
+
+	private void doTestChangedClassFileDetected(boolean nonLocal) throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IFile classFile = createProjectWithClassFile(nonLocal);
+
+		if (nonLocal) {
+			assertNull("The class file is expected to have no location in the local file system", classFile.getLocation());
+		} else {
+			assertNotNull("The class file is expected to have a location in the local file system", classFile.getLocation());
+		}
+
+		// consume the deltas created while setting the test up
+		build();
+
+		ChangedClassFilesCollector collector = new ChangedClassFilesCollector();
+		workspace.addResourceChangeListener(collector, IResourceChangeEvent.POST_BUILD);
+		try {
+			classFile.setContents(new ByteArrayInputStream(getClassFileBytes(ClassTwo.class)), IResource.FORCE, null);
+			build();
+		} finally {
+			workspace.removeResourceChangeListener(collector);
+		}
+
+		assertNull("Failed to compute the changed class files: " + collector.error, collector.error);
+		assertTrue("No POST_BUILD event was received at all", collector.events.get() > 0);
+		assertTrue("The changed class file was not detected, detected files: " + collector.resources,
+				collector.resources.contains(classFile));
+		assertTrue("Unexpected fully qualified type names detected: " + collector.names,
+				collector.names.contains(ClassTwo.class.getName()));
+	}
+
+	/**
+	 * Creates a project containing a single class file, holding the byte code of {@link ClassOne}.
+	 *
+	 * @param nonLocal
+	 *            if <code>true</code> the project is created in a file system which is not the local one
+	 * @return the created class file
+	 */
+	private IFile createProjectWithClassFile(boolean nonLocal) throws Exception {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		String name = nonLocal ? "HcrNonLocalClassFiles" : "HcrLocalClassFiles";
+		project = workspace.getRoot().getProject(name);
+		if (project.exists()) {
+			project.delete(true, true, null);
+		}
+		IProjectDescription description = workspace.newProjectDescription(name);
+		if (nonLocal) {
+			projectLocation = Files.createTempDirectory(name).toFile();
+			URI localUri = URIUtil.toURI(new Path(projectLocation.getAbsolutePath()));
+			description.setLocationURI(WrapperFileSystem.toWrapperURI(localUri));
+		}
+		project.create(description, null);
+		project.open(null);
+
+		IFolder folder = project.getFolder("bin");
+		folder.create(true, true, null);
+		IFile classFile = folder.getFile("HcrTestClass.class");
+		classFile.create(new ByteArrayInputStream(getClassFileBytes(ClassOne.class)), true, null);
+		return classFile;
+	}
+
+	/**
+	 * Returns the byte code of the given (already compiled) type.
+	 */
+	private static byte[] getClassFileBytes(Class<?> clazz) throws IOException {
+		String resource = clazz.getName().replace('.', '/') + ".class";
+		try (InputStream stream = clazz.getClassLoader().getResourceAsStream(resource)) {
+			assertNotNull("Unable to find the class file of " + clazz.getName(), stream);
+			return stream.readAllBytes();
+		}
+	}
+
+	/**
+	 * Runs a build and waits until all (possibly asynchronously running) builds are done, so that all POST_BUILD events are delivered.
+	 */
+	private static void build() throws CoreException {
+		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
+		waitForBuild();
+	}
+
+	private static void delete(File file) {
+		File[] children = file.listFiles();
+		if (children != null) {
+			for (File child : children) {
+				delete(child);
+			}
+		}
+		file.delete();
+	}
+}

--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.26.100.qualifier
+Bundle-Version: 3.26.200.qualifier
 Bundle-ClassPath: jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/hcr/JavaHotCodeReplaceManager.java
+++ b/org.eclipse.jdt.debug/model/org/eclipse/jdt/internal/debug/core/hcr/JavaHotCodeReplaceManager.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.debug.core.hcr;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,7 +39,6 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.MultiStatus;
@@ -1144,11 +1145,12 @@ public class JavaHotCodeReplaceManager implements IResourceChangeListener,
 		/**
 		 * Answers whether children should be visited.
 		 * <p>
-		 * If the associated resource is a class file which has been changed,
-		 * record it.
+		 * If the associated resource is a class file which has been changed, record it.
+		 *
+		 * @throws CoreException
 		 */
 		@Override
-		public boolean visit(IResourceDelta delta) {
+		public boolean visit(IResourceDelta delta) throws CoreException {
 			if (delta == null
 					|| 0 == (delta.getKind() & IResourceDelta.CHANGED)) {
 				return false;
@@ -1162,66 +1164,66 @@ public class JavaHotCodeReplaceManager implements IResourceChangeListener,
 					}
 					if (CLASS_FILE_EXTENSION.equals(resource.getFullPath()
 							.getFileExtension())) {
-						IPath localLocation = resource.getLocation();
-						if (localLocation != null) {
-							String path = localLocation.toOSString();
-							IClassFileReader reader = ToolFactory
-									.createDefaultClassFileReader(
-											path,
-											IClassFileReader.CLASSFILE_ATTRIBUTES);
-							if (reader != null) {
-								// this name is slash-delimited
-								String qualifiedName = new String(
-										reader.getClassName());
-								boolean hasBlockingErrors = false;
-								try {
-									if (!Platform.getPreferencesService().getBoolean(
-											JDIDebugPlugin.getUniqueIdentifier(),
-											JDIDebugModel.PREF_HCR_WITH_COMPILATION_ERRORS,
-											true,
-											null)) {
-										// If the user doesn't want to replace
-										// classfiles containing
-										// compilation errors, get the source
-										// file associated with
-										// the class file and query it for
-										// compilation errors
-										IJavaProject pro = JavaCore
-												.create(resource.getProject());
-										ISourceAttribute sourceAttribute = reader
-												.getSourceFileAttribute();
-										String sourceName = null;
-										if (sourceAttribute != null) {
-											sourceName = new String(
-													sourceAttribute
-															.getSourceFileName());
-										}
-										IResource sourceFile = getSourceFile(
-												pro, qualifiedName, sourceName);
-										if (sourceFile != null) {
-											IMarker[] problemMarkers = null;
-											problemMarkers = sourceFile
-													.findMarkers(
-															IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER,
-															true,
-															IResource.DEPTH_INFINITE);
-											for (IMarker problemMarker : problemMarkers) {
-												if (problemMarker.getAttribute(
-														IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR) {
-													hasBlockingErrors = true;
-													break;
-												}
+						IClassFileReader reader = null;
+						try (InputStream contents = ((IFile) resource).getContents(true)) {
+							reader = ToolFactory.createDefaultClassFileReader(
+									contents, IClassFileReader.CLASSFILE_ATTRIBUTES);
+						} catch (IOException e) {
+							throw new CoreException(new Status(IStatus.ERROR, JDIDebugPlugin.getUniqueIdentifier(),
+									"Failed to read class file: " + resource.getFullPath(), e)); //$NON-NLS-1$
+						}
+						if (reader != null) {
+							// this name is slash-delimited
+							String qualifiedName = new String(
+									reader.getClassName());
+							boolean hasBlockingErrors = false;
+							try {
+								if (!Platform.getPreferencesService().getBoolean(
+										JDIDebugPlugin.getUniqueIdentifier(),
+										JDIDebugModel.PREF_HCR_WITH_COMPILATION_ERRORS,
+										true,
+										null)) {
+									// If the user doesn't want to replace
+									// classfiles containing
+									// compilation errors, get the source
+									// file associated with
+									// the class file and query it for
+									// compilation errors
+									IJavaProject pro = JavaCore
+											.create(resource.getProject());
+									ISourceAttribute sourceAttribute = reader
+											.getSourceFileAttribute();
+									String sourceName = null;
+									if (sourceAttribute != null) {
+										sourceName = new String(
+												sourceAttribute
+														.getSourceFileName());
+									}
+									IResource sourceFile = getSourceFile(
+											pro, qualifiedName, sourceName);
+									if (sourceFile != null) {
+										IMarker[] problemMarkers = null;
+										problemMarkers = sourceFile
+												.findMarkers(
+														IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER,
+														true,
+														IResource.DEPTH_INFINITE);
+										for (IMarker problemMarker : problemMarkers) {
+											if (problemMarker.getAttribute(
+													IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR) {
+												hasBlockingErrors = true;
+												break;
 											}
 										}
 									}
-								} catch (CoreException e) {
-									JDIDebugPlugin.log(e);
 								}
-								if (!hasBlockingErrors) {
-									fFiles.add(resource);
-									// dot-delimit the name
-									fNames.add(qualifiedName.replace('/', '.'));
-								}
+							} catch (CoreException e) {
+								JDIDebugPlugin.log(e);
+							}
+							if (!hasBlockingErrors) {
+								fFiles.add(resource);
+								// dot-delimit the name
+								fNames.add(qualifiedName.replace('/', '.'));
 							}
 						}
 					}


### PR DESCRIPTION
ChangedClassFilesVisitor used ToolFactory.createDefaultClassFileReader(String) API variant to read class bytes for changed class file represented by an IFile. This API uses plain Java.nio code, ignoring Eclipse resources API and possible underlined custom FileSystem/FileStore.

This leads to the problem that for custom file system implementations, which supply file system content on the fly (encoding on write/decoding on read), wrong (not properly decoded) class bytes were read by HCR.

The fix ensures that the IFile change detected by ChangedClassFilesVisitor results in proper class bytes read via IFile.getContents(boolean) API.

Tests contributed by Claude Opus 5.