### PR TITLE
VMInstallTests.testJavaRuntimeQuerySystemPackages_modularJDK fails on Java 25 builds #1000

### DIFF
--- a/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/VMInstallTests.java
+++ b/org.eclipse.jdt.debug.tests/tests/org/eclipse/jdt/debug/tests/core/VMInstallTests.java
@@ -253,14 +253,16 @@ public class VMInstallTests extends AbstractDebugTest {
 			// The following test-cases don't work if the VMInstall has the latest supported version. Internally jdt.core limits higher versions to
 			// the latest supported one. Consequently these intended error-scenarios, testing too high versions don't fail (as expected).
 			String nextJavaVersion = Integer.toString(majorJavaVersion + 1);
-			CoreException e2 = assertThrows(CoreException.class, () -> JavaRuntime.getProvidedVMPackages(vm, nextJavaVersion));
-			assertEquals("release " + nextJavaVersion + " is not found in the system", e2.getMessage());
+			Set<String> providedVMPackages = JavaRuntime.getProvidedVMPackages(vm, nextJavaVersion);
+			boolean present = providedVMPackages.stream().anyMatch(name -> name.equals("java.lang"));
+			assertTrue("Package not present", present);
 
 			String versionAfterLatestSupported = String.valueOf(latestSupportedJavaVersion + 1);
-			CoreException e3 = assertThrows(CoreException.class, () -> JavaRuntime.getProvidedVMPackages(vm, versionAfterLatestSupported));
+			providedVMPackages = JavaRuntime.getProvidedVMPackages(vm, versionAfterLatestSupported);
 			// Passing a release not yet supported by JDT should not fail if the JDK actually provides it (e.g. if one uses early-access builds).
 			// Since EA-builds are not generally available in all test setups we check at least that the method passes the initial validation
-			assertEquals("release " + versionAfterLatestSupported + " is not found in the system", e3.getMessage());
+			present = providedVMPackages.stream().anyMatch(name -> name.equals("java.lang"));
+			assertTrue("Package not present", present);
 		}
 		CoreException e4 = assertThrows(CoreException.class, () -> JavaRuntime.getProvidedVMPackages(vm, "definitivly-not-a-version"));
 		assertEquals("Invalid release: definitivly-not-a-version", e4.getMessage());


### PR DESCRIPTION


JDT Core no longer throws CoreException when release is not found. It simply chooses latest available. Adjust the test accordingly.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #1000

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
