### PR TITLE
Use the new bundle name of the JSch library in launch configs

### DIFF
--- a/org.eclipse.jdt.debug.jdi.tests/JDI Test Suite.launch
+++ b/org.eclipse.jdt.debug.jdi.tests/JDI Test Suite.launch
@@ -349,7 +349,6 @@
         <setEntry value="org.eclipse.jface.text@default:default"/>
         <setEntry value="org.eclipse.jface@default:default"/>
         <setEntry value="org.eclipse.jsch.core@default:default"/>
-        <setEntry value="org.eclipse.jsch.tests@default:default"/>
         <setEntry value="org.eclipse.jsch.ui@default:default"/>
         <setEntry value="org.eclipse.ltk.core.refactoring.tests@default:default"/>
         <setEntry value="org.eclipse.ltk.core.refactoring@default:default"/>

--- a/org.eclipse.jdt.debug.tests/JDT Debug Test Suite.launch
+++ b/org.eclipse.jdt.debug.tests/JDT Debug Test Suite.launch
@@ -38,8 +38,8 @@
     <booleanAttribute key="run_in_ui_thread" value="true"/>
     <setAttribute key="selected_target_bundles">
         <setEntry value="com.api.tools.buildnotes.nl@default:false"/>
+        <setEntry value="com.github.mwiede.jsch@default:default"/>
         <setEntry value="com.ibm.icu@default:default"/>
-        <setEntry value="com.jcraft.jsch@default:default"/>
         <setEntry value="javax.servlet.jsp@default:default"/>
         <setEntry value="javax.servlet@default:default"/>
         <setEntry value="org.apache.ant@default:default"/>


### PR DESCRIPTION
The Platform switched from com.jcraft.jsch to com.github.mwiede.jsch. Also drop org.eclipse.jsch.tests, which was retired in 2025.

https://github.com/eclipse-platform/eclipse.platform/issues/958

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])

